### PR TITLE
Simplify url matching, make patterns DRY

### DIFF
--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, path
 
 from . import views, views2, detail_views, merge_views
 from .autocomplete3 import (
@@ -11,71 +11,60 @@ from .views2 import GenericEntitiesCreateStanbolView
 
 app_name = "apis_entities"
 
-# TODO : Check that all following regexes are correct and are consistent overall,
-# e.g. [a-z0-9_]+ does not allow uppercase, is that on purpose?
-# e.g. change [a-zA-Z0-9-_]+ into [azAZ09_]+ and confirm 
+entity_patterns = [
+    path('list/', views.GenericListViewNew.as_view(),
+         name='generic_entities_list',
+         ),
+    path('create/', views2.GenericEntitiesCreateView.as_view(),
+         name='generic_entities_create_view',
+         ),
+    path('<int:pk>/detail/', detail_views.GenericEntitiesDetailView.as_view(),
+         name='generic_entities_detail_view',
+         ),
+    path('<int:pk>/edit/', views2.GenericEntitiesEditView.as_view(),
+         name='generic_entities_edit_view',
+         ),
+    path('<int:pk>/delete/', views2.GenericEntitiesDeleteView.as_view(),
+         name='generic_entities_delete_view',
+         ),
+]
+
+autocomplete_patterns = [
+    path('createstanbol/<slug:entity>/<int:ent_merge_pk>/',
+         GenericEntitiesCreateStanbolView.as_view(),
+         name='generic_entities_stanbol_create',
+         ),
+    path('createstanbol/<slug:entity>/',
+         GenericEntitiesCreateStanbolView.as_view(),
+         name='generic_entities_stanbol_create',
+         ),
+    path('<slug:entity>/<int:ent_merge_pk>/',
+         GenericEntitiesAutocomplete.as_view(),
+         name='generic_entities_autocomplete',
+         ),
+    path('<slug:entity>/<str:db_include>/',
+         GenericEntitiesAutocomplete.as_view(),
+         name='generic_entities_autocomplete',
+         ),
+    path('<slug:entity>/',
+         GenericEntitiesAutocomplete.as_view(),
+         name='generic_entities_autocomplete',
+         ),
+]
 
 urlpatterns = [
-    url(
-        r"^entity/(?P<entity>[a-z0-9_]+)/(?P<pk>[0-9]+)/edit$",
-        views2.GenericEntitiesEditView.as_view(),
-        name="generic_entities_edit_view",
-    ),
-    url(
-        r"^entity/(?P<entity>[a-z0-9_]+)/(?P<pk>[0-9]+)/detail$",
-        detail_views.GenericEntitiesDetailView.as_view(),
-        name="generic_entities_detail_view",
-    ),
-    url(
-        r"^entity/(?P<entity>[a-z0-9_]+)/create$",
-        views2.GenericEntitiesCreateView.as_view(),
-        name="generic_entities_create_view",
-    ),
-    url(
-        r"^entity/(?P<entity>[a-z0-9_]+)/(?P<pk>[0-9]+)/delete$",
-        views2.GenericEntitiesDeleteView.as_view(),
-        name="generic_entities_delete_view",
-    ),
-    url(
-        r"^entity/(?P<entity>[a-z0-9_]+)/list/$",
-        views.GenericListViewNew.as_view(),
-        name="generic_entities_list",
-    ),
-    url(
-        r"^autocomplete/createstanbol/(?P<entity>[a-zA-Z0-9-_]+)/$",
-        GenericEntitiesCreateStanbolView.as_view(),
-        name="generic_entities_stanbol_create",
-    ),
-    url(
-        r"^autocomplete/createstanbol/(?P<entity>[a-zA-Z0-9-_]+)/(?P<ent_merge_pk>[0-9]+)/$",
-        GenericEntitiesCreateStanbolView.as_view(),
-        name="generic_entities_stanbol_create",
-    ),
-    url(
-        r"^autocomplete/(?P<entity>[a-zA-Z0-9-_]+)/(?P<ent_merge_pk>[0-9]+)/$",
-        GenericEntitiesAutocomplete.as_view(),
-        name="generic_entities_autocomplete",
-    ),
-    url(
-        r"^autocomplete/(?P<entity>[a-zA-Z0-9-_]+)/$",
-        GenericEntitiesAutocomplete.as_view(),
-        name="generic_entities_autocomplete",
-    ),
-    url(
-        r"^autocomplete/(?P<entity>[a-zA-Z0-9-_]+)/(?P<db_include>[a-z]+)/$",
-        GenericEntitiesAutocomplete.as_view(),
-        name="generic_entities_autocomplete",
-    ),
-    url(
-        r"^autocomplete-network/(?P<entity>[a-zA-Z0-9-_]+)/$",
-        GenericNetworkEntitiesAutocomplete.as_view(),
-        name="generic_network_entities_autocomplete",
-    ),
+    path('entity/<slug:entity>/', include(entity_patterns), ),
+    path('autocomplete/', include(autocomplete_patterns), ),
+    path('autocomplete-network/<slug:entity>/',
+         GenericNetworkEntitiesAutocomplete.as_view(),
+         name='generic_network_entities_autocomplete',
+         ),
+
     # TODO __sresch__ : This seems unused. Remove it once sure
     # url(r"^detail/work/(?P<pk>[0-9]+)$",
     #     detail_views.WorkDetailView.as_view(), name="work_detail"),
 
-    url(r"^place/geojson/$", views.getGeoJson, name="getGeoJson"),
+    path('place/geojson/', views.getGeoJson, name='getGeoJson'),
     # __before_rdf_refactoring__
     # url(r"^place/geojson/list/$", views.getGeoJsonList, name="getGeoJsonList"),
     # url(r"^place/network/list/$", views.getNetJsonList, name="getNetJsonList"),
@@ -85,14 +74,12 @@ urlpatterns = [
     #     name="resolve_ambigue_place",
     # ),
 
-    url(r"^maps/birthdeath/$", views.birth_death_map, name="birth_death_map"),
-    url(r"^networks/relation_place/$", views.pers_place_netw, name="pers_place_netw"),
-    url(
-        r"^networks/relation_institution/$", views.pers_inst_netw, name="pers_inst_netw"
-    ),
-    url(r"^networks/generic/$", views.generic_network_viz, name="generic_network_viz"),
+    path('maps/birthdeath/', views.birth_death_map, name='birth_death_map'),
+    path('networks/relation_place/', views.pers_place_netw, name='pers_place_netw'),
+    path('networks/relation_institution/', views.pers_inst_netw, name='pers_inst_netw'),
+    path('networks/generic/', views.generic_network_viz, name='generic_network_viz'),
     #    url(
     #        r'^compare/(?P<app>[a-z_]+)/(?P<kind>[a-z]+)/(?P<pk>\d+)$', ReversionCompareView.as_view()
     #    ),
-    url(r"^merge-objects/$", merge_views.merge_objects, name="merge_objects"),
+    path('merge-objects/', merge_views.merge_objects, name='merge_objects'),
 ]


### PR DESCRIPTION
**Describe your changes**
Refactor of `apis_entites`' `urls.py`.

- Replaces superfluous regex path matching (via `url`, an outdated alias for `re_path`) with simpler `path` matching.
- Groups URLs with the same prefixes together to remove redundancy (see [Including other URLconfs](https://docs.djangoproject.com/en/4.1/topics/http/urls/#including-other-urlconfs) in the Django docs).
- Adapts quotation marks for consistency.

**Additional context**
Commented URL patterns/TODOs were left untouched for now. If any of them are re-enabled in the future, they should also be adapted to match the refactored patterns.

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [ ] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
