### PR TITLE
Resolves #16 - Re-enable list filters

### DIFF
--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -69,21 +69,24 @@ class GenericEntityListFilter(django_filters.FilterSet):
         exclude = fields_to_exclude
 
     def __init__(self, *args, **kwargs):
-
         # call super init foremost to create dictionary of filters which will be processed further below
         super().__init__(*args, **kwargs)
         self.entity_class = self.Meta.model
 
         def set_sort_filters(default_filters):
             """
-            Method to read in from the settings file which filters should be enabled / disabled and if there are
-            methods or labels to override the default ones.
+            Check for existence of "list_filters" setting for an entity class
+            and return an ordered dictionary containing filters for
+            applicable fields plus pre-set filters defined for all entities
+            (in GenericEntityListFilter's Meta class).
 
-            :param default_filter_dict: the default filter dictionary created on filter class instantiation
-                (which comprises filters defined: in GenericListFilter, in specific model ListFilter and their defaults)
+            :param default_filters: dictionary of filters created
+                                    on filter class instantiation;
+                                    includes: GenericListFilter, specific
+                                    model ListFilter and their defaults
 
-            :return: a new dictionary which is a subset of the input dictionary and only contains the filters which
-                are referenced in the settings file (and if there were methods or labels also referenced, using them)
+            :return: ordered dictionary with tuples of field names
+                     and filters defined for them
             """
             field_filters = OrderedDict()
 

--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -38,22 +38,20 @@ from apis_core.apis_entities.models import AbstractEntity, TempEntityClass
 # TODO __sresch__ : Do this better
 fields_to_exclude = getattr(settings, "APIS_RELATIONS_FILTER_EXCLUDE", [])
 
-# __before_rdf_refactoring__
-# class GenericListFilter(django_filters.FilterSet):
-# __after_rdf_refactoring__
+
 class GenericEntityListFilter(django_filters.FilterSet):
 
     fields_to_exclude = getattr(settings, "APIS_RELATIONS_FILTER_EXCLUDE", [])
 
-    name = django_filters.CharFilter(method="name_label_filter", label="Name or Label")
+    name = django_filters.CharFilter(method="name_label_filter", label="Name or label")
+    related_entity_name = django_filters.CharFilter(method="related_entity_name_method", label="Related entity")
+    related_property_name = django_filters.CharFilter(method="related_property_name_method", label="Related property")
+
     collection = django_filters.ModelMultipleChoiceFilter(queryset=Collection.objects.all())
 
     # TODO __sresch__ : look into how the date values can be intercepted so that they can be parsed with the same logic as in edit forms
     start_date = django_filters.DateFromToRangeFilter()
     end_date = django_filters.DateFromToRangeFilter()
-
-    related_entity_name = django_filters.CharFilter(method="related_entity_name_method", label="related entity")
-    related_property_name = django_filters.CharFilter(method="related_property_name_method", label="related property")
 
     class Meta:
         model = TempEntityClass
@@ -168,39 +166,30 @@ class GenericEntityListFilter(django_filters.FilterSet):
         """
 
         if value.startswith("*") and not value.endswith("*"):
-
             value = value[1:]
             return "__iendswith", value
 
         elif not value.startswith("*") and value.endswith("*"):
-
             value = value[:-1]
             return "__istartswith", value
 
         elif value.startswith('"') and value.endswith('"'):
-
             value = value[1:-1]
             return "__iexact", value
 
         else:
-
             if value.startswith("*") and value.endswith("*"):
-
                 value = value[1:-1]
-
             return "__icontains", value
-
 
     def name_label_filter(self, queryset, name, value):
         # TODO __sresch__ : include alternative names queries
-
         lookup, value = self.construct_lookup(value)
 
-        queryset_related_label=queryset.filter(**{"label__label"+lookup : value})
-        queryset_self_name=queryset.filter(**{name+lookup : value})
+        queryset_related_label = queryset.filter(**{"label__label"+lookup : value})
+        queryset_self_name = queryset.filter(**{name+lookup : value})
 
-        return ( queryset_related_label | queryset_self_name ).distinct().all()
-
+        return (queryset_related_label|queryset_self_name).distinct().all()
 
     def related_entity_name_method(self, queryset, name, value):
         # __before_rdf_refactoring__
@@ -298,7 +287,6 @@ class GenericEntityListFilter(django_filters.FilterSet):
 
         return queryset
 
-
     def related_property_name_method(self, queryset, name, value):
         # __before_rdf_refactoring__
         #
@@ -372,7 +360,6 @@ class GenericEntityListFilter(django_filters.FilterSet):
         ).distinct()
 
         return queryset
-
 
     def related_arbitrary_model_name(self, queryset, name, value):
         """
@@ -493,11 +480,8 @@ def get_list_filter_of_entity(entity):
     entity_list_filter_class = entity_class.get_entity_list_filter()
 
     if entity_list_filter_class is None:
-
         class AdHocEntityListFilter(GenericEntityListFilter):
-
             class Meta(GenericEntityListFilter.Meta):
-
                 model = entity_class
 
         entity_list_filter_class = AdHocEntityListFilter

--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -40,9 +40,16 @@ fields_to_exclude = getattr(settings, "APIS_RELATIONS_FILTER_EXCLUDE", [])
 
 
 class GenericEntityListFilter(django_filters.FilterSet):
+    """
+    Entity fields by which a given entity's list view can be
+    filtered on the frontend.
 
+    Combines config options in an app's settings file with entity-specific
+    settings defined in models.
+    """
     fields_to_exclude = getattr(settings, "APIS_RELATIONS_FILTER_EXCLUDE", [])
 
+    # add default labels to form fields on frontend
     name = django_filters.CharFilter(method="name_label_filter", label="Name or label")
     related_entity_name = django_filters.CharFilter(method="related_entity_name_method", label="Related entity")
     related_property_name = django_filters.CharFilter(method="related_property_name_method", label="Related property")


### PR DESCRIPTION
**Describe your changes**
This PR re-enables filtering lists of entities by entity-specific keywords. It is implemented in a way that requires config of `list_filters` via entity models rather than via an app's settings file. Additional commits clean up existing code/formatting.

Summary of changes:
- refactor method responsible for setting filters based on `list_filter` setting in models
- move the method out of `GenericEntityListFilter`'s `__init__` method for readability
- add, improve inline code comments, Docstrings
- fix formatting issues

**Related issues and PRs**
Resolves issue:
- #16 

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [ ] My changes follow the project's code formatting rules and style guidelines
- [x] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
