### PR TITLE
Fix entity names in list view + entity_settings not getting picked up

### DIFF
--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -129,6 +129,9 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         self.filter = None
 
     def get_model(self):
+        """
+        Look up the model class for the given entity
+        """
         model = ContentType.objects.get(
             app_label__startswith="apis_", model=self.entity
         ).model_class()
@@ -172,7 +175,6 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         else:
             edit_v = False
 
-        # check APIS_ENTITIES var in Settings for key used for table columns
         try:
             default_cols = model.entity_settings["table_fields"]
         except KeyError as e:

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -286,6 +286,8 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
             toggleable_cols = []
         if context["enable_merge"] and self.request.user.is_authenticated:
             toggleable_cols = toggleable_cols + ["merge"]
+        # TODO kk spelling of this dict key should get fixed throughout
+        #  (togglable_colums -> toggleable_columns)
         context["togglable_colums"] = toggleable_cols + ENTITIES_DEFAULT_COLS
 
         return context

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -237,9 +237,12 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
             context["class_name"] = f"{class_name}"
         if model._meta.verbose_name_plural:
             context["class_name_plural"] = f"{model._meta.verbose_name_plural.title()}"
+        # rudimentary way of pluralising the name of a model class
         else:
             if class_name.endswith("s"):
-                context["class_name_plural"] = f"{class_name}"
+                context["class_name_plural"] = f"{class_name}es"
+            elif class_name.endswith("y"):
+                context["class_name_plural"] = f"{class_name[:-1]}ies"
             else:
                 context["class_name_plural"] = f"{class_name}s"
 

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -18,6 +18,7 @@ from django_tables2.export.views import ExportMixin
 # from reversion_compare.views import HistoryCompareDetailView
 
 from apis_core.apis_metainfo.models import Uri, UriCandidate, Text
+
 # __before_rdf_refactoring__
 # from apis_core.apis_relations.models import AbstractRelation
 from apis_core.helper_functions.RDFParser import RDFParser
@@ -165,7 +166,9 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         """
         session = getattr(self.request, "session", False)
         entity = self.kwargs.get("entity")
-        selected_cols = self.request.GET.getlist("columns")  # populates "Select additional columns" dropdown
+        selected_cols = self.request.GET.getlist(
+            "columns"
+        )  # populates "Select additional columns" dropdown
         if session:
             edit_v = self.request.session.get("edit_views", False)
         else:
@@ -439,7 +442,7 @@ def getGeoJsonList(request):
 #     objects = relation.objects.filter(related_place__status="distinct")
 #     nodes = dict()
 #     edges = []
-# 
+#
 #     for x in objects:
 #         if x.related_place.pk not in nodes.keys():
 #             place_url = reverse_lazy(
@@ -493,10 +496,10 @@ def getGeoJsonList(request):
 #             }
 #         )
 #     lst_json = {"edges": edges, "nodes": [nodes[x] for x in nodes.keys()]}
-# 
+#
 #     return HttpResponse(json.dumps(lst_json), content_type="application/json")
-# 
-# 
+#
+#
 # @user_passes_test(access_for_all_function)
 # def getNetJsonListInstitution(request):
 #     """Used to retrieve a Json to draw a network"""
@@ -504,7 +507,7 @@ def getGeoJsonList(request):
 #     objects = relation.objects.all()
 #     nodes = dict()
 #     edges = []
-# 
+#
 #     for x in objects:
 #         if x.related_institution.pk not in nodes.keys():
 #             inst_url = reverse_lazy(
@@ -559,10 +562,10 @@ def getGeoJsonList(request):
 #             }
 #         )
 #     lst_json = {"edges": edges, "nodes": [nodes[x] for x in nodes.keys()]}
-# 
+#
 #     return HttpResponse(json.dumps(lst_json), content_type="application/json")
-# 
-# 
+#
+#
 # @login_required
 # def resolve_ambigue_place(request, pk, uri):
 #     """Only used to resolve place names."""
@@ -579,7 +582,7 @@ def getGeoJsonList(request):
 #             pl_n_1.save()
 #         UriCandidate.objects.filter(entity=entity).delete()
 #         reversion.set_user(request.user)
-# 
+#
 #     return HttpResponseRedirect(url)
 
 

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -127,6 +127,7 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         super(GenericListViewNew, self).__init__(*args, **kwargs)
         self.entity = None
         self.filter = None
+        self.entity_settings = None
 
     def get_model(self):
         """
@@ -135,6 +136,11 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         model = ContentType.objects.get(
             app_label__startswith="apis_", model=self.entity
         ).model_class()
+
+        try:
+            self.entity_settings = model.entity_settings
+        except AttributeError as e:
+            self.entity_settings = {}
 
         return model
 
@@ -177,7 +183,7 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
             "columns"
         )  # populates "Select additional columns" dropdown
         try:
-            default_cols = model.entity_settings["table_fields"]
+            default_cols = self.entity_settings["table_fields"]
         except KeyError as e:
             default_cols = []  # gets set to "name" in get_entities_table when empty
         default_cols = default_cols + selected_cols
@@ -267,12 +273,12 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
                 context = dict(context, **chartdata)
 
         try:
-            context["enable_merge"] = model.entity_settings[class_name]["merge"]
+            context["enable_merge"] = self.entity_settings["merge"]
         except KeyError:
             context["enable_merge"] = False
 
         try:
-            toggleable_cols = model.entity_settings["additional_cols"]
+            toggleable_cols = self.entity_settings["additional_cols"]
         except KeyError:
             toggleable_cols = []
         if context["enable_merge"] and self.request.user.is_authenticated:

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -142,11 +142,8 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
 
     def get_queryset(self, **kwargs):
         self.entity = self.kwargs.get("entity")
-        qs = (
-            ContentType.objects.get(app_label__startswith="apis_", model=self.entity)
-            .model_class()
-            .objects.all()
-        ).order_by("name")
+
+        qs = (self.get_model().objects.all()).order_by("name")
         self.filter = get_list_filter_of_entity(self.entity)(
             self.request.GET, queryset=qs
         )


### PR DESCRIPTION
This PR fixes (parts of) the problem reported and dicussed in #18 + another case of the recurring issue of `entity_settings` not getting applied to some model classes because class names aren't matched correctly.

Caveat: only `GenericListViewNew` in `apis_entities/views.py` was refactored, so other views may need equivalent work (depending on where/how `context` data is reused/set).

Summary of changes:
- Reverts `context['class_name']` to singular but _verbose_ name
- Introduces `context['class_name_plural']` for more flexibility in Django templates (once templates are refactored to work on a per-project basis, see acdh-oeaw/apis-rdf-devops#3)
- Improves ad-hoc pluralisation of class names which don't have `verbose_name_plural` set
- Fixes broken access of `entity_settings` configs for camel-cased class names
- Removes, simplifies redundant code, improves variables names, adapts formatting for readability
 
**Additional context**
As before, references to `settings.APIS_ENTITIES` were dropped altogether; entity settings are assumed to be set for each entity class individually in `models.py` going forward (see discussion in acdh-oeaw/apis-ontologies#9).

The use of `self` variables (or lack thereof) in this class continues to be somewhat unclear to me, but I introduced `self.entity_settings` anyway to allow for less convoluted checking for entity settings. Pointing it out in case this could have unintended effects I'm unaware of.

Lastly, the ordering in `get_queryset()` might need some further looking into because the view seems to get reused for non-entity classes as well, which do not necessarily have a `name` field objects can be ordered by.

**Related issues and PRs**
Partly solves issue:
- #18

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [x] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
