### PR TITLE
Bugfix/correct plural name property

### DIFF
--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -59,6 +59,8 @@ class BaseRelationManager(models.Manager):
 # passed class, but not for implicit superclasses. For this to be possible, the object manager must be overriden
 @reversion.register(follow=["vocabsbaseclass_ptr"])
 class Property(RootObject):
+    class Meta:
+        verbose_name_plural = "Properties"
 
     objects = BaseRelationManager()
 


### PR DESCRIPTION
Added the correct plural form for Property class so that Django will display "Properties" instead of Propertys.

**Related issues and PRs**
Resolves issue:
- #18 (partially)

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
