### PR TITLE
Allow use of abstract classes in models.py

### DIFF
--- a/apis_core/helper_functions/ContentType.py
+++ b/apis_core/helper_functions/ContentType.py
@@ -6,14 +6,16 @@ from django.db.models.base import ModelBase
 
 class GetContentTypes:
 
-    # class memeber dictionary, used for caching ContentType objects in method get_content_type_of_class_or_instance
+    # class member dict for caching ContentType objects in
+    # get_content_type_of_class_or_instance method
     class_content_type_dict = {}
 
     def get_names(self):
-        """Function to create Module/Class name tuples
+        """
+        Create tuples from a list of model classes to store their module names
+        and class names (as strings).
 
-        Returns:
-            [list]: [list of Modile/Class tuples]
+        :return: a list of tuples
         """
         res = []
         for cls in self._lst_cont:
@@ -21,22 +23,20 @@ class GetContentTypes:
         return res
 
     def get_model_classes(self):
-        """Returns list of django model classes
-
-        Returns:
-            [list]: [django model classes]
+        """
+        Return a list of Django model classes.
         """
         return self._lst_cont
 
     @classmethod
     def get_content_type_of_class_or_instance(cls, model_class_or_instance):
         """
-        Helper method which caches ContentType of a given model class or instance. When first called on a model
-        it fetches its respective ContentType from DB and caches it in a class dictionary. Later this dictionary is
-        called
+        Helper method which caches ContentType of a given model class or instance.
+        When first called on a model, it fetches its respective ContentType from the DB
+        and caches it in a class dictionary. Later, this dictionary is called.
 
-        :param model_class_or_instance: can be either a model class or an instance of a model class
-        :return: The django ContentType object for the given parameter
+        :param model_class_or_instance: model class or instance of a model class
+        :return: dictionary holding Django ContentType object
         """
 
         model_class = None
@@ -59,9 +59,14 @@ class GetContentTypes:
 
     def __init__(self, lst_conts=None):
         """
+        Iterate through a list of modules and filter for
+        - classes
+        - which are not abstract
+        - except for those explicitly ignored (via models_exclude list).
 
-        Args:
-            lst_conts ([list], optional): [list of entity names]. Defaults to list of apis_core entities.
+        :param lst_conts: (optional) list of paths to app models, in form of strings,
+                          e.g. "apis_core.apis_entities.models".
+                          By default, apis_core models are iterated over.
         """
         models_exclude = [
             "texttype_collections",

--- a/apis_core/helper_functions/ContentType.py
+++ b/apis_core/helper_functions/ContentType.py
@@ -39,7 +39,6 @@ class GetContentTypes:
         :return: dictionary holding Django ContentType object
         """
 
-        model_class = None
         if type(model_class_or_instance) is ModelBase:
             # true if model_class_or_instance is model class
             model_class = model_class_or_instance
@@ -57,7 +56,7 @@ class GetContentTypes:
             )
         return cls.class_content_type_dict[model_class]
 
-    def __init__(self, lst_conts=None):
+    def __init__(self, lst_conts: list = None):
         """
         Iterate through a list of modules and filter for
         - classes

--- a/apis_core/helper_functions/ContentType.py
+++ b/apis_core/helper_functions/ContentType.py
@@ -6,20 +6,18 @@ from django.db.models.base import ModelBase
 
 class GetContentTypes:
 
-
     # class memeber dictionary, used for caching ContentType objects in method get_content_type_of_class_or_instance
     class_content_type_dict = {}
-
 
     def get_names(self):
         """Function to create Module/Class name tuples
 
         Returns:
             [list]: [list of Modile/Class tuples]
-        """            
+        """
         res = []
         for cls in self._lst_cont:
-            res.append((cls.__module__.split('.')[-2], cls.__name__))
+            res.append((cls.__module__.split(".")[-2], cls.__name__))
         return res
 
     def get_model_classes(self):
@@ -27,9 +25,8 @@ class GetContentTypes:
 
         Returns:
             [list]: [django model classes]
-        """            
+        """
         return self._lst_cont
-
 
     @classmethod
     def get_content_type_of_class_or_instance(cls, model_class_or_instance):
@@ -55,18 +52,32 @@ class GetContentTypes:
             )
 
         if model_class not in cls.class_content_type_dict:
-            cls.class_content_type_dict[model_class] = ContentType.objects.get(model=model_class.__name__)
+            cls.class_content_type_dict[model_class] = ContentType.objects.get(
+                model=model_class.__name__
+            )
         return cls.class_content_type_dict[model_class]
-
 
     def __init__(self, lst_conts=None):
         """
 
         Args:
             lst_conts ([list], optional): [list of entity names]. Defaults to list of apis_core entities.
-        """        
-        models_exclude = ["texttype_collections", "relationbaseclass", "baserelationmanager", "relationpublishedqueryset", "inheritanceforwardmanytoonedescriptor", "inheritanceforeignkey"]
-        apis_modules = ['apis_core.apis_metainfo.models', 'apis_core.apis_vocabularies.models', 'apis_core.apis_entities.models', 'apis_core.apis_relations.models', "apis_ontology.models"]
+        """
+        models_exclude = [
+            "texttype_collections",
+            "relationbaseclass",
+            "baserelationmanager",
+            "relationpublishedqueryset",
+            "inheritanceforwardmanytoonedescriptor",
+            "inheritanceforeignkey",
+        ]
+        apis_modules = [
+            "apis_core.apis_metainfo.models",
+            "apis_core.apis_vocabularies.models",
+            "apis_core.apis_entities.models",
+            "apis_core.apis_relations.models",
+            "apis_ontology.models",
+        ]
         if lst_conts is not None:
             r2 = []
             for c in lst_conts:
@@ -78,7 +89,9 @@ class GetContentTypes:
         lst_cont = []
         for m in lst_cont_pre:
             for cls_n in dir(m):
-                if not cls_n.startswith('__') and "__module__" in list(dir(getattr(m, cls_n))):
+                if not cls_n.startswith("__") and "__module__" in list(
+                    dir(getattr(m, cls_n))
+                ):
                     if (
                         getattr(m, cls_n).__module__ in apis_modules
                         and getattr(m, cls_n) not in lst_cont

--- a/apis_core/helper_functions/ContentType.py
+++ b/apis_core/helper_functions/ContentType.py
@@ -96,8 +96,8 @@ class GetContentTypes:
                         getattr(m, cls_n).__module__ in apis_modules
                         and getattr(m, cls_n) not in lst_cont
                         and cls_n.lower() not in models_exclude
-                        and not "abstract" in cls_n.lower()
                         and inspect.isclass(getattr(m, cls_n))
+                        and getattr(m, cls_n)._meta.abstract is False
                     ):
                         lst_cont.append(getattr(m, cls_n))
         lst_cont.append(ContentType)


### PR DESCRIPTION
**Describe your changes**
The change in this PR gets rid of the Serializer-related error when adding abstract classes to models.py (see #27).

However, abstract classes continue to be displayed to users on the frontend, e.g. in the Entities dropdown in the main menu (which leads to an error when clicked, due to their non-existence). -> Any other affected views still need cleaning up as well. See also **TODO** section in the linked issue.

**Related issues and PRs**
Partially resolves issue:
- #27

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [x] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
