### PR TITLE
Fix unicode validation of Property name_forward, name_reverse 

### DIFF
--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -645,9 +645,8 @@ class Triple(models.Model):
 
         return self.__repr__()
 
-    def get_web_object(self):
-
         # __before_rdf_refactoring__
+        # def get_web_object(self):
         # Method from RelationBaseClass
         #
         # nameA = self.get_related_entity_instanceA().name
@@ -677,6 +676,8 @@ class Triple(models.Model):
         # return result
         #
         # __after_rdf_refactoring__
+
+    def get_web_object(self):
         return {
             "relation_pk": self.pk,
             "subj": self.subj.name,

--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -612,6 +612,7 @@ class Triple(models.Model):
         null=True,
         on_delete=models.CASCADE,
         related_name="triple_set_from_subj",
+        verbose_name="Subject",
     )
     obj = InheritanceForeignKey(
         RootObject,
@@ -619,6 +620,7 @@ class Triple(models.Model):
         null=True,
         on_delete=models.CASCADE,
         related_name="triple_set_from_obj",
+        verbose_name="Object",
     )
     prop = models.ForeignKey(
         Property,
@@ -626,6 +628,7 @@ class Triple(models.Model):
         null=True,
         on_delete=models.CASCADE,
         related_name="triple_set_from_prop",
+        verbose_name="Property",
     )
 
     objects = BaseRelationManager()

--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -4,8 +4,10 @@ import unicodedata
 
 # from reversion import revisions as reversion
 import reversion
+
 # from apis_core.apis_entities.models import Person
 from apis_core.apis_entities.models import RootObject, TempEntityClass
+
 #######################################################################
 #
 # Custom Managers
@@ -134,7 +136,6 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
                 )
 
                 if len(contenttype_parent) == 1:
-
                     contenttype_parent = contenttype_parent[0]
                     parent_list.append(contenttype_parent)
                     parent_list.extend(get_all_parents(contenttype_parent))
@@ -147,7 +148,6 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
             class_current = contenttype_current.model_class()
 
             for class_child in class_current.__subclasses__():
-
                 # TODO __sresch__ : Avoid ContentType DB fetch
                 contenttype_child = ContentType.objects.get(model=class_child.__name__)
                 child_list.append(contenttype_child)
@@ -160,7 +160,6 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
         for parent_contenttype in parent_contenttype_list:
 
             if parent_contenttype in contenttype_already_saved_list:
-
                 raise Exception(
                     f"Pre-existing parent class found when trying to save or remove a property subject or object class."
                     f" The current class to be saved is '{contenttype_to_add_or_remove.model_class().__name__}',"
@@ -172,7 +171,6 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
         children_contenttype_list = get_all_children(contenttype_to_add_or_remove)
 
         for child_contenttype in children_contenttype_list:
-
             subj_or_obj_field_function(child_contenttype)
 
     if kwargs["pk_set"] is not None and len(kwargs["pk_set"]) == 1:
@@ -202,7 +200,6 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
             subj_or_obj_field_function = subj_or_obj_field.remove
 
         if subj_or_obj_field_function is not None:
-
             cascade_subj_obj_class_to_children(
                 contenttype_to_add_or_remove=ContentType.objects.get(
                     pk=min(kwargs["pk_set"])
@@ -213,12 +210,10 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
 
 
 def subj_class_changed(sender, **kwargs):
-
     subj_or_obj_class_changed(sender, is_subj=True, **kwargs)
 
 
 def obj_class_changed(sender, **kwargs):
-
     subj_or_obj_class_changed(sender, is_subj=False, **kwargs)
 
 
@@ -588,8 +583,7 @@ class RelationPublishedQueryset(models.QuerySet):
 
 
 # TODO __sresch__ : Move this somewhere else so that it can be imported at several places (right now it's redundant with copies)
-from django.db.models.fields.related_descriptors import \
-    ForwardManyToOneDescriptor
+from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
 
 
 class InheritanceForwardManyToOneDescriptor(ForwardManyToOneDescriptor):
@@ -735,7 +729,6 @@ class Triple(models.Model):
 
 
 class TempTriple(Triple):
-
     review = models.BooleanField(
         default=False,
         help_text="Should be set to True, if the data record holds up quality standards.",

--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -73,7 +73,7 @@ class Property(RootObject):
     # TODO RDF : Redundancy between name_forward and name, solve this.
     name_forward = models.CharField(
         max_length=255,
-        verbose_name="Name reverse",
+        verbose_name="Name forward",
         help_text='Inverse relation like: "is sub-class of" vs. "is super-class of".',
         blank=True,
     )

--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -103,14 +103,17 @@ class Property(RootObject):
         return self.name
 
     def save(self, *args, **kwargs):
-        if self.name_reverse != unicodedata.normalize("NFC", self.name_reverse):
-            self.name_reverse = unicodedata.normalize("NFC", self.name_reverse)
-
-        if self.name_reverse == "" or self.name_reverse == None:
-            self.name_reverse = self.name + " [REVERSE]"
-
         # TODO RDF : Temporary hack, remove this once better solution is found
         self.name_forward = self.name
+
+        if self.name_reverse is None or self.name_reverse == "":
+            self.name_reverse = self.name_forward + " [REVERSE]"
+
+        if unicodedata.is_normalized("NFC", self.name_forward) is False:
+            self.name_forward = unicodedata.normalize("NFC", self.name_forward)
+
+        if unicodedata.is_normalized("NFC", self.name_reverse) is False:
+            self.name_reverse = unicodedata.normalize("NFC", self.name_reverse)
 
         super(Property, self).save(*args, **kwargs)
         return self


### PR DESCRIPTION
**Describe your changes**
This PR fixes the order of variable assignments/assignment checks and unicode normalisation of strings implemented in the `save()` method of class `Property`.

Summary:
- puts `self.name_forward` assignment first for later reuse
- checks for existence of `self.name_reverse` before attempting unicode normalisation
- applies unicode normalisation to both variables
- fixes syntax

**Additional context**
Only the last commit 4e73bf9 is relevant to this PR / contains the changes described above.

All earlier commits are partial cherry-picks of PR #25 (specifically: all changes to apis_core/apis_relations/models.py), which is expected to get merged at a later point.

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
