### PR TITLE
Allow overriding the APIS_ENTITIES setting

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -1052,10 +1052,13 @@ if "registration" in getattr(settings, "INSTALLED_APPS", []):
 #  It would be better done if entity settings would be fully moved
 #  into the entities themselves.
 def fill_settings_with_entity_attributes():
-    for entity_class in AbstractEntity.get_all_entity_classes():
-        entity_settings = entity_class.entity_settings
+    # if APIS_ENTITIES are not defined in the settings, we take the
+    # ones that are defined in the entity classes
+    if not settings.APIS_ENTITIES:
+        for entity_class in AbstractEntity.get_all_entity_classes():
+            entity_settings = entity_class.entity_settings
 
-        settings.APIS_ENTITIES[entity_class.__name__] = entity_settings
+            settings.APIS_ENTITIES[entity_class.__name__] = entity_settings
 
 
 fill_settings_with_entity_attributes()

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -183,7 +183,7 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
             "columns"
         )  # populates "Select additional columns" dropdown
         try:
-            default_cols = self.entity_settings["table_fields"]
+            default_cols = settings.APIS_ENTITIES.get(class_name)["table_fields"]
         except KeyError as e:
             default_cols = []  # gets set to "name" in get_entities_table when empty
         default_cols = default_cols + selected_cols


### PR DESCRIPTION
The APIS_ENTITIES are created using the values that are stored in
the `entity_settings` attribute of entities. In some cases it might
make sense to be able to define those in the global settings file.
This commit changes the code so it checks for the existense of the
APIS_ENTITIES setting and only uses the `entity_settings` attribute
if the global settings is empty.
