### PR TITLE
Work around hard coded dependency on apis_ontology

### DIFF
--- a/apis_core/api_routers.py
+++ b/apis_core/api_routers.py
@@ -4,7 +4,10 @@ import importlib
 import inspect
 from ast import literal_eval
 from django.conf import settings
-from apis_ontology.models import *
+try:
+    from apis_ontology.models import *
+except ImportError:
+    pass
 from apis_core.apis_metainfo.models import *
 # from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse

--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -254,22 +254,27 @@ class AbstractEntity(RootObject):
             entity_classes = []
             entity_names = []
 
-            from apis_ontology import models as ontology_models
+            # this try-expect is a workaround, because `apis_ontology` module
+            # might not be installed
+            try:
+                from apis_ontology import models as ontology_models
 
-            for entity_name, entity_class in inspect.getmembers(
-                ontology_models, inspect.isclass
-            ):
-
-                # print(entity_name, entity_class)
-
-                if (
-                    # entity_class.__module__ == "apis_core.apis_entities.models"
-                    entity_class.__module__ == "apis_ontology.models"
-                    and entity_name != "ent_class"
-                    and entity_class._meta.abstract is False
+                for entity_name, entity_class in inspect.getmembers(
+                    ontology_models, inspect.isclass
                 ):
-                    entity_classes.append(entity_class)
+
+                    # print(entity_name, entity_class)
+
+                    if (
+                        # entity_class.__module__ == "apis_core.apis_entities.models"
+                        entity_class.__module__ == "apis_ontology.models"
+                        and entity_name != "ent_class"
+                        and entity_class._meta.abstract is False
+                    ):
+                        entity_classes.append(entity_class)
                     entity_names.append(entity_name.lower())
+            except ImportError:
+                pass
 
             cls._all_entity_classes = entity_classes
             cls._all_entity_names = entity_names

--- a/apis_core/helper_functions/ContentType.py
+++ b/apis_core/helper_functions/ContentType.py
@@ -89,7 +89,15 @@ class GetContentTypes:
                     if c in c2:
                         r2.append(c2)
             apis_modules = r2
-        lst_cont_pre = [importlib.import_module(x) for x in apis_modules]
+
+        # this is a hack, because the `apis_modules` are hardcoded, up there
+        # but there is no guarantee that all of them are available
+        lst_cont_pre = []
+        for module in apis_modules:
+            try:
+                lst_cont_pre.append(importlib.import_module(module))
+            except ImportError:
+                pass
         lst_cont = []
         for m in lst_cont_pre:
             for cls_n in dir(m):


### PR DESCRIPTION
This commit introduces some try-except blocks around hardcoded imports
of `apis_ontology`. `apis_ontology` is not part of this project and
there is no dependency defined anywhere. With the exception handling
it becomes possible to run tests in this project.

Closes: https://github.com/acdh-oeaw/apis-core-rdf/issues/33