### PR TITLE
Bump Python requirement to >=3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ include = [{path = "LICENSE.txt", format = "sdist"}, {path = "README.rst", forma
 exclude = ["manage.py", "__pycache__"]
 
 [tool.poetry.dependencies]
-python = ">=3.7, <3.9"
+python = ">=3.8, <3.9"
 Django = "~3.1.8"
 djangorestframework = "^3.12.2"
 django-filter = "^2.4.0"


### PR DESCRIPTION
Given that we depend on pandas >1.5.3 which needs Python >=3.8 it makes
sense to update the projects Python dependency so that poetry does not
freak out.

Closes: #38
