### PR TITLE
apis_entities: Reinitialize the bibsonomy events when redrawing relation table

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/edit_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/edit_generic.html
@@ -222,6 +222,9 @@
 
             })            //$(".form.ajax_form").unbind()
             console.log($('#tab_'+data.tab+" select.listselect2"))
+            {% if apis_bibsonomy %}
+            reinitialize_bibsonomy_tooltips()
+            {% endif %}
         };
         if (!$.ApisForms) {
             $.ApisForms = {}


### PR DESCRIPTION
Up until now the bibsonomy events got only initialized when the document was
loaded. This led to changes in the table break bibsonomy functionality. The
bibsonomy app now moved the event initialization to a separate function, which
we now call during redrawing the table.

See also acdh-oeaw/apis-bibsonomy#15
