### PR TITLE
apis: check for existence of webpage before including in urlpatterns

### DIFF
--- a/apis/urls.py
+++ b/apis/urls.py
@@ -15,8 +15,9 @@ if "theme" in settings.INSTALLED_APPS:
         url(r"^", include("theme.urls", namespace="theme")),
         url(r"^admin/", admin.site.urls),
         url(r"^info/", include("infos.urls", namespace="info")),
-        url(r"^webpage/", include("webpage.urls", namespace="webpage")),
     ]
+    if "webpage" in settings.INSTALLED_APPS:
+        urlpatterns.append(url(r"^webpage/", include("webpage.urls", namespace="webpage")))
 if "paas_theme" in settings.INSTALLED_APPS:
     urlpatterns = [
         url(r"^apis/", include("apis_core.urls", namespace="apis")),
@@ -27,8 +28,9 @@ if "paas_theme" in settings.INSTALLED_APPS:
         url(r"^", include("paas_theme.urls", namespace="theme")),
         url(r"^admin/", admin.site.urls),
         url(r"^info/", include("infos.urls", namespace="info")),
-        url(r"^webpage/", include("webpage.urls", namespace="webpage")),
     ]
+    if "webpage" in settings.INSTALLED_APPS:
+        urlpatterns.append(url(r"^webpage/", include("webpage.urls", namespace="webpage")))
 else:
     urlpatterns = [
         url(r"^apis/", include("apis_core.urls", namespace="apis")),
@@ -38,8 +40,9 @@ else:
         ),
         url(r"^admin/", admin.site.urls),
         url(r"^info/", include("infos.urls", namespace="info")),
-        url(r"^", include("webpage.urls", namespace="webpage")),
     ]
+    if "webpage" in settings.INSTALLED_APPS:
+        urlpatterns.append(url(r"^", include("webpage.urls", namespace="webpage")))
 
 
 if 'viecpro_vis' in settings.INSTALLED_APPS:
@@ -63,4 +66,5 @@ if "oebl_irs_workflow" in settings.INSTALLED_APPS:
             include("oebl_irs_workflow.urls", namespace="oebl_irs_workflow"),
         )
     )
-handler404 = "webpage.views.handler404"
+if "webpage" in settings.INSTALLED_APPS:
+    handler404 = "webpage.views.handler404"


### PR DESCRIPTION
The 'webpage' django app is not part of apis. To make the apis app self
contained and not rely on a not installed thirt party app, this commit
introduces checks before including `webpage` urlpatterns.
