### PR TITLE
Replace self_contenttype with property

### DIFF
--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -342,17 +342,8 @@ class RootObject(models.Model):
     # self_contenttype: a foreign key to the respective contenttype comes in handy when querying for
     # triples where the subject's or object's contenttype must be respected (e.g. get all triples
     # where the subject is a Person)
-    self_contenttype = models.ForeignKey(
-        ContentType, on_delete=models.deletion.CASCADE, null=True, blank=True
-    )
     objects = models.Manager()
     objects_inheritance = InheritanceManager()
-
-    def save(self, *args, **kwargs):
-        if self.self_contenttype is None:
-            self.self_contenttype = caching.get_contenttype_of_class(self.__class__)
-
-        super().save(*args, **kwargs)
 
     def __str__(self):
 
@@ -360,6 +351,10 @@ class RootObject(models.Model):
             return self.name
         else:
             return "no name provided"
+
+    @property
+    def self_contenttype(self):
+        return caching.get_contenttype_of_class(self.__class__)
 
 
 @reversion.register()


### PR DESCRIPTION
Given that there is a cache now, we can use that to get the contenttype of the
class from memory instead of storing this information in the database every
instance of a model.
That way we don't use the database that often.

@steffres, what do you think? If that approach makes sense, I would update the
rest of the code that uses the `self_contenttype` field.
