### PR TITLE
Rh/hotfix/change display name on create page to verbose name

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -248,7 +248,6 @@ class GenericEntitiesCreateView(View):
         }
         template = get_template("apis_entities/edit_generic.html")
         entity_class = caching.get_ontology_class_of_name(entity)
-        print(entity_class)
         return HttpResponse(
             template.render(
                 request=request,

--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -247,6 +247,8 @@ class GenericEntitiesCreateView(View):
             "create": request.user.has_perm("entities.add_{}".format(entity))
         }
         template = get_template("apis_entities/edit_generic.html")
+        entity_class = caching.get_ontology_class_of_name(entity)
+        print(entity_class)
         return HttpResponse(
             template.render(
                 request=request,
@@ -255,6 +257,7 @@ class GenericEntitiesCreateView(View):
                     "permissions": permissions,
                     "form": form,
                     "form_text": form_text,
+                    "entity_verbose_name": entity_class._meta.verbose_name,
                 },
             )
         )
@@ -269,7 +272,7 @@ class GenericEntitiesCreateView(View):
             form_text.save(entity_2)
             return redirect(
                 reverse(
-                    "apis:apis_entities:generic_entities_detail_view",
+                    "apis:apis_entities:generic_entities_edit_view",
                     kwargs={"pk": entity_2.pk, "entity": entity},
                 )
             )

--- a/apis_core/apis_entities/templates/apis_entities/edit_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/edit_generic.html
@@ -61,7 +61,7 @@
                                 </h3>
             		        {% else %}
                                 <h2>
-                                    <small>create new object type:</small> <strong>{{ entity_type|title }}</strong>
+                                    <small>Create new:</small> <strong>{{ entity_verbose_name|title }}</strong>
                                 </h2>
                             {% endif %}
                         </div>


### PR DESCRIPTION
**Describe your changes**
Create entity page showed entity name with spaces as one word, first char uppercase. Replaced with `Entity._meta.verbose_name|title`

- Change A
- Change B



**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [x] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
