### PR TITLE
apis_entities: fix merging two entities

### DIFF
--- a/apis_core/apis_entities/forms.py
+++ b/apis_core/apis_entities/forms.py
@@ -232,7 +232,9 @@ def get_entities_form(entity):
 class GenericEntitiesStanbolForm(forms.Form):
     def save(self, *args, **kwargs):
         cd = self.cleaned_data
-        entity = RDFParser(cd["entity"], self.entity.title()).get_or_create()
+        entity = RDFParser(
+            cd["entity"], self.entity.title(), app_label_entities="apis_ontology"
+        ).get_or_create()
         return entity
 
     def __init__(self, entity, *args, **kwargs):

--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -283,9 +283,7 @@ class TempEntityClass(AbstractEntity):
         from apis_core.apis_metainfo.models import Uri
 
         e_a = type(self).__name__
-        self_model_class = ContentType.objects.get(
-            app_label="apis_entities", model__iexact=e_a
-        ).model_class()
+        self_model_class = ContentType.objects.get(model__iexact=e_a).model_class()
         if isinstance(entities, int):
             entities = self_model_class.objects.get(pk=entities)
         if not isinstance(entities, list) and not isinstance(entities, QuerySet):


### PR DESCRIPTION
The RDFParser needs the correct app_label_entities set, to find the
ContentType. We could also fix the RDFParser directly, but at the
current state this could have unknown consequences.
In the merge method of the TempEntityClass it seems that the lookup
of the ContentType also works withtout setting the app_label.
