### PR TITLE
apis_relations: fix RootObject import and remove TempEntityClass import

### DIFF
--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -6,7 +6,7 @@ import unicodedata
 import reversion
 
 # from apis_core.apis_entities.models import Person
-from apis_core.apis_entities.models import RootObject, TempEntityClass
+from apis_core.apis_metainfo.models import RootObject
 from apis_core.helper_functions import DateParser
 from crum import get_current_request
 from django.conf import settings


### PR DESCRIPTION
The RootObject resides in apis_core.apis_metainfo and should be imported
from there. The TempEntityClass is not used in this class at all.
