### PR TITLE
apis-entities: Readd the merge form in the edit template

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/edit_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/edit_generic.html
@@ -125,6 +125,17 @@
                         <div class="card-body">
                             <div class="card" id="accordion" role="tablist" aria-multiselectable="true">
                             {% block additional_accordion %}
+                            <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="headingOne">
+                                            <h4 class="panel-title">
+                                                <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">Merge with</a>
+                                            </h4>
+                                    </div>
+                                    <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+                                            <div id="tab_merge_with" class="panel-body">{% load crispy_forms_tags %} {% crispy form_merge_with  form_merge_with.helper %} </div>
+                                    </div>
+                            </div>
+                            <hr/>
                             {% endblock additional_accordion %}
                             {% for obj in right_card %}
                                 <div class="card card-default">


### PR DESCRIPTION
The entity specific templates containing the merge form were dropped in
5bdeb5c as `unused legacy clutter`.
