### PR TITLE
feat: implement duplication of RootObject children

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -286,3 +286,19 @@ class GenericEntitiesDeleteView(DeleteView):
             "apis_core:apis_entities:generic_entities_list", kwargs={"entity": entity}
         )
         return super(GenericEntitiesDeleteView, self).dispatch(request, *args, **kwargs)
+
+
+@method_decorator(login_required, name="dispatch")
+class GenericEntitiesDuplicateView(View):
+    def get(self, request, *args, **kwargs):
+        entity_model = caching.get_entity_class_of_name(kwargs["entity"])
+        source_obj = get_object_or_404(entity_model, pk=kwargs["pk"])
+
+        newobj = source_obj.duplicate()
+
+        return redirect(
+            reverse(
+                "apis:apis_entities:generic_entities_edit_view",
+                kwargs={"pk": newobj.id, "entity": kwargs["entity"]},
+            )
+        )

--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -272,8 +272,14 @@ class TempEntityClass(AbstractEntity):
             kwargs={"entity": entity, "pk": self.id},
         )
 
-    def merge_with(self, entities):
+    def get_duplicate_url(self):
+        entity = self.__class__.__name__.lower()
+        return reverse(
+            "apis_core:apis_entities:generic_entities_duplicate_view",
+            kwargs={"entity": entity, "pk": self.id},
+        )
 
+    def merge_with(self, entities):
         # TODO: check if these imports can be put to top of module without
         #  causing circular import issues.
         from apis_core.apis_labels.models import Label

--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -56,6 +56,15 @@
                     </svg>
                   </a>
               {% endif %}
+              {% if object.get_duplicate_url %}
+	         |
+                  <a href="{{ object.get_duplicate_url }}" title="Duplicate">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-copy">
+                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                       <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                      </svg>
+                  </a>
+              {% endif %}
             {% endif %}
           </h2>
         </div>

--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -37,6 +37,11 @@ entity_patterns = [
         edit_generic.GenericEntitiesDeleteView.as_view(),
         name="generic_entities_delete_view",
     ),
+    path(
+        "<int:pk>/duplicate/",
+        edit_generic.GenericEntitiesDuplicateView.as_view(),
+        name="generic_entities_duplicate_view",
+    ),
 ]
 
 autocomplete_patterns = [


### PR DESCRIPTION
This commit adds a method `duplicate` to the RootObject class. The
method creates a copy of self and tries to copy some of the relations
too as well as the reverse ManyToOneRels.
The commit also introduces a `GenericEntitiesDuplicateView` in
apis_entities.edit_generic, a `get_duplicate_url` in
`apis_entities.models` and an url entry for that view. Last but not
least it adds a duplicate link to the `detail_views/detail_generic.html`
template.