### PR TITLE
fix: use logger instead of an exception

### DIFF
--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -1,3 +1,5 @@
+import logging
+
 from collections import OrderedDict
 
 import django_filters
@@ -126,12 +128,10 @@ class GenericEntityListFilter(django_filters.FilterSet):
                         default_filters[field_name].label = filter_settings["label"]
 
                     field_filters[field_name] = default_filters[field_name]
-
             else:
-                raise ValueError(
-                    f"Filters for individual entities need to be of type "
-                    f"string or dictionary.\n"
-                    f"Got instead: {type(f)}"
+                logging.error(
+                    "Unusable filter - should be name of a default filter or a dict, got %s",
+                    f,
                 )
 
         for f_name, f_filter in default_filters.items():


### PR DESCRIPTION
Even if there is an unusable filter, doesn't mean the remaining
interface could not still be used. Using logging we can inform the admin
of the misconfiguration, but still show the form.
