### PR TITLE
fix: add acdh-django-charts dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ django-summernote = "^0.8.11"
 djangorestframework-jsonschema = "^0.1.1"
 pandas = "^1.5.3"
 django-admin-csvexport = "^1.9"
+acdh-django-charts = "^0.5.3"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
There are a couple of templates that rely on templatetags from the
acdh-django-charts project, namely in `apis_vis`:

 * average.html
 * inst_range.html
 * avgmemperyer.html

and generic_list.html in `apis_metainfo`.
