### PR TITLE
refactor: get rid of `webpage` dependency

### DIFF
--- a/apis/settings/base.py
+++ b/apis/settings/base.py
@@ -617,3 +617,4 @@ APIS_OSD_JS = (
 APIS_OSD_IMG_PREFIX = (
     "https://cdnjs.cloudflare.com/ajax/libs/openseadragon/2.4.0/images/"
 )
+BASE_TEMPLATE = "webpage/base.html"

--- a/apis_core/apis_entities/api_mappings/cidoc_mapping.py
+++ b/apis_core/apis_entities/api_mappings/cidoc_mapping.py
@@ -1,13 +1,7 @@
 from django.conf import settings
 from rdflib import RDF, RDFS, XSD, BNode, Literal, URIRef, OWL
 
-try:
-    from webpage.metadata import PROJECT_METADATA
-except ImportError:
-    try:
-        from webpage.utils import PROJECT_METADATA
-    except ImportError:
-        PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD")
+PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD")
 
 base_uri = getattr(settings, "APIS_BASE_URI", "http://apis.info")
 if base_uri.endswith("/"):

--- a/apis_core/apis_entities/api_renderers.py
+++ b/apis_core/apis_entities/api_renderers.py
@@ -15,13 +15,7 @@ from rest_framework import renderers
 from apis_core.apis_tei.tei import TeiEntCreator
 from .api_mappings.cidoc_mapping import m_person, m_place, m_work, m_institution
 
-try:
-    from webpage.metadata import PROJECT_METADATA
-except ImportError:
-    try:
-        from webpage.utils import PROJECT_METADATA
-    except ImportError:
-        PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD")
+PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD", {})
 
 
 base_uri = getattr(settings, "APIS_BASE_URI", "http://apis.info")

--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -277,7 +277,7 @@ class GenericEntitiesDeleteView(DeleteView):
     #     app_label='apis_entities', model='tempentityclass').model_class()
     model = importlib.import_module("apis_core.apis_entities.models").TempEntityClass
     template_name = getattr(
-        settings, "APIS_DELETE_VIEW_TEMPLATE", "apis_entities/confirm_delete.html"
+        settings, "APIS_DELETE_VIEW_TEMPLATE", "confirm_delete.html"
     )
 
     def dispatch(self, request, *args, **kwargs):

--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% load django_tables2 %}
 {% block title %} {{ object }} {% endblock %}

--- a/apis_core/apis_entities/templates/apis_entities/edit_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/edit_generic.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% block scriptHeader %}
 {{block.super}}

--- a/apis_core/apis_entities/templates/apis_entities/generic_list.html
+++ b/apis_core/apis_entities/templates/apis_entities/generic_list.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends base_template %}
 {% load i18n %}
 {% block title %} See all {{entity|title}}s {% endblock %}
 {% block content %}

--- a/apis_core/apis_entities/templates/apis_entities/generic_network_visualization.html
+++ b/apis_core/apis_entities/templates/apis_entities/generic_network_visualization.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% load crispy_forms_tags %}
 {% block scriptHeader %}

--- a/apis_core/apis_entities/templates/apis_entities/map_list.html
+++ b/apis_core/apis_entities/templates/apis_entities/map_list.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block scriptHeader %}
 <style type="text/css">
 

--- a/apis_core/apis_entities/templates/apis_entities/network.html
+++ b/apis_core/apis_entities/templates/apis_entities/network.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% block scriptHeader %}
 

--- a/apis_core/apis_entities/templates/apis_entities/network_institution.html
+++ b/apis_core/apis_entities/templates/apis_entities/network_institution.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% block scriptHeader %}
 

--- a/apis_core/apis_labels/templates/apis_labels/label_create.html
+++ b/apis_core/apis_labels/templates/apis_labels/label_create.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 
 {% block Titel %}Create Label{% endblock %}
 {% block scriptHeader %}

--- a/apis_core/apis_labels/templates/apis_labels/labels_list.html
+++ b/apis_core/apis_labels/templates/apis_labels/labels_list.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block Titel %} See all Labels {% endblock %}
 {% block content %}
 

--- a/apis_core/apis_labels/views.py
+++ b/apis_core/apis_labels/views.py
@@ -53,5 +53,5 @@ def label_edit(request, pk):
 
 class LabelDelete(DeleteView):
     model = Label
-    template_name = "apis_templates/confirm_delete.html"
+    template_name = "confirm_delete.html"
     success_url = reverse_lazy("apis_labels:label_list")

--- a/apis_core/apis_metainfo/templates/apis_metainfo/uri_detail.html
+++ b/apis_core/apis_metainfo/templates/apis_metainfo/uri_detail.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% load django_tables2 %}
 {% block title %} {{ object }} {% endblock %}

--- a/apis_core/apis_metainfo/templates/base.html
+++ b/apis_core/apis_metainfo/templates/base.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+{% load static %}
+{% load browsing_extras %}
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Title Placeholder{% endblock %}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% block metaDescription %}
+    <meta name="description" content="Description">
+    <meta name="author" content="Author">
+  {% endblock %}
+  <!-- Start favicons -->
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ SHARED_URL }}favicon/apple-touch-icon.png"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ SHARED_URL }}favicon/favicon-32x32.png"/>
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ SHARED_URL }}favicon/favicon-16x16.png"/>
+  <link rel="manifest" href="{{ SHARED_URL }}favicon/manifest.json"/>
+  <link rel="mask-icon" href="{{ SHARED_URL }}favicon/safari-pinned-tab.svg" color="#00aba9"/>
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/css/bootstrap-select.min.css"/>
+  <meta name="theme-color" content="#ffffff"/>
+  <!-- End favicons -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  {% include "apis_entities/apis_templatetag.html" %}
+  <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500" rel="stylesheet"/>
+  <link rel="stylesheet" id="fundament-styles" href="{{ SHARED_URL }}fundament/dist/fundament/css/fundament.min.css"
+        type="text/css"/>
+  <link rel="stylesheet" href="{{ PROJECT_CSS }}?rnd=1" rel="stylesheet"/>
+  <link rel="stylesheet" href="{{ SHARED_URL }}apis/libraries/scroll-to-top/css/ap-scroll-top.min.css"/>
+
+  {% block scriptHeader %}
+  {% endblock %}
+</head>
+
+<body role="document" class="home contained fixed-nav" id="body" style="height: unset!important;">
+<div class="hfeed site" id="page">
+  <div class="wrapper-fluid wrapper-navbar sticky-navbar" id="wrapper-navbar" itemscope=""
+       itemtype="http://schema.org/WebSite">
+    <a class="skip-link screen-reader-text sr-only" href="#content">Skip to content</a>
+    <!-- Start site navigation -->
+    <nav class="navbar navbar-expand-lg navbar-light">
+      <div class="container-fluid">
+
+        <!-- Start custom branding -->
+        <a href="/" class="navbar-brand custom-logo-link" rel="home" itemprop="url">
+          <img src="{{ PROJECT_LOGO }}" class="img-fluid"/>
+        </a>
+        <!-- End custom branding -->
+
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown"
+                aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"/>
+        </button>
+
+        <!-- Start main menu -->
+        <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">
+          <ul id="main-menu" class="navbar-nav">
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                 aria-expanded="false">About
+                <span class="caret"/>
+              </a>
+              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+		      {% block about-dropdown-menu-items %}
+		      {% endblock about-dropdown-menu-items %}
+              </div>
+            </li>
+            <!-- Wrap dropdown menus in custom blocks to allow override in Ontology -->
+            {% block custom_dropdown_menus %}
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                 aria-expanded="false">
+                Entities
+                <span class="caret"/>
+              </a>
+              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {% for ent in entities_links %}
+                  <a class="dropdown-item"
+                     href="{% url 'apis:apis_entities:generic_entities_list' ent.0 %}">{{ ent.1 }}</a>
+                {% endfor %}
+                <a class="dropdown-item" href="{% url 'apis:apis_metainfo:uri_browse' %}">URIs</a>
+              </div>
+            </li>
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                 aria-expanded="false">Relations
+                <span class="caret"/>
+              </a>
+              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {% for ent in relations_list %}
+                  <a class="dropdown-item"
+                     href="{% url 'apis:apis_relations:generic_relations_list' ent %}">{{ ent|title }}</a>
+                {% endfor %}
+              </div>
+            </li>
+            {% endblock %}
+          </ul>
+
+          <!-- Start user login submenu -->
+          <ul class="navbar-nav justify-content-end">
+            {% if user.is_authenticated %}
+              <li class="nav-item dropdown ml-auto">
+                <a href="" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+                   aria-expanded="false">
+                  User: {{ user.get_username }}
+                </a>
+                <div class="dropdown-menu dropdown-menu-right">
+                  <div class="dropdown-item">
+                    <a class="nav-link p-0" href="{% url 'admin:logout' %}">
+                      <span class="feather-32" data-feather="log-out"></span>
+                      log out
+                    </a>
+                  </div>
+                  <div class="dropdown-item">
+                    <form class="form-inline">
+                      <div class="form-check">
+                        <input id="check_edit_views" type="checkbox"
+                               class="form-check-input"
+                               {% if request.session.edit_views %}checked{% endif %}>
+                        <label class="form-check-label" for="check_edit_views">
+                          Use edit views
+                        </label>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </li>
+            {% else %}
+              <li class="nav-item dropdown ml-auto">
+                <a class="nav-link p-0" href="{% url 'admin:login' %}?next={{ request.path|urlencode }}">
+                  <span class="feather-32" data-feather="log-in"></span>
+                </a>
+              </li>
+            {% endif %}
+          </ul>
+          <!-- End user login submenu -->
+
+        </div>
+        <!-- End main menu -->
+
+      </div>
+    </nav>
+    <!-- End site navigation -->
+  </div>
+
+  <!-- Start main content block -->
+  <div id="content">
+    {% if DEV_VERSION %}
+      <div class="alert alert-danger" role="alert">
+        This is a DEVELOPMENT instance. Click <a href="https://{{ PROJECT_NAME }}.acdh.oeaw.ac.at">here</a> for the
+        Production version
+      </div>
+    {% endif %}
+    {% block content %}{% endblock %}
+  </div>
+  <!-- End main content block -->
+
+  <div class="d-flex footer-separator justify-content-center p-2"></div>
+  <!-- Start site footer -->
+  <div id="wrapper-footer-full" class="fundament-default-footer">
+    <div class="d-flex flex-column container-fluid p-4" id="footer-full-content" tabindex="-1">
+      <div class="d-flex flex-column align-self-center justify-content-center">
+        <div class="d-flex flex-column">
+          <div class="align-self-center p-1">
+            <a href="https://www.oeaw.ac.at/acdh/">
+              <img class="w-75"
+                   alt="ACDH website"
+                   src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg"/>
+            </a>
+          </div>
+          <div class="align-self-center w-50 p-1 text-center">
+            Austrian Centre for Digital Humanities (ACDH) of the Austrian Academy of Sciences
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Start imprint, project partners -->
+  <div id="wrapper-footer-secondary" class="footer-imprint-bar p-2 text-center">
+    <a href="/imprint.html">Imprint | Impressum</a>
+    {% if user.is_authenticated %}
+      {% if DB_NAME %}
+        <div class="footer-imprint-bar">
+          <div>{{ DB_NAME }}</div>
+        </div>
+      {% endif %}
+    {% endif %}
+  </div>
+  <!-- End imprint, project partners -->
+  <!-- End site footer -->
+</div>
+
+{% block scripts %}
+  <script src="{{ SHARED_URL }}fundament/dist/fundament/js/fundament.min.js"></script>
+  <script type="text/javascript"
+          src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/js/bootstrap-select.min.js"></script>
+  <script src="{{ SHARED_URL }}apis/libraries/scroll-to-top/js/ap-scroll-top.min.js"></script>
+{% endblock %}
+
+{% block scripts2 %}
+{% endblock scripts2 %}
+
+</body>
+</html>

--- a/apis_core/apis_metainfo/templates/browsing/create_base_template.html
+++ b/apis_core/apis_metainfo/templates/browsing/create_base_template.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block title %}{% endblock %}
 {% load crispy_forms_tags %}
 {% block content %}

--- a/apis_core/apis_metainfo/templates/browsing/generic_list.html
+++ b/apis_core/apis_metainfo/templates/browsing/generic_list.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% load django_tables2 %}
 {% load browsing_extras %}

--- a/apis_core/apis_metainfo/templates/confirm_delete.html
+++ b/apis_core/apis_metainfo/templates/confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block content %}
     <div class="modal-dialog">
         <div class="modal-content">

--- a/apis_core/apis_metainfo/views.py
+++ b/apis_core/apis_metainfo/views.py
@@ -40,5 +40,5 @@ class UriUpdate(LoginRequiredMixin, BaseUpdateView):
 
 class UriDelete(LoginRequiredMixin, DeleteView):
     model = Uri
-    template_name = "webpage/confirm_delete.html"
+    template_name = "confirm_delete.html"
     success_url = reverse_lazy("apis_core:apis_metainfo:uri_browse")

--- a/apis_core/apis_relations/templates/apis_relations/relations_detail_generic.html
+++ b/apis_core/apis_relations/templates/apis_relations/relations_detail_generic.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load static %}
 {% block title %} {{ object }} {% endblock %}
 {% block scriptHeader %}

--- a/apis_core/apis_vis/templates/apis_vis/avgage.html
+++ b/apis_core/apis_vis/templates/apis_vis/avgage.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load charts_extras %}
 {% block scriptHeader %}
 {{ block.super }}

--- a/apis_core/apis_vis/templates/apis_vis/avgmemperyear.html
+++ b/apis_core/apis_vis/templates/apis_vis/avgmemperyear.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load charts_extras %}
 {% block scriptHeader %}
 {{ block.super }}

--- a/apis_core/apis_vis/templates/apis_vis/heatmap.html
+++ b/apis_core/apis_vis/templates/apis_vis/heatmap.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block scriptHeader %}
 {{ block.super }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.heat/0.2.0/leaflet-heat.js"></script>

--- a/apis_core/apis_vis/templates/apis_vis/inst_range.html
+++ b/apis_core/apis_vis/templates/apis_vis/inst_range.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% load charts_extras %}
 {% block scriptHeader %}
 {{ block.super }}

--- a/apis_core/apis_vocabularies/api_renderers.py
+++ b/apis_core/apis_vocabularies/api_renderers.py
@@ -4,11 +4,7 @@ from rdflib.namespace import SKOS, RDF, DC, RDFS
 from rest_framework import renderers
 import skosify
 
-try:
-    from webpage.metadata import PROJECT_METADATA
-except ImportError:
-    from webpage.utils import PROJECT_METADATA
-
+PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD")
 
 base_uri_web = getattr(settings, "APIS_BASE_URI", "http://apis.info")
 if base_uri_web.endswith("/"):

--- a/apis_core/context_processors/custom_context_processors.py
+++ b/apis_core/context_processors/custom_context_processors.py
@@ -31,6 +31,7 @@ def list_apis_settings(request):
     res = {
         "additional_functions": getattr(settings, "APIS_COMPONENTS", []),
         "request": request,
+        "basetemplate": getattr(settings, "BASE_TEMPLATE", "base.html"),
     }
     if "apis_highlighter" in settings.INSTALLED_APPS:
         res["highlighter_active"] = True

--- a/apis_core/context_processors/webpage_content_processors.py
+++ b/apis_core/context_processors/webpage_content_processors.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+
+def shared_url(request):
+    shared_url = getattr(settings, "SHARED_URL", "/static/")
+    return {"SHARED_URL": shared_url}

--- a/apis_core/templates/apis_templates/registration/registration_closed.html
+++ b/apis_core/templates/apis_templates/registration/registration_closed.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block content %}
 <div id="modal-reg-closed" class="modal fade">
   <div class="modal-dialog">

--- a/apis_core/templates/apis_templates/registration/registration_form.html
+++ b/apis_core/templates/apis_templates/registration/registration_form.html
@@ -1,4 +1,4 @@
-{% extends "webpage/base.html" %}
+{% extends basetemplate %}
 {% block content %}
 <form method="post" action="">
     {% csrf_token %}

--- a/apis_core/urls.py
+++ b/apis_core/urls.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from django.contrib.auth.decorators import login_required
 from django.urls import path
 from django.views.static import serve
+from django.views.generic import TemplateView
 from rest_framework import routers
 
 from apis_core.api_routers import load_additional_serializers
@@ -122,6 +123,7 @@ def build_apis_mock_request(method, path, view, original_request, **kwargs):
 
 
 urlpatterns = [
+    path("", TemplateView.as_view(template_name="base.html"), name="apis_index"),
     path("admin/", admin.site.urls),
     # url(r'^swagger(?P<format>\.json|\.yaml)$', SchemaViewSwagger.without_ui(cache_timeout=-1), name='schema-json'),
     # url(r'^swagger/$', SchemaViewSwagger.with_ui('swagger', cache_timeout=-1), name='schema-swagger-ui'),


### PR DESCRIPTION
`webpage` is a frontend that is part of another repository. some of the
functionality (mostly the `base.html` template, but also some variables)
were used throughout the apis_core codebase. The `base.html` was
replaced by a thinned down `base.html` in the apis templates folder.
Another template that was used from `webpage` was the
`confirm_delete.html` template, merged with the same template in
`apis_entities` and moved to the main `templates` folder.
Some views relied on some webpage functionality, those code snippets
were replaced.
A `shared_url` context_processor was also copied from `webpage` and
enhanced.
Closes: #133
