### PR TITLE
fix(apis_entities): fix transferral of Uris in merge method

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -312,9 +312,7 @@ class TempEntityClass(AbstractEntity):
                         if s not in sl:
                             getattr(self, f.name).add(s)
             Label.objects.create(label=str(ent), label_type=lt, temp_entity=self)
-            for u in Uri.objects.filter(root_object=ent):
-                u.entity = self
-                u.save()
+            Uri.objects.filter(root_object=ent).update(root_object=self)
             for l in Label.objects.filter(temp_entity=ent):
                 l.temp_entity = self
                 l.save()


### PR DESCRIPTION
The existing for loop that should update the root_object of the Uris
sets the attribute `entity` which is not a field in the Uri model. It
simply gets lost when saving. The field is called `root_object`. We fix
this and replace the for loop with a filter update, which would have
shown the mistake in the first place.
