### PR TITLE
fix(utils): fix bug and add test case

### DIFF
--- a/apis_core/utils/caching.py
+++ b/apis_core/utils/caching.py
@@ -316,12 +316,13 @@ def get_all_contenttype_classes():
                 if not cls_n.startswith("__") and "__module__" in list(
                     dir(getattr(m, cls_n))
                 ):
+                    mod = getattr(m, cls_n)
                     if (
-                        getattr(m, cls_n).__module__ in apis_modules
-                        and getattr(m, cls_n) not in lst_cont
+                        mod.__module__ in apis_modules
+                        and mod not in lst_cont
                         and cls_n.lower() not in models_exclude
-                        and inspect.isclass(getattr(m, cls_n))
-                        and getattr(m, cls_n)._meta.abstract is False
+                        and inspect.isclass(mod)
+                        and (hasattr(mod, "_meta") and mod._meta.abstract is False)
                     ):
                         lst_cont.append(getattr(m, cls_n))
         lst_cont.append(ContentType)

--- a/apis_core/utils/test_caching.py
+++ b/apis_core/utils/test_caching.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+
+from apis_core.utils import caching
+
+all_class_modules_and_names = {
+    "apis_metainfo": [
+        "Collection",
+        "RootObject",
+        "Source",
+        "Text",
+        "Uri",
+        "UriCandidate",
+    ],
+    "apis_vocabularies": [
+        "CollectionType",
+        "LabelType",
+        "TextType",
+        "VocabNames",
+        "VocabsBaseClass",
+        "VocabsUri",
+    ],
+    "apis_entities": ["TempEntityClass"],
+    "apis_relations": ["TempTriple", "Property", "Triple"],
+    "contenttypes": ["ContentType"],
+}
+
+
+class CachingTest(TestCase):
+    def test_get_all_class_modules_and_names(self):
+        expected = []
+        for key in all_class_modules_and_names:
+            for name in all_class_modules_and_names[key]:
+                expected.append((key, name))
+        res = caching.get_all_class_modules_and_names()
+        self.assertEqual(res, expected)


### PR DESCRIPTION
The `get_all_contenttype_classes` method checked for abstact classes by
looking at the `_meta` attribute without checking if that `_meta`
attribute even existed. This commit adds an additional check and adds a
testcase.
