### PR TITLE
feat(apis_metainfo): cleanup menu block in base template

### DIFF
--- a/apis_core/apis_metainfo/templates/base.html
+++ b/apis_core/apis_metainfo/templates/base.html
@@ -86,25 +86,8 @@
             <div class="collapse navbar-collapse justify-content-end"
                  id="navbarNavDropdown">
               <ul id="main-menu" class="navbar-nav mr-auto">
-                <li class="nav-item dropdown">
-                  <a href="#"
-                     class="nav-link dropdown-toggle"
-                     data-toggle="dropdown"
-                     role="button"
-                     aria-haspopup="true"
-                     aria-expanded="false">About
-                    <span class="caret" />
-                  </a>
-                  <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
-                    {% block about-dropdown-menu-items %}
-                    {% endblock about-dropdown-menu-items %}
-
-                  </div>
-                </li>
-                <!-- Wrap dropdown menus in custom blocks to allow override in Ontology -->
-
-                {% block custom_dropdown_menus %}
+                {% block main-menu %}
                   <li class="nav-item dropdown">
                     <a href="#"
                        class="nav-link dropdown-toggle"
@@ -140,7 +123,10 @@
                       {% endfor %}
                     </div>
                   </li>
-                {% endblock %}
+                {% endblock main-menu %}
+
+                {% block main-menu-extra %}
+                {% endblock main-menu-extra %}
 
               </ul>
               <!-- Start user login submenu -->


### PR DESCRIPTION
The menu block contained a default `About` menu item, allowing the user
to add custom menu items. By default, that menu item is emtpy, so it
showed a dropdown menu without any menuitems.
This commit replaces this menu item with a `main-menu-extra` block. This
gives downstream projects more control over the menu, letting them add
not only menu items to an existing menu, but also additional menus.
The block around the existing dropdown menus was renamed: prior to this
it was called `custom_dropdown_menus` which is a bit misleading, given
it contains the default apis menu items. This block was renamed to
`main-menu` (like the id of the `ul` tag it is enclosed in).
