### PR TITLE
fix(apis_metainfo): add zero margin to the usermenu in the navbar

### DIFF
--- a/apis_core/apis_metainfo/templates/base.html
+++ b/apis_core/apis_metainfo/templates/base.html
@@ -96,7 +96,7 @@
           </ul>
 
           <!-- Start user login submenu -->
-          <ul class="navbar-nav justify-content-end">
+          <ul class="navbar-nav justify-content-end mr-0">
             {% if user.is_authenticated %}
               <li class="nav-item dropdown ml-auto">
                 <a href="" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"


### PR DESCRIPTION
This way it sticks to its right sibling, which is currently the end of
the parent element.