### PR TITLE
Feat: fixes #169 - edit and detail buttons in listviews

### DIFF
--- a/apis_core/apis_entities/tables.py
+++ b/apis_core/apis_entities/tables.py
@@ -26,7 +26,7 @@ class MergeColumn(tables.Column):
         return mark_safe(input_form.format(value, value))
 
 
-def get_entities_table(entity, edit_v, default_cols):
+def get_entities_table(entity, edit_v, default_cols, is_authenticated=False):
     if default_cols is None:
         default_cols = [
             "name",
@@ -34,6 +34,7 @@ def get_entities_table(entity, edit_v, default_cols):
 
     class GenericEntitiesTable(tables.Table):
         def render_name(self, record, value):
+         
             if value == "":
                 return "(No name provided)"
             else:
@@ -71,7 +72,7 @@ def get_entities_table(entity, edit_v, default_cols):
 
         class Meta:
             model = caching.get_ontology_class_of_name(entity)
-            fields = ["detail"]+[default_cols]
+            fields = ["detail", "edit"] + default_cols if is_authenticated else ["detail"] + default_cols
             attrs = {"class": "table table-hover table-striped table-condensed"}
             # quick ensurance if column is indeed a field of this entity
             for col in default_cols:
@@ -85,8 +86,15 @@ def get_entities_table(entity, edit_v, default_cols):
         def __init__(self, *args, **kwargs):
 
             self.base_columns["detail"] = tables.TemplateColumn(
-                template_name='apis_entities/tables_detail_button_tempalte.html'
+                template_name='apis_entities/tables_detail_button_template.html',
+                extra_context={'entity_class':entity}
             )
+
+            if is_authenticated:
+                self.base_columns["edit"] = tables.TemplateColumn(
+                    template_name='apis_entities/tables_edit_button_template.html',
+                    extra_context={'entity_class':entity}
+                )
 
             super().__init__(*args, **kwargs)
 

--- a/apis_core/apis_entities/tables.py
+++ b/apis_core/apis_entities/tables.py
@@ -71,7 +71,7 @@ def get_entities_table(entity, edit_v, default_cols):
 
         class Meta:
             model = caching.get_ontology_class_of_name(entity)
-            fields = default_cols
+            fields = ["detail"]+[default_cols]
             attrs = {"class": "table table-hover table-striped table-condensed"}
             # quick ensurance if column is indeed a field of this entity
             for col in default_cols:
@@ -83,6 +83,11 @@ def get_entities_table(entity, edit_v, default_cols):
                     )
 
         def __init__(self, *args, **kwargs):
+
+            self.base_columns["detail"] = tables.TemplateColumn(
+                template_name='apis_entities/tables_detail_button_tempalte.html'
+            )
+
             super().__init__(*args, **kwargs)
 
     return GenericEntitiesTable

--- a/apis_core/apis_entities/templates/apis_entities/tables_detail_button_template.html
+++ b/apis_core/apis_entities/templates/apis_entities/tables_detail_button_template.html
@@ -1,0 +1,2 @@
+<!-- <button class="btn btn-primary btn-sm" onclick="updateRelationDate(this, '{{record.pk}}')">DetailView</button> -->
+<a class="btn btn-primary btn-sm" href="{{% url 'apis:generic_entities_detail_view' pk='{{record.pk}}' %}}" >Edit Views</a>

--- a/apis_core/apis_entities/templates/apis_entities/tables_detail_button_template.html
+++ b/apis_core/apis_entities/templates/apis_entities/tables_detail_button_template.html
@@ -1,2 +1,3 @@
-<!-- <button class="btn btn-primary btn-sm" onclick="updateRelationDate(this, '{{record.pk}}')">DetailView</button> -->
-<a class="btn btn-primary btn-sm" href="{{% url 'apis:generic_entities_detail_view' pk='{{record.pk}}' %}}" >Edit Views</a>
+<a
+    href="{% url 'apis:apis_entities:generic_entities_detail_view' entity=entity_class pk=record.pk %}"><i
+        data-feather="eye" title="eye"></i></a>

--- a/apis_core/apis_entities/templates/apis_entities/tables_edit_button_template.html
+++ b/apis_core/apis_entities/templates/apis_entities/tables_edit_button_template.html
@@ -1,0 +1,1 @@
+<a class="btn btn-primary btn-sm" href="{{% url 'apis:generic_entities_edit_view' pk='{{record.pk}}' %}}" >Edit Views</a>

--- a/apis_core/apis_entities/templates/apis_entities/tables_edit_button_template.html
+++ b/apis_core/apis_entities/templates/apis_entities/tables_edit_button_template.html
@@ -1,1 +1,9 @@
-<a class="btn btn-primary btn-sm" href="{{% url 'apis:generic_entities_edit_view' pk='{{record.pk}}' %}}" >Edit Views</a>
+<a
+    href="{% url 'apis:apis_entities:generic_entities_edit_view' entity=entity_class pk=record.pk %}">
+    <svg width="24" height="24" viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor"
+        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+        class="feather feather-edit">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+    </svg></a>

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -114,7 +114,6 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         settings, "APIS_LIST_VIEW_TEMPLATE", "apis:apis_entities/generic_list.html"
     )
     login_url = "/accounts/login/"
-    print("class GenericListView New called")
     def __init__(self, *args, **kwargs):
         super(GenericListViewNew, self).__init__(*args, **kwargs)
         self.entity = None
@@ -171,6 +170,7 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         else:
             edit_v = False
 
+        user_is_authenticated = self.request.user.is_authenticated
         selected_cols = self.request.GET.getlist(
             "columns"
         )  # populates "Select additional columns" dropdown
@@ -181,7 +181,7 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         default_cols = default_cols + selected_cols
 
         self.table_class = get_entities_table(
-            class_name, edit_v, default_cols=default_cols
+            class_name, edit_v, default_cols=default_cols, is_authenticated=user_is_authenticated
         )
         table = super(GenericListViewNew, self).get_table()
         RequestConfig(

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -114,7 +114,7 @@ class GenericListViewNew(UserPassesTestMixin, ExportMixin, SingleTableView):
         settings, "APIS_LIST_VIEW_TEMPLATE", "apis:apis_entities/generic_list.html"
     )
     login_url = "/accounts/login/"
-
+    print("class GenericListView New called")
     def __init__(self, *args, **kwargs):
         super(GenericListViewNew, self).__init__(*args, **kwargs)
         self.entity = None

--- a/apis_core/apis_relations/rel_views.py
+++ b/apis_core/apis_relations/rel_views.py
@@ -18,6 +18,7 @@ class GenericRelationView(GenericListViewNew):
         settings, "APIS_LIST_VIEW_TEMPLATE", "apis_entities/generic_list.html"
     )
     login_url = "/accounts/login/"
+    print("reached class")
 
     def get_queryset(self, **kwargs):
         self.entity = self.kwargs.get("entity")
@@ -49,8 +50,12 @@ class GenericRelationView(GenericListViewNew):
         # self.table_class = get_generic_relation_listview_table(relation_name=relation_name)
         if self.entity == "property":
             self.table_class = PropertyTable
+            print("called Property table")
+
         else:
             self.table_class = TripleTable
+            print("called Triple table")
+
         table = super(GenericListViewNew, self).get_table()
         RequestConfig(
             self.request, paginate={"page": 1, "per_page": self.paginate_by}

--- a/apis_core/apis_relations/rel_views.py
+++ b/apis_core/apis_relations/rel_views.py
@@ -18,8 +18,6 @@ class GenericRelationView(GenericListViewNew):
         settings, "APIS_LIST_VIEW_TEMPLATE", "apis_entities/generic_list.html"
     )
     login_url = "/accounts/login/"
-    print("reached class")
-
     def get_queryset(self, **kwargs):
         self.entity = self.kwargs.get("entity")
         # qs = AbstractRelation.get_relation_class_of_name(self.entity).objects.all()
@@ -50,11 +48,9 @@ class GenericRelationView(GenericListViewNew):
         # self.table_class = get_generic_relation_listview_table(relation_name=relation_name)
         if self.entity == "property":
             self.table_class = PropertyTable
-            print("called Property table")
 
         else:
             self.table_class = TripleTable
-            print("called Triple table")
 
         table = super(GenericListViewNew, self).get_table()
         RequestConfig(


### PR DESCRIPTION
**Describe your changes**
Add template columns with redirect to edit and detail views in entity listviews. 
Edit-view-column only shown if user is authenticated.

-> But anyway, listviews are currently only visible if user is logged in.
- so might be improved in the future by checking against actual edit permission, instead of only authentication. But this was beyond the scope of this issue for now. 


**Additional context**
Implemented as discussed in todays JFX.

- all other link columns are unchanged; I did only add the two new columns and changed the column order so that detail and edit columns are shown to the left. 

Resolves issue:
- #169 

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [x] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
