### PR TITLE
feat(apis_entities): let users override the serializer

### DIFF
--- a/apis_core/utils/utils.py
+++ b/apis_core/utils/utils.py
@@ -61,3 +61,22 @@ def get_child_classes(objids, obclass, labels=False):
         return (objids, labels_lst)
     else:
         return objids
+
+
+def get_python_safe_module_path(instance: object):
+    """
+    return a python safe version of the full path of an object
+    this can for example be used as a method name
+    """
+    modulepath = get_module_path(instance)
+    return modulepath.replace(".", "_")
+
+
+def get_module_path(instance: object):
+    """
+    return the full path to the class of an object
+    """
+    instance_type = type(instance)
+    module = instance_type.__module__
+    name = instance_type.__name__
+    return f"{module}.{name}"


### PR DESCRIPTION
This commit lets the users define a function in an entity for providing
a custom serializer for a specific suffix. So for example, it is
possible to define a `serializer_tei` method in an entity which returns
a custom serializer which is then used if a a tei version of the api is
requested.
