### PR TITLE
feat(apis_metainfo): replace fundament with pure bootstrap

### DIFF
--- a/apis_core/apis_metainfo/templates/base.html
+++ b/apis_core/apis_metainfo/templates/base.html
@@ -16,14 +16,15 @@
   <link rel="icon" type="image/png" sizes="16x16" href="{{ SHARED_URL }}favicon/favicon-16x16.png"/>
   <link rel="manifest" href="{{ SHARED_URL }}favicon/manifest.json"/>
   <link rel="mask-icon" href="{{ SHARED_URL }}favicon/safari-pinned-tab.svg" color="#00aba9"/>
+  {% block styles %}
+  {% include "partials/bootstrap4_css.html" %}
+  {% endblock styles %}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/css/bootstrap-select.min.css"/>
   <meta name="theme-color" content="#ffffff"/>
   <!-- End favicons -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   {% include "apis_entities/apis_templatetag.html" %}
   <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,500" rel="stylesheet"/>
-  <link rel="stylesheet" id="fundament-styles" href="{{ SHARED_URL }}fundament/dist/fundament/css/fundament.min.css"
-        type="text/css"/>
   <link rel="stylesheet" href="{{ PROJECT_CSS }}?rnd=1" rel="stylesheet"/>
   <link rel="stylesheet" href="{{ SHARED_URL }}apis/libraries/scroll-to-top/css/ap-scroll-top.min.css"/>
 
@@ -42,7 +43,7 @@
 
         <!-- Start custom branding -->
         <a href="/" class="navbar-brand custom-logo-link" rel="home" itemprop="url">
-          <img src="{{ PROJECT_LOGO }}" class="img-fluid"/>
+          <img src="{{ PROJECT_LOGO }}" class="img-fluid" style="height: 36px;"/>
         </a>
         <!-- End custom branding -->
 
@@ -53,7 +54,7 @@
 
         <!-- Start main menu -->
         <div class="collapse navbar-collapse justify-content-end" id="navbarNavDropdown">
-          <ul id="main-menu" class="navbar-nav">
+          <ul id="main-menu" class="navbar-nav mr-auto">
             <li class="nav-item dropdown">
               <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
                  aria-expanded="false">About
@@ -96,7 +97,7 @@
           </ul>
 
           <!-- Start user login submenu -->
-          <ul class="navbar-nav justify-content-end mr-0">
+          <ul class="navbar-nav">
             {% if user.is_authenticated %}
               <li class="nav-item dropdown ml-auto">
                 <a href="" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
@@ -190,7 +191,8 @@
 </div>
 
 {% block scripts %}
-  <script src="{{ SHARED_URL }}fundament/dist/fundament/js/fundament.min.js"></script>
+  {% include "partials/feather_js.html" %}
+  {% include "partials/bootstrap4_js.html" %}
   <script type="text/javascript"
           src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/js/bootstrap-select.min.js"></script>
   <script src="{{ SHARED_URL }}apis/libraries/scroll-to-top/js/ap-scroll-top.min.js"></script>

--- a/apis_core/apis_metainfo/templates/partials/bootstrap4_css.html
+++ b/apis_core/apis_metainfo/templates/partials/bootstrap4_css.html
@@ -1,0 +1,2 @@
+{# the bootstrap 4.6.2 stylesheet, as suggested on https://getbootstrap.com/docs/4.6/getting-started/introduction/ #}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">

--- a/apis_core/apis_metainfo/templates/partials/bootstrap4_js.html
+++ b/apis_core/apis_metainfo/templates/partials/bootstrap4_js.html
@@ -1,0 +1,2 @@
+{# the bootstrap 4.6.2 javascript, as suggested on https://getbootstrap.com/docs/4.6/getting-started/introduction/ #}
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>

--- a/apis_core/apis_metainfo/templates/partials/feather_js.html
+++ b/apis_core/apis_metainfo/templates/partials/feather_js.html
@@ -1,0 +1,5 @@
+{# include feather icons as described on https://github.com/feathericons/feather#2-include #}
+<script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
+<script>
+  feather.replace()
+</script>


### PR DESCRIPTION
This commit replaces the used `fundament` stylesheet links and script
sources with pure bootstrap4 and feather. The bootstrap stylesheet link
was put in the `partials/bootstrap4_css.html` template partial, the
needed bootstrap4 javascript sources from bootstrap and feather are in
the `partials/bootstrap4_js.html` and `partials/feather_js.html`
templates.
The stylesheet `include` was put into a `styles` block.
To make the navbar reflect the navbar as it was with fundament, the
project-logo had to be hardcoded with a height of 36px. The mr-0 we
just introduced in https://github.com/acdh-oeaw/apis-core-rdf/commit/c35d13bcf026b9946c3ec0eb908b87880a246e02, to move the usermenu to the end of the
navbar, was replaced by setting the #main-menu to `mr-auto`.

Closes: https://github.com/acdh-oeaw/apis-core-rdf/issues/180