### PR TITLE
fix(apis_relations): show notes field and store notes

### DIFF
--- a/apis_core/apis_relations/forms2.py
+++ b/apis_core/apis_relations/forms2.py
@@ -44,6 +44,7 @@ class GenericTripleForm(forms.ModelForm):
             "prop",
             "start_date_written",
             "end_date_written",
+            "notes",
         ]
         widgets = {
             "subj": forms.HiddenInput(),
@@ -160,6 +161,7 @@ class GenericTripleForm(forms.ModelForm):
 
         self.fields["start_date_written"].initial = triple.start_date_written
         self.fields["end_date_written"].initial = triple.end_date_written
+        self.fields["notes"].initial = triple.notes
         self.instance = triple
 
     def load_remaining_data_from_input(
@@ -190,6 +192,7 @@ class GenericTripleForm(forms.ModelForm):
 
         self.instance.start_date_written = self.fields["start_date_written"].initial
         self.instance.end_date_written = self.fields["end_date_written"].initial
+        self.instance.notes = self.fields["notes"].initial
         self.instance.save()
 
         return self.instance

--- a/apis_core/apis_relations/tables.py
+++ b/apis_core/apis_relations/tables.py
@@ -469,6 +469,7 @@ def get_generic_triple_table(other_entity_class_name, entity_pk_self, detail):
                 "end_date_written",
                 "other_prop",
                 "other_entity",
+                "notes",
             ]
             # reuse the list for ordering
             sequence = tuple(fields)

--- a/apis_core/apis_relations/views.py
+++ b/apis_core/apis_relations/views.py
@@ -134,6 +134,7 @@ def save_ajax_form(
         start_date_written,
         end_date_written,
     )
+    form.fields["notes"].initial = request.POST["notes"]
     form.save()
 
     data = {


### PR DESCRIPTION
The TempTriple model has a notes field, that should be usabel to store
metadata. This commit adds it to the form and the form handling of the
GenericTripleForm.

Closes: #197
