### PR TITLE
fix(apis_entities,apis_relations): drop login_url override

### DIFF
--- a/apis_core/apis_entities/detail_generic.py
+++ b/apis_core/apis_entities/detail_generic.py
@@ -23,9 +23,6 @@ from apis_core.core.mixins import ViewPassesTestMixin
 
 
 class GenericEntitiesDetailView(ViewPassesTestMixin, EntityInstanceMixin, View):
-
-    login_url = "/accounts/login/"
-
     def get(self, request, *args, **kwargs):
 
         entity = self.entity.lower()

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -117,7 +117,6 @@ class GenericListViewNew(
     template_name = getattr(
         settings, "APIS_LIST_VIEW_TEMPLATE", "apis_entities/generic_list.html"
     )
-    login_url = "/accounts/login/"
 
     def __init__(self, *args, **kwargs):
         super(GenericListViewNew, self).__init__(*args, **kwargs)

--- a/apis_core/apis_relations/rel_views.py
+++ b/apis_core/apis_relations/rel_views.py
@@ -17,7 +17,6 @@ class GenericRelationView(GenericListViewNew):
     template_name = getattr(
         settings, "APIS_LIST_VIEW_TEMPLATE", "apis_entities/generic_list.html"
     )
-    login_url = "/accounts/login/"
 
     def get_queryset(self, **kwargs):
         self.entity = self.kwargs.get("entity")


### PR DESCRIPTION
The default login_url for the UserPassesTestMixin defaults to
settings.LOGIN_URL which defaults to "/accounts/login/" - therefore the
override does not make sense.
