### PR TITLE
fix(apis): show an empty page on `/` instead of an errorpage

### DIFF
--- a/apis/urls.py
+++ b/apis/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.urls import include, re_path
 from django.contrib import admin
 from django.urls import path
+from django.views.generic import TemplateView
 
 from apis_core.apis_entities.api_views import GetEntityGeneric
 
@@ -44,6 +45,7 @@ else:
     ]
     if "webpage" in settings.INSTALLED_APPS:
         urlpatterns.append(path("", include("webpage.urls", namespace="webpage")))
+    urlpatterns.append(path("", TemplateView.as_view(template_name="base.html")))
 
 
 if "viecpro_vis" in settings.INSTALLED_APPS:


### PR DESCRIPTION
most setups have `webpage` installed and therefore have a landing page,
but we should set a landing page nonetheless. it gets overriden if
`webpage` is installed the `webpage` urlpatterns are prepended.
