### PR TITLE
Change ContentType.objects.get to .get_for_model

### DIFF
--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -122,7 +122,7 @@ def subj_or_obj_class_changed(sender, is_subj, **kwargs):
             class_current = contenttype_current.model_class()
             for class_child in class_current.__subclasses__():
                 # TODO: Avoid ContentType DB fetch
-                contenttype_child = ContentType.objects.get(model=class_child.__name__)
+                contenttype_child = ContentType.objects.get_for_model(class_child)
                 child_list.append(contenttype_child)
                 child_list.extend(get_all_children(contenttype_child))
 
@@ -292,7 +292,7 @@ class Triple(models.Model):
         if self.subj is not None:
             subj_class_name = self.subj.__class__.__name__
             if (
-                ContentType.objects.get(model=subj_class_name)
+                ContentType.objects.get_for_model(self.subj.__class__)
                 not in self.prop.subj_class.all()
             ):
                 raise Exception(
@@ -301,7 +301,7 @@ class Triple(models.Model):
         if self.obj is not None:
             obj_class_name = self.obj.__class__.__name__
             if (
-                ContentType.objects.get(model=obj_class_name)
+                ContentType.objects.get_for_model(model=self.obj.__class__)
                 not in self.prop.obj_class.all()
             ):
                 raise Exception(
@@ -347,7 +347,6 @@ class TempTriple(Triple):
         """Adaption of the save() method of the class to automatically parse string-dates into date objects"""
 
         if parse_dates:
-
             # overwrite every field with None as default
             start_date = None
             start_start_date = None

--- a/apis_core/utils/caching.py
+++ b/apis_core/utils/caching.py
@@ -364,8 +364,8 @@ def get_contenttype_of_class(model_class):
     if _class_contenttype_dict is None:
         _class_contenttype_dict = {}
     if model_class not in _class_contenttype_dict:
-        _class_contenttype_dict[model_class] = ContentType.objects.get(
-            model=model_class.__name__
+        _class_contenttype_dict[model_class] = ContentType.objects.get_for_model(
+            model_class
         )
 
     return _class_contenttype_dict[model_class]


### PR DESCRIPTION
**Describe your changes**

- Changed `ContentType.objects.get(model=<MODEL NAME>)` to `ContentType.objects.get_for_model(<MODEL>)`

**Additional context**
Due to case sensitivity issues in Postgres, looking up ContentTypes with the string name causes problems. Previously using the workaround script (https://github.com/acdh-oeaw/apis-ontologies/blob/8a561a50fee5220e0e93255c40cb152695531864/jelinek/ontology_specific_scripts/postgres_specific.py), but this causes further errors.

Instead, change the ContentType lookups to use the actual model, rather than the string name. There still seems to be some use of `ContentType.objects.get()` elsewhere; will investigate.

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [X] My changes don't generate new warnings or errors
- [X] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
