### PR TITLE
filter allowed related types to only types where a relation-property actually exists

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -28,6 +28,7 @@ from .views import get_highlighted_texts
 from .views import set_session_variables
 from ..apis_vocabularies.models import TextType
 from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.apis_entities.mixins import EntityMixin, EntityInstanceMixin
 
 if "apis_highlighter" in settings.INSTALLED_APPS:
@@ -49,8 +50,7 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
             .select_subclasses()
         )
 
-        for entity_class in caching.get_all_entity_classes():
-
+        for entity_class in helpers.get_classes_with_allowed_relation_from(self.entity):
             entity_content_type = ContentType.objects.get_for_model(entity_class)
 
             other_entity_class_name = entity_class.__name__.lower()

--- a/apis_core/utils/helpers.py
+++ b/apis_core/utils/helpers.py
@@ -1,0 +1,39 @@
+import functools
+import itertools
+from typing import Type
+
+
+from apis_core.apis_entities.models import TempEntityClass
+from apis_core.apis_relations.models import Property
+
+
+@functools.lru_cache
+def get_classes_with_allowed_relation_from(
+    entity_name: str,
+) -> list[Type[TempEntityClass]]:
+    """Returns a list of classes to which the given class may be related by a Property"""
+
+    # Find all the properties where the entity is either subject or object
+    properties_with_entity_as_subject = Property.objects.filter(
+        subj_class__model=entity_name
+    ).prefetch_related("obj_class")
+    properties_with_entity_as_object = Property.objects.filter(
+        obj_class__model=entity_name
+    ).prefetch_related("subj_class")
+
+    content_type_querysets = []
+
+    # Where entity is subject, get all the object content_types
+    for p in properties_with_entity_as_subject:
+        objs = p.obj_class.all()
+        content_type_querysets.append(objs)
+    # Where entity is object, get all the subject content_types
+    for p in properties_with_entity_as_object:
+        subjs = p.subj_class.all()
+        content_type_querysets.append(subjs)
+
+    # Join querysets with itertools.chain, call set to make unique, and extract the model class
+    return [
+        content_type.model_class()
+        for content_type in set(itertools.chain(*content_type_querysets))
+    ]


### PR DESCRIPTION
feat: entity edit, filter related entity types to only those where a relation property exists

Currently, the relationed edit panel on the right shows all possible entities, even if no relations can actually be created between the two. This commit filters the entity types using the requested type, to limit the relatable entities to only those for which a relationship can actually be created.

This should clean up the interface quite a bit, especially where there are lots of entity types

**Describe your changes**
- In the Edit view, change the right panel ("Related To") to show only the Entity types to which a relationship can actually be created (i.e. where there is a Property connecting the two entity types), rather than all entities. Implements the function `get_classes_with_allowed_relation_from`, which takes an entity-type name from the request and uses it to look up allowed relations. This also caches the result.

**Additional context**
Already implemented once, before some code changes (see https://github.com/acdh-oeaw/apis-core-rdf/tree/rh/fix/filter-relation-entities-on-edit). Reimplimented for current dev branch.

**Related issues and PRs**
Link to issues your pull request resolves and other PRs it affects. E.g.

Resolves issue:
- #219

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [X] My changes don't generate new warnings or errors
- [X] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
