### PR TITLE
fix(apis_relations): fix accidental newline after `if` in template

### DIFF
--- a/apis_core/apis_relations/templates/apis_relations/delete_button_generic_ajax_form.html
+++ b/apis_core/apis_relations/templates/apis_relations/delete_button_generic_ajax_form.html
@@ -1,20 +1,18 @@
 {% load apis_helpers %}
-<a id="tempEntity_ 
-  {% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}
-   " class="reldelete" aria-label="Left Align" onclick=DeleteTempEntity(' 
-  {% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}
-   ',"relations/{{ record|content_type|lower }}")>
-  <svg xmlns="http://www.w3.org/2000/svg"
-       width="24"
-       height="24"
-       viewBox="0 0 24 24"
-       fill="none"
-       stroke="currentColor"
-       stroke-width="2"
-       stroke-linecap="round"
-       stroke-linejoin="round"
-       class="feather feather-trash">
-    <polyline points="3 6 5 6 21 6"></polyline>
-    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-  </svg>
+{# djlint:off #}
+<a id="tempEntity_{% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}" class="reldelete" aria-label="Left Align" onclick=DeleteTempEntity('{% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}',"relations/{{ record|content_type|lower }}")>
+{# djlint:on #}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="24"
+     height="24"
+     viewBox="0 0 24 24"
+     fill="none"
+     stroke="currentColor"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     class="feather feather-trash">
+  <polyline points="3 6 5 6 21 6"></polyline>
+  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+</svg>
 </a>

--- a/apis_core/apis_relations/templates/apis_relations/edit_button_generic_ajax_form.html
+++ b/apis_core/apis_relations/templates/apis_relations/edit_button_generic_ajax_form.html
@@ -1,17 +1,17 @@
 {% load apis_helpers %}
-<a class='reledit' onclick=GetFormAjax(null," 
-  {% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}
-   ")>
-  <svg xmlns="http://www.w3.org/2000/svg"
-       width="24"
-       height="24"
-       viewBox="0 0 24 24"
-       fill="none"
-       stroke="currentColor"
-       stroke-width="2"
-       stroke-linecap="round"
-       stroke-linejoin="round"
-       class="feather feather-edit-2">
-    <polygon points="16 3 21 8 8 21 3 21 3 16 16 3"></polygon>
-  </svg>
+{# djlint:off #}
+<a class='reledit' onclick=GetFormAjax(null,"{% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}")>
+{# djlint:on #}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="24"
+     height="24"
+     viewBox="0 0 24 24"
+     fill="none"
+     stroke="currentColor"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     class="feather feather-edit-2">
+  <polygon points="16 3 21 8 8 21 3 21 3 16 16 3"></polygon>
+</svg>
 </a>


### PR DESCRIPTION
In dba667f we reformatted all templates automatically using djlint.
dlint added newlines before and after `if` statements, which leads to
broken javascript, if the `if` statement is used to generate a function
argument. This commit turns djlint off for in two places where such
arguments are created using `if` statements (the edit and delete buttons
of the relations form).

Closes: #236
