### PR TITLE
feat(apis_metainfo): provide a login template

### DIFF
--- a/apis_core/apis_metainfo/templates/registration/login.html
+++ b/apis_core/apis_metainfo/templates/registration/login.html
@@ -1,0 +1,15 @@
+{% extends basetemplate %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+  <div class="container">
+    <div class="mt-4">
+      <form method="post" action="{% url 'login' %}">
+        {% csrf_token %}
+        {{ form|crispy }}
+        <input type="submit" value="login">
+        <input type="hidden" name="next" value="{{ next }}">
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
Django by default does not come with a login template. If we want to
make APIS work out of the box at some point, we have to ship a minimal
login template. This commit introduces this template.

Closes: #210
