### PR TITLE
feat(utils): replace `caching` module with `helpers`

### DIFF
--- a/apis_core/api_routers.py
+++ b/apis_core/api_routers.py
@@ -26,7 +26,7 @@ from django_filters import rest_framework as filters
 from apis_core.apis_entities.models import TempEntityClass
 from .api_renderers import NetJsonRenderer
 from .apis_relations.models import Triple, Property
-from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.core.mixins import ListViewObjectFilterMixin
 
 try:
@@ -196,7 +196,7 @@ class RelatedTripleSerializer(ApisBaseSerializer):
 
 
 def generic_serializer_creation_factory():
-    lst_cont = caching.get_all_contenttype_classes()
+    lst_cont = helpers.get_apis_model_classes() + helpers.get_entities_model_classes()
     not_allowed_filter_fields = [
         "useradded",
         "vocab_name",

--- a/apis_core/apis_entities/api_views.py
+++ b/apis_core/apis_entities/api_views.py
@@ -26,7 +26,7 @@ from .api_renderers import (
     EntityToCIDOCTURTLE,
 )
 from .serializers_generic import EntitySerializer
-from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.utils.utils import get_python_safe_module_path
 
 
@@ -373,7 +373,7 @@ class GetOrCreateEntity(APIView):
                 if len(r1_2) == 2:
                     q_d["first_name"] = r1_2[1].strip()
                     q_d["name"] = r1_2[0].strip()
-            ent = caching.get_ontology_class_of_name(entity).objects.create(**q_d)
+            ent = helpers.get_entity_class_by_name(entity).objects.create(**q_d)
         res = {
             "id": ent.pk,
             "url": reverse_lazy(

--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -17,8 +17,7 @@ from django.db.models import Q
 
 from apis_core.apis_metainfo.models import Uri, Collection
 from apis_core.apis_vocabularies.models import VocabsBaseClass
-from apis_core.utils import caching
-from apis_core.utils.caching import get_autocomplete_property_choices
+from apis_core.utils import helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 
 path_ac_settings = getattr(settings, "APIS_AUTOCOMPLETE_SETTINGS", False)
@@ -128,7 +127,7 @@ class GenericEntitiesAutocomplete(autocomplete.Select2ListView):
         ent_merge_pk = self.kwargs.get("ent_merge_pk", False)
         choices = []
         headers = {"Content-Type": "application/json"}
-        ent_model = caching.get_ontology_class_of_name(ac_type)
+        ent_model = helpers.get_entity_class_by_name(ac_type)
         ent_model_name = ent_model.__name__
 
         model_fields = ent_model._meta.get_fields()
@@ -482,7 +481,7 @@ class PropertyAutocomplete(autocomplete.Select2ListView):
 
     def get(self, request, *args, **kwargs):
         more = False
-        choices = get_autocomplete_property_choices(
+        choices = helpers.property_autocomplete_choices(
             kwargs["entity_self"], kwargs["entity_other"], self.q
         )
         return http.HttpResponse(

--- a/apis_core/apis_entities/detail_generic.py
+++ b/apis_core/apis_entities/detail_generic.py
@@ -17,7 +17,7 @@ from apis_core.apis_relations.tables import (
 )
 from apis_core.utils.utils import access_for_all
 from apis_core.apis_relations.models import TempTriple
-from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from apis_core.apis_entities.mixins import EntityInstanceMixin
 from apis_core.core.mixins import ViewPassesTestMixin
@@ -37,7 +37,7 @@ class GenericEntitiesDetailView(ViewPassesTestMixin, EntityInstanceMixin, View):
             .select_subclasses()
         )
 
-        for entity_class in caching.get_all_entity_classes():
+        for entity_class in helpers.get_entities_model_classes():
 
             entity_content_type = ContentType.objects.get_for_model(entity_class)
 

--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -25,7 +25,6 @@ from apis_core.apis_relations.tables import (
 from .forms import get_entities_form, GenericEntitiesStanbolForm
 from .views import set_session_variables
 from ..apis_vocabularies.models import TextType
-from apis_core.utils import caching
 from apis_core.utils import helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from apis_core.apis_entities.mixins import EntityMixin, EntityInstanceMixin

--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -9,7 +9,7 @@ from django.db.models import Q, JSONField
 
 from apis_core.apis_metainfo.models import Collection
 from apis_core.apis_entities.models import TempEntityClass
-from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from apis_core.utils.filtermethods import (
     related_entity_name,
@@ -249,7 +249,7 @@ def get_list_filter_of_entity(entity):
     :return: Entity specific FilterClass
     """
 
-    entity_class = caching.get_entity_class_of_name(entity)
+    entity_class = helpers.get_entity_class_by_name(entity)
     entity_list_filter_class = entity_class.get_entity_list_filter()
     if entity_list_filter_class is None:
 

--- a/apis_core/apis_entities/forms.py
+++ b/apis_core/apis_entities/forms.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 
 from apis_core.apis_metainfo.models import Uri, Collection
 from apis_core.apis_vocabularies.models import TextType
-from apis_core.utils import DateParser, caching, settings as apis_settings
+from apis_core.utils import DateParser, helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from .fields import ListSelect2, Select2Multiple
 
@@ -45,7 +45,7 @@ def get_entities_form(entity):
 
     class GenericEntitiesForm(forms.ModelForm):
         class Meta:
-            model = caching.get_entity_class_of_name(entity)
+            model = helpers.get_entity_class_by_name(entity)
 
             exclude = [
                 "start_date",

--- a/apis_core/apis_entities/management/commands/serialize_to_cidoc.py
+++ b/apis_core/apis_entities/management/commands/serialize_to_cidoc.py
@@ -14,7 +14,7 @@ from apis_core.apis_entities.api_renderers import EntityToCIDOC
 from apis_core.apis_entities.serializers_generic import EntitySerializer
 from apis_core.apis_vocabularies.api_renderers import VocabToSkos
 from apis_core.apis_vocabularies.serializers import GenericVocabsSerializer
-from apis_core.utils import caching
+from apis_core.utils import helpers
 
 map_ct = {
     "trig": ("application/x-trig", "trig"),
@@ -157,7 +157,7 @@ class Command(BaseCommand):
                 named_graph_vocabs = "/".join(named_graph.split("/")[:-1]) + "/vocabs#"
             else:
                 named_graph_vocabs = named_graph + "/vocabs#"
-        ent = caching.get_ontology_class_of_name(options["entity"])
+        ent = helpers.get_entity_class_by_name(options["entity"])
         res = []
         objcts = ent.objects.filter(**json.loads(options["filter"]))
         if objcts.filter(uri__uri__icontains=" ").count() > 0:

--- a/apis_core/apis_entities/management/commands/serialize_to_json.py
+++ b/apis_core/apis_entities/management/commands/serialize_to_json.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand
 from django.core.serializers.json import DjangoJSONEncoder
 
 from apis_core.apis_entities.serializers_generic import EntitySerializer
-from apis_core.utils import caching
+from apis_core.utils import helpers
 
 
 class Command(BaseCommand):
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        ent = caching.get_ontology_class_of_name(options["entity"])
+        ent = helpers.get_entity_class_by_name(options["entity"])
         res = []
         objcts = ent.objects.filter(**json.loads(options["filter"]))
         if objcts.filter(uri__uri__icontains=" ").count() > 0:

--- a/apis_core/apis_entities/mixins.py
+++ b/apis_core/apis_entities/mixins.py
@@ -2,7 +2,7 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 from django.shortcuts import get_object_or_404
 
-from apis_core.utils import caching
+from apis_core.utils import helpers
 
 
 class EntityMixin:
@@ -10,7 +10,7 @@ class EntityMixin:
         super().setup(request, *args, **kwargs)
         if "entity" in kwargs:
             self.entity = kwargs.get("entity")
-            self.entity_model = caching.get_entity_class_of_name(self.entity)
+            self.entity_model = helpers.get_entity_class_by_name(self.entity)
         else:
             raise Http404(_("No `entity` found in the path"))
 

--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from model_utils.managers import InheritanceManager
 from django.db.models.query import QuerySet
 
-from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.utils import DateParser
 from apis_core.apis_metainfo.models import RootObject, Collection
 from apis_core.apis_relations.models import TempTriple
@@ -377,7 +377,7 @@ def create_default_uri(sender, instance, raw, **kwargs):
     if not raw:
         from apis_core.apis_metainfo.models import Uri
 
-        if kwargs["created"] and sender in caching.get_all_ontology_classes():
+        if kwargs["created"] and sender in helpers.get_entities_model_classes():
             if BASE_URI.endswith("/"):
                 base1 = BASE_URI[:-1]
             else:

--- a/apis_core/apis_entities/tables.py
+++ b/apis_core/apis_entities/tables.py
@@ -9,7 +9,7 @@ from apis_core.apis_metainfo.tables import (
     generic_render_start_date_written,
     generic_render_end_date_written,
 )
-from apis_core.utils import caching
+from apis_core.utils import helpers
 
 
 def get_entities_table(entity, default_cols):
@@ -54,7 +54,7 @@ def get_entities_table(entity, default_cols):
             id = tables.LinkColumn()
 
         class Meta:
-            model = caching.get_ontology_class_of_name(entity)
+            model = helpers.get_entity_class_by_name(entity)
             fields = default_cols
             attrs = {"class": "table table-hover table-striped table-condensed"}
             # quick ensurance if column is indeed a field of this entity

--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -23,7 +23,7 @@ from django.core.exceptions import ValidationError, ImproperlyConfigured
 
 # from django.contrib.contenttypes.fields import GenericRelation
 # from utils.highlighter import highlight_text
-from apis_core.utils import caching, rdf
+from apis_core.utils import helpers, rdf
 
 from apis_core.apis_metainfo import signals
 
@@ -65,7 +65,7 @@ class RootObject(models.Model):
 
     def save(self, *args, **kwargs):
         if self.self_contenttype is None:
-            self.self_contenttype = caching.get_contenttype_of_class(self.__class__)
+            self.self_contenttype = ContentType.objects.get_for_model(self)
         super().save(*args, **kwargs)
 
     def __str__(self):
@@ -91,7 +91,7 @@ class RootObject(models.Model):
         for field in related_fields:
             objdict.pop(field.name, None)
 
-        entity_model = caching.get_entity_class_of_name(self._meta.model_name)
+        entity_model = helpers.get_entity_class_by_name(self._meta.model_name)
         newobj = entity_model.objects.create(**objdict)
 
         for field in related_fields:

--- a/apis_core/apis_relations/views.py
+++ b/apis_core/apis_relations/views.py
@@ -11,7 +11,7 @@ from apis_core.apis_entities.autocomplete3 import PropertyAutocomplete
 
 from apis_core.apis_relations.models import Property, TempTriple
 
-from apis_core.utils import caching
+from apis_core.utils import helpers
 
 
 # TODO RDF: After full conversion to ne ajax logic, remove this function
@@ -102,8 +102,8 @@ def save_ajax_form(
     self_other = kind_form.split("triple_form_")[1].split("_to_")
     entity_type_self_str = self_other[0]
     entity_type_other_str = self_other[1]
-    entity_type_self_class = caching.get_entity_class_of_name(entity_type_self_str)
-    entity_type_other_class = caching.get_entity_class_of_name(entity_type_other_str)
+    entity_type_self_class = helpers.get_entity_class_by_name(entity_type_self_str)
+    entity_type_other_class = helpers.get_entity_class_by_name(entity_type_other_str)
     entity_instance_self = entity_type_self_class.objects.get(pk=SiteID)
     entity_instance_other = entity_type_other_class.get_or_create_uri(
         uri=request.POST["other_entity"]

--- a/apis_core/urls.py
+++ b/apis_core/urls.py
@@ -14,26 +14,27 @@ from apis_core.api_routers import views
 #     PlaceGeoJsonViewSet,
 # )
 # from apis_core.apis_vocabularies.api_views import UserViewSet
-from apis_core.utils import caching
+from apis_core.utils import helpers
 from apis_core.apis_metainfo.viewsets import UriToObjectViewSet
 from apis_core.core.views import Dumpdata
 
 app_name = "apis_core"
 
 router = routers.DefaultRouter()
-for app_label, model_str in caching.get_all_class_modules_and_names():
+for model in helpers.get_apis_model_classes() + helpers.get_entities_model_classes():
+    app_label, modelname = model._meta.label_lower.split(".")
     if "_" in app_label:
         route_prefix = app_label.split("_")[1]
     else:
         route_prefix = app_label
     try:
         router.register(
-            r"{}/{}".format(route_prefix, model_str.lower()),
-            views[model_str.lower()],
-            model_str.lower(),
+            r"{}/{}".format(route_prefix, modelname),
+            views[modelname],
+            modelname,
         )
-    except Exception as e:
-        print("{} not found, skipping".format(model_str.lower()))
+    except Exception:
+        print("{} not found, skipping".format(modelname))
 
 # inject the manually created UriToObjectViewSet into the api router
 router.register(r"metainfo/uritoobject", UriToObjectViewSet, basename="uritoobject")

--- a/apis_core/utils/helpers.py
+++ b/apis_core/utils/helpers.py
@@ -3,23 +3,27 @@ import importlib
 import inspect
 import itertools
 import logging
-from typing import Type
 
-
-from apis_core.apis_entities.models import TempEntityClass
-from apis_core.apis_relations.models import Property
-
+from django.http import Http404
 from django.apps import apps
 from django.db import DEFAULT_DB_ALIAS, router
 from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 
+#########################################################
+# Some of these methods are used on startup of the Django
+# application, because they are referenced in models.
+# Therefore we have to put the imports of models into the
+# method bodies, so we don't get circular imports.
+# In the long run we might look into removing the need for
+# importing those functions in the model classes
+###########################################################
+
 
 @functools.lru_cache
-def get_classes_with_allowed_relation_from(
-    entity_name: str,
-) -> list[Type[TempEntityClass]]:
+def get_classes_with_allowed_relation_from(entity_name: str) -> list:
     """Returns a list of classes to which the given class may be related by a Property"""
+    from apis_core.apis_relations.models import Property
 
     # Find all the properties where the entity is either subject or object
     properties_with_entity_as_subject = Property.objects.filter(
@@ -45,6 +49,110 @@ def get_classes_with_allowed_relation_from(
         content_type.model_class()
         for content_type in set(itertools.chain(*content_type_querysets))
     ]
+
+
+APIS_APP_LABELS = [
+    "apis_metainfo",
+    "apis_relations",
+    "apis_vocabularies",
+    "apis_entities",
+]
+
+
+@functools.cache
+def get_apis_model_classes():
+    """
+    Get all model classes that are part of the apis core modules. We do this
+    by getting all the models from all the apps and comparing their app_labels
+    """
+    model_classes = filter(
+        lambda model: model._meta.label_lower.split(".")[0] in APIS_APP_LABELS,
+        apps.get_models(),
+    )
+    return list(model_classes)
+
+
+@functools.cache
+def get_entities_model_classes():
+    """
+    Get all model classes that are part of ontologies modules. We do this
+    by getting all the models from all the apps and checking which of them
+    inherit from `AbstractEntity`. Then we also remove `TempEntityClass`.
+    """
+    from apis_core.apis_entities.models import AbstractEntity, TempEntityClass
+
+    model_classes = list(
+        filter(lambda model: issubclass(model, AbstractEntity), apps.get_models())
+    )
+    model_classes.remove(TempEntityClass)
+    return model_classes
+
+
+@functools.cache
+def get_entity_class_by_name(name: str):
+    """
+    This is sometimes needed in the code to get a class by a human readable
+    identifier (`person`, `place`, ...). In various cases is would be probably
+    better to use the ContentTypes framework instead
+    """
+    for entity in get_entities_model_classes():
+        _, model_name = entity._meta.label_lower.split(".")
+        if model_name == name.lower():
+            return entity
+    raise Http404(f"Entity {entity} not found.")
+
+
+@functools.cache
+def property_autocomplete_choices(entity_name_from, entity_name_to, needle):
+    from apis_core.apis_entities.autocomplete3 import PropertyAutocomplete
+    from apis_core.apis_relations.models import Property
+
+    model_from = ContentType.objects.get_for_model(
+        get_entity_class_by_name(entity_name_from)
+    )
+    model_to = ContentType.objects.get_for_model(
+        get_entity_class_by_name(entity_name_to)
+    )
+
+    rbc_self_subj_other_obj = Property.objects.filter(
+        subj_class=model_from,
+        obj_class=model_to,
+        name__icontains=needle,
+    )
+    rbc_self_obj_other_subj = Property.objects.filter(
+        subj_class=model_to,
+        obj_class=model_from,
+        name_reverse__icontains=needle,
+    )
+    choices = []
+    # The Select2ListView class when finding results for some user input, returns these
+    # results in this 'choices' list. This is a list of dictionaries, where each dictionary
+    # has an id and a text. In our case however the results can come from two different sets:
+    # the one where result hits match on the forward name of a property and the other set
+    # where the result hits match on the reverse name. These hits need to re-used later,
+    # but additionally the direction of the property is also needed later to persist it
+    # correctly (e.g. when creating a triple between two persons, where one is the mother and
+    # the other is the daughter, then the property direction is needed). I could not find a
+    # way to return in this function a choices list with dictionaries or something else,
+    # that would pass additional data. So I am misusing the 'id' item in the dictionary by
+    # encoding the id and the direction into a string which will be parsed and split later on.
+    for rbc in rbc_self_subj_other_obj:
+        choices.append(
+            {
+                # misuse of the id item as explained above
+                "id": f"id:{rbc.pk}__direction:{PropertyAutocomplete.SELF_SUBJ_OTHER_OBJ_STR}",
+                "text": rbc.name,
+            }
+        )
+    for rbc in rbc_self_obj_other_subj:
+        choices.append(
+            {
+                # misuse of the id item as explained above
+                "id": f"id:{rbc.pk}__direction:{PropertyAutocomplete.SELF_OBJ_OTHER_SUBJ_STR}",
+                "text": rbc.name_reverse,
+            }
+        )
+    return choices
 
 
 def get_member_for_entity(


### PR DESCRIPTION
The `caching` module is mostly implemented using code obfuscation and it
reimplements functionalitis from core Python and from Django.
This commit introduces a couple of `utils.helpers` functions that use
the Pyton `functools.cache` to provide the same functionality.

For now we are not deleting the `caching` module completely, because
there are still projects using it.