### PR TITLE
chore(docs): make documentation build workflow more robust

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,8 @@ name: "Build documentation"
 on:
   push:
     branches: main
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 permissions:
@@ -51,6 +53,8 @@ jobs:
          touch .nojekyll
          git config user.name github-actions
          git config user.email github-actions@github.com
-         git add .
-         git commit -m "Updated documentation"
-         git push --set-upstream origin pages
+         if ! git diff --exit-code .; then
+           git add .
+           git commit -m "Updated documentation"
+           git push --set-upstream origin pages
+         fi


### PR DESCRIPTION
The workflow should ignore changes to the .github repository and only
try to push changes if there are some.
