### PR TITLE
fix: use the filter method of the superclass, if it exists

### DIFF
--- a/apis_core/core/mixins.py
+++ b/apis_core/core/mixins.py
@@ -40,6 +40,8 @@ class ListViewObjectFilterMixin:
     """
 
     def filter_queryset(self, queryset):
+        if hasattr(super(), "filter_queryset"):
+            queryset = super().filter_queryset(queryset)
         if hasattr(settings, "APIS_LIST_VIEW_OBJECT_FILTER"):
             return settings.APIS_LIST_VIEW_OBJECT_FILTER(self, queryset)
         return queryset


### PR DESCRIPTION
Python does not pass the object from one parent classes' method to the
next, we have to call super() ourselves, if the method exists.

Closes: #263
