### PR TITLE
fix: show reference button in detail view

### DIFF
--- a/apis_core/apis_relations/tables.py
+++ b/apis_core/apis_relations/tables.py
@@ -530,6 +530,12 @@ def get_generic_triple_table(other_entity_class_name, entity_pk_self, detail):
                     args=[other_entity_class_name, A("other_entity")],
                 )
 
+                # bibsonomy button
+                if "apis_bibsonomy" in settings.INSTALLED_APPS:
+                    self.base_columns["ref"] = tables.TemplateColumn(
+                        template_name="apis_relations/references_button_generic_ajax_form.html"
+                    )
+
                 super().__init__(data=data, *args, **kwargs)
 
         return TripleTableDetail


### PR DESCRIPTION
There are projects that use references on relations. Therefore the
references button should also be listed in the reference table - this is
already the case in the edit view, but not yet in the detail view. This
commit hardcodes this button in the detail view. This is a hack, but
given that the whole Reference logic is rewritten, it does not make much
sense to refactor the whole codebase to make this table more
customizable.
