### PR TITLE
fix(deps): loosen Python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ include = [{path = "LICENSE.txt", format = "sdist"}, {path = "README.rst", forma
 exclude = ["manage.py", "__pycache__"]
 
 [tool.poetry.dependencies]
-python = ">=3.11, <3.12"
+python = "^3.11"
 Django = "^4.1"
 djangorestframework = "^3.14.0"
 django-filter = "^2.4.0"


### PR DESCRIPTION
Support everything greater than or equal to 3.11.
This makes the project more compatible with other Python projects.

Closes: #255
