### PR TITLE
Consider only the first primary URI of entities

### DIFF
--- a/apis_core/apis_relations/forms2.py
+++ b/apis_core/apis_relations/forms2.py
@@ -145,7 +145,14 @@ class GenericTripleForm(forms.ModelForm):
         self.fields["property"].choices = [property_initial_value]
 
         other_entity_initial_value = (
-            str(Uri.objects.get(root_object=entity_instance_other)),
+            str(
+                Uri.objects.filter(
+                    root_object=entity_instance_other,
+                    uri__startswith=getattr(
+                        settings, "APIS_BASE_URI", "http://apis.info/"
+                    ),
+                ).first()
+            ),
             f"<span ><small>db</small> {str(entity_instance_other)}</span>",
         )
         self.fields["other_entity"].initial = other_entity_initial_value


### PR DESCRIPTION
where an entity might have more than one URI

primary URI is one that is in the same domain as
defined in APIS_BASE_URI in settings

the default value for APIS_BASE_URI is hardcoded to be consistent with the same value used in apis_entities at the time of the creation of the URI object

Resolves issue:
- #221 


**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x ] My changes don't generate new warnings or errors
- [x ] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
