### PR TITLE
fix: use empty dict as fallback for PROJECT_DEFAULT_MD

### DIFF
--- a/apis_core/apis_entities/api_mappings/cidoc_mapping.py
+++ b/apis_core/apis_entities/api_mappings/cidoc_mapping.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from rdflib import RDF, RDFS, XSD, BNode, Literal, URIRef, OWL
 
-PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD")
+PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD", {})
 
 base_uri = getattr(settings, "APIS_BASE_URI", "http://apis.info")
 if base_uri.endswith("/"):

--- a/apis_core/apis_vocabularies/api_renderers.py
+++ b/apis_core/apis_vocabularies/api_renderers.py
@@ -4,7 +4,7 @@ from rdflib.namespace import SKOS, RDF, DC, RDFS
 from rest_framework import renderers
 import skosify
 
-PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD")
+PROJECT_METADATA = getattr(settings, "PROJECT_DEFAULT_MD", {})
 
 base_uri_web = getattr(settings, "APIS_BASE_URI", "http://apis.info")
 if base_uri_web.endswith("/"):


### PR DESCRIPTION
This way the application doesn't crash and burn when PROJECT_DEFAULT_MD
is not set.
