### PR TITLE
fix(api_routers): allow to let the `id` field be writeable in API

### DIFF
--- a/apis_core/api_routers.py
+++ b/apis_core/api_routers.py
@@ -10,6 +10,7 @@ from apis_core.apis_metainfo.models import *
 
 # from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from django.conf import settings
 from rest_framework import pagination, serializers, viewsets
 from rest_framework import renderers
 from rest_framework.response import Response
@@ -255,6 +256,8 @@ def generic_serializer_creation_factory():
         class TemplateSerializer(serializers.HyperlinkedModelSerializer):
 
             id = serializers.ReadOnlyField()
+            if getattr(settings, "APIS_API_ID_WRITABLE", False):
+                id = serializers.IntegerField()
             url = serializers.HyperlinkedIdentityField(
                 view_name=f"apis:apis_api:{entity_str.lower()}-detail"
             )

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -230,6 +230,20 @@ APIS_API_EXCLUDE_SETS
 Boolean setting for excluding related objects from the API. Normally its not needed to touch this.
 
 
+
+APIS_API_ID_WRITABLE
+---------------------
+
+.. code-block:: python
+
+    APIS_API_ID_WRITABLE = False
+
+
+Boolean setting for defining if the `id` field of an entity is writable via the
+API. Defaults to false. You can set it to `True` if you want to import entities
+from another instance and want to keep the `id`.
+
+
 APIS_LIST_VIEWS_ALLOWED
 -----------------------
 


### PR DESCRIPTION
The API does not allow the entity id to be writeable by default. This
commit introduces a setting that lets the user override this behaviour.

Closes: #296
