### PR TITLE
fix(apis_entities): only set field attributes for existing fields

### DIFF
--- a/apis_core/apis_entities/forms.py
+++ b/apis_core/apis_entities/forms.py
@@ -178,10 +178,19 @@ def get_entities_form(entity):
                     crispy_main_fields, crispy_meta_fields
                 )
             )
-            self.fields["status"].required = False
-            self.fields["collection"].required = False
-            self.fields["start_date_written"].required = False
-            self.fields["end_date_written"].required = False
+            # backwards compatibility:
+            # those fields are part of TempEntityClass - this
+            # block can probably be removed when TempEntityClass
+            # is gone from apis_entities
+            # for now we at least check if they exist
+            if "status" in self.fields:
+                self.fields["status"].required = False
+            if "collection" in self.fields:
+                self.fields["collection"].required = False
+            if "start_date_written" in self.fields:
+                self.fields["start_date_written"].required = False
+            if "end_date_written" in self.fields:
+                self.fields["end_date_written"].required = False
 
             instance = getattr(self, "instance", None)
             if instance != None:


### PR DESCRIPTION
There is some legacy code that expects specific model fields (the ones
that were part of TempEntityClass). This commit checks if those even
exist, before setting their attributes.

Closes: #298