### PR TITLE
feat: introduce new templatetags

### DIFF
--- a/apis_core/apis_entities/templatetags/apis_templatetags.py
+++ b/apis_core/apis_entities/templatetags/apis_templatetags.py
@@ -1,4 +1,6 @@
+from operator import itemgetter
 from django import template
+from apis_core.utils import caching
 
 register = template.Library()
 
@@ -15,3 +17,18 @@ def url_replace(request, field, value):
     dict_[field] = value
 
     return dict_.urlencode()
+
+
+@register.simple_tag
+def entities_list_links():
+    """
+    Retrieve all models which inherit from AbstractEntity class
+    and return their class name and verbose name.
+    """
+    entities_classes = caching.get_all_entity_classes() or []
+    entities_links = [
+        (e.__name__.lower(), e._meta.verbose_name.title()) for e in entities_classes
+    ]
+    entities_links.sort(key=itemgetter(1))
+
+    return entities_links

--- a/apis_core/apis_metainfo/templates/base.html
+++ b/apis_core/apis_metainfo/templates/base.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 {% load static %}
 {% load apis_metainfo_extras %}
+{% load apiscore %}
+{% load apis_templatetags %}
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -19,18 +21,18 @@
     <!-- Start favicons -->
     <link rel="apple-touch-icon"
           sizes="180x180"
-          href="{{ SHARED_URL }}favicon/apple-touch-icon.png" />
+          href="{% shared_url %}favicon/apple-touch-icon.png" />
     <link rel="icon"
           type="image/png"
           sizes="32x32"
-          href="{{ SHARED_URL }}favicon/favicon-32x32.png" />
+          href="{% shared_url %}favicon/favicon-32x32.png" />
     <link rel="icon"
           type="image/png"
           sizes="16x16"
-          href="{{ SHARED_URL }}favicon/favicon-16x16.png" />
-    <link rel="manifest" href="{{ SHARED_URL }}favicon/manifest.json" />
+          href="{% shared_url %}favicon/favicon-16x16.png" />
+    <link rel="manifest" href="{% shared_url %}favicon/manifest.json" />
     <link rel="mask-icon"
-          href="{{ SHARED_URL }}favicon/safari-pinned-tab.svg"
+          href="{% shared_url %}favicon/safari-pinned-tab.svg"
           color="#00aba9" />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
           rel="stylesheet" />
@@ -49,7 +51,7 @@
           rel="stylesheet" />
     <link rel="stylesheet" href="{{ PROJECT_CSS }}?rnd=1" rel="stylesheet" />
     <link rel="stylesheet"
-          href="{{ SHARED_URL }}apis/libraries/scroll-to-top/css/ap-scroll-top.min.css" />
+          href="{% shared_url %}apis/libraries/scroll-to-top/css/ap-scroll-top.min.css" />
 
     {% block scriptHeader %}{% endblock %}
 
@@ -103,12 +105,11 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
                       {% block entities-menu-items %}
+                        {% entities_list_links as entities_links %}
                         {% for ent in entities_links %}
                           <a class="dropdown-item"
                              href="{% url 'apis:apis_entities:generic_entities_list' ent.0 %}">{{ ent.1 }}</a>
                         {% endfor %}
-                        <a class="dropdown-item"
-                           href="{% url 'apis:apis_metainfo:uri_browse' %}">URIs</a>
                       {% endblock entities-menu-items %}
 
                     </div>
@@ -238,7 +239,7 @@
       {% include "partials/bootstrap4_js.html" %}
       <script type="text/javascript"
               src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/js/bootstrap-select.min.js"></script>
-      <script src="{{ SHARED_URL }}apis/libraries/scroll-to-top/js/ap-scroll-top.min.js"></script>
+      <script src="{% shared_url %}apis/libraries/scroll-to-top/js/ap-scroll-top.min.js"></script>
     {% endblock %}
 
     {% block scripts2 %}

--- a/apis_core/core/templatetags/apiscore.py
+++ b/apis_core/core/templatetags/apiscore.py
@@ -1,0 +1,10 @@
+from django import template
+from django.conf import settings
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def shared_url():
+    return getattr(settings, "SHARED_URL", "/static")


### PR DESCRIPTION
This commit introduces a core templatetag `shared_url` to access the
`SHARED_URL` setting (the templatetag defaults to `/static/`). It also
updates the base template to use this templatetag.

The commit also introduces an apis_entities templatetag
`entities_list_links` that returns a list of links to the list views of
all entities. It also updates the base template to use this templatetag.

Closes: #293
