### PR TITLE
refactor: use `utils.settings.get_entity_settings_by_modelname`

### DIFF
--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 from apis_core.apis_metainfo.models import Collection
 from apis_core.apis_entities.models import TempEntityClass
 from apis_core.utils import caching
+from apis_core.utils.settings import get_entity_settings_by_modelname
 
 # The following classes define the filter sets respective to their models.
 # Also by what was enabled in the global settings file (or disabled by not explicitley enabling it).
@@ -103,11 +104,9 @@ class GenericEntityListFilter(django_filters.FilterSet):
             "status",
             "references",
         ]
-        list_filters = []
-        if settings.APIS_ENTITIES:
-            entity_settings = settings.APIS_ENTITIES.get(self.entity_class.__name__, {})
-            list_filters = entity_settings.get("list_filters", {})
-            list_filters_exclude.extend(entity_settings.get("list_filters_exclude", []))
+        entity_settings = get_entity_settings_by_modelname(self.entity_class.__name__)
+        list_filters = entity_settings.get("list_filters", {})
+        list_filters_exclude.extend(entity_settings.get("list_filters_exclude", []))
 
         # The `list_filters` setting of an entity defines both the order of filters and it allows to define additional filters
         # A filter is defined by a name and a dict describing its attributes

--- a/apis_core/apis_entities/forms.py
+++ b/apis_core/apis_entities/forms.py
@@ -15,6 +15,7 @@ from django.urls import reverse
 from apis_core.apis_metainfo.models import Uri, Collection
 from apis_core.apis_vocabularies.models import TextType
 from apis_core.utils import DateParser, caching, settings as apis_settings
+from apis_core.utils.settings import get_entity_settings_by_modelname
 from .fields import ListSelect2, Select2Multiple
 
 if "apis_highlighter" in settings.INSTALLED_APPS:
@@ -159,17 +160,12 @@ def get_entities_form(entity):
                 :param entity_name: string representation of an entity name
                 :return: a list of strings
                 """
-                entity_settings = getattr(settings, "APIS_ENTITIES", None)
+                entity_settings = get_entity_settings_by_modelname(entity_name)
+                form_order = entity_settings.get("form_order", [])
 
-                if entity_settings is not None:
-                    try:
-                        form_order = entity_settings[entity_name].get("form_order", [])
-                    except KeyError as e:
-                        form_order = []
-
-                    if len(form_order) > 0:
-                        remaining = set(field_names) - set(form_order)
-                        field_names = form_order + list(remaining)
+                if len(form_order) > 0:
+                    remaining = set(field_names) - set(form_order)
+                    field_names = form_order + list(remaining)
 
                 return field_names
 

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -22,6 +22,7 @@ from apis_core.utils.utils import (
     access_for_all_function,
     ENTITIES_DEFAULT_COLS,
 )
+from apis_core.utils.settings import get_entity_settings_by_modelname
 from .filters import get_list_filter_of_entity
 from .forms import (
     GenericFilterFormHelper,
@@ -136,9 +137,8 @@ class GenericListViewNew(
             "columns"
         )  # populates "Select additional columns" dropdown
         default_cols = []  # get set to "name" in get_entities_table when empty
-        if hasattr(settings, "APIS_ENTITIES"):
-            class_settings = settings.APIS_ENTITIES.get(class_name, {})
-            default_cols = class_settings.get("table_fields", [])
+        entity_settings = get_entity_settings_by_modelname(class_name)
+        default_cols = entity_settings.get("table_fields", [])
         default_cols = default_cols + selected_cols
 
         self.table_class = get_entities_table(
@@ -229,9 +229,8 @@ class GenericListViewNew(
                 context = dict(context, **chartdata)
 
         toggleable_cols = []
-        if hasattr(settings, "APIS_ENTITIES"):
-            entity_settings = settings.APIS_ENTITIES.get(class_name, {})
-            toggleable_cols = entity_settings.get("additional_cols", [])
+        entity_settings = get_entity_settings_by_modelname(class_name)
+        toggleable_cols = entity_settings.get("additional_cols", [])
 
         # TODO kk spelling of this dict key should get fixed throughout
         #  (togglable_colums -> toggleable_columns)


### PR DESCRIPTION
This replaces every occurence of direct access to settings.APIS_ENTITIES
with the helper function `get_entity_settings_by_modelname`
