### PR TITLE
fix: remove duplicate of `references` attribute in detail view

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -198,19 +198,11 @@
                         </tr>
                       {% endif %}
 
-                      {% if object.references %}
-                        <tr>
-                          <th>References</th>
-                          <td>{{ object.references }}</td>
-                        </tr>
-                      {% endif %}
-
                     </table>
                   {% endblock info-metadata %}
 
                   {% block left-pane-additional %}
                   {% endblock left-pane-additional %}
-
                 </div>
               </div>
             </div>


### PR DESCRIPTION
The `references` of an entity were listed two times in the detail view.
This commit removes the second occurence. Somehow this leads to djlint
being confused, therefore an unrelated newline has to be remove too...
