### PR TITLE
fix: put function call in separate document.ready function

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/apis_templatetag.html
+++ b/apis_core/apis_entities/templates/apis_entities/apis_templatetag.html
@@ -33,7 +33,9 @@
                         console.log('apScrollTop: init');
                     }
                 });
-	$(document).on('submit', 'form.form.ajax_form', unbind_ajax_forms);
+            });
+            $(document).ready(function() {
+	      $(document).on('submit', 'form.form.ajax_form', unbind_ajax_forms);
             });
 </script>
 <script type="text/javascript">


### PR DESCRIPTION
This way our custom function is still called, even if the function call
above it fails - which it does, if the apScrollTop thingy is not
installed.
