### PR TITLE
refactor(apis_entities): rewrite the relevant fields logic

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -114,11 +114,11 @@
                       <th>Titel</th>
                       <td>{{ object.name }}</td>
                     </tr>
-                    {% for x in relvant_fields %}
+                    {% for field, value in relevant_fields %}
                       <tr>
-                        <th>{{ x.0 }}</th>
+                        <th>{{ field.verbose_name }}</th>
                         <td>
-                          <small>{{ x.1 }}</small>
+                          <small>{{ value }}</small>
                         </td>
                       </tr>
                     {% endfor %}


### PR DESCRIPTION
The approach so far was to manually go through all the fields and have
an `exclude` list. It makes more sense to use `model_to_dict` from
django forms. If projects need more customization, they can override the
template.
The variable was also renamed to `relevant_fields` and we also pass the
field to the template, to be able to access the verbose_name.

Closes: #331
