### PR TITLE
refactor(apis_entities): cleanup relation listings in detailview

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -217,14 +217,8 @@
                     {% for obj in right_card %}
 
                       {% if obj.1.data|length > 0 %}
-                        <div class="card card-default">
-                          <div class="card-heading">
-                            <h4 class="card-title">{{ obj.0 }}</h4>
-                          </div>
-                          <div class="card-body">
-                            <div id="tab_{{ obj.2 }}" class="card-body">{% render_table obj.1 %}</div>
-                          </div>
-                        </div>
+                        <h4>{{ obj.0 }}</h4>
+                        <div id="tab_{{ obj.2 }}">{% render_table obj.1 %}</div>
                       {% endif %}
 
                     {% endfor %}


### PR DESCRIPTION
The relations were a card in a card in a card. Thats too much borders
and clutters the view. Lets at least drop the most inner card.
