### PR TITLE
refactor: replace the `relations_list` with hardcoded links

### DIFF
--- a/apis_core/apis_metainfo/templates/base.html
+++ b/apis_core/apis_metainfo/templates/base.html
@@ -126,10 +126,10 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
                       {% block relations-menu-items %}
-                        {% for ent in relations_list %}
-                          <a class="dropdown-item"
-                             href="{% url 'apis:apis_relations:generic_relations_list' ent %}">{{ ent|title }}</a>
-                        {% endfor %}
+                        <a class="dropdown-item"
+                           href="{% url 'apis:apis_relations:generic_relations_list' "property" %}">Properties</a>
+                        <a class="dropdown-item"
+                           href="{% url 'apis:apis_relations:generic_relations_list' "triple" %}">Triples</a>
                       {% endblock relations-menu-items %}
 
                     </div>


### PR DESCRIPTION
The relations list was sourced from a context processor. This is
overengineered for a list of two items. We therefore replace the items
with a hardcoded list, which allows us to drop the context processor in
the future.
