### PR TITLE
fix: introduce APIS_LIST_LINKS_TO_EDIT variable

### DIFF
--- a/apis_core/apis_entities/tables.py
+++ b/apis_core/apis_entities/tables.py
@@ -1,6 +1,7 @@
 import django_tables2 as tables
 from django.utils.safestring import mark_safe
 from django_tables2.utils import A
+from apis_core.utils.settings import list_links_to_edit
 
 from apis_core.apis_metainfo.tables import (
     generic_order_start_date_written,
@@ -11,7 +12,7 @@ from apis_core.apis_metainfo.tables import (
 from apis_core.utils import caching
 
 
-def get_entities_table(entity, edit_v, default_cols):
+def get_entities_table(entity, default_cols):
     if default_cols is None:
         default_cols = [
             "name",
@@ -31,7 +32,7 @@ def get_entities_table(entity, edit_v, default_cols):
         order_end_date_written = generic_order_end_date_written
         render_start_date_written = generic_render_start_date_written
         render_end_date_written = generic_render_end_date_written
-        if edit_v:
+        if list_links_to_edit():
             name = tables.LinkColumn(
                 "apis:apis_entities:generic_entities_edit_view",
                 args=[entity.lower(), A("pk")],

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -45,16 +45,12 @@ def set_session_variables(request):
     ann_proj_pk = request.GET.get("project", None)
     types = request.GET.getlist("types", None)
     users_show = request.GET.getlist("users_show", None)
-    edit_views = request.GET.get("edit_views", False)
     if types:
         request.session["entity_types_highlighter"] = types
     if users_show:
         request.session["users_show_highlighter"] = users_show
     if ann_proj_pk:
         request.session["annotation_project"] = ann_proj_pk
-    if edit_views:
-        if edit_views != "false":
-            request.session["edit_views"] = True
     return request
 
 
@@ -120,10 +116,6 @@ class GenericListViewNew(
         class_name = model.__name__
 
         session = getattr(self.request, "session", False)
-        if session:
-            edit_v = self.request.session.get("edit_views", False)
-        else:
-            edit_v = False
 
         selected_cols = self.request.GET.getlist(
             "columns"
@@ -133,9 +125,7 @@ class GenericListViewNew(
         default_cols = entity_settings.get("table_fields", [])
         default_cols = default_cols + selected_cols
 
-        self.table_class = get_entities_table(
-            class_name, edit_v, default_cols=default_cols
-        )
+        self.table_class = get_entities_table(class_name, default_cols=default_cols)
         table = super(GenericListViewNew, self).get_table()
         RequestConfig(
             self.request, paginate={"page": 1, "per_page": self.paginate_by}

--- a/apis_core/utils/settings.py
+++ b/apis_core/utils/settings.py
@@ -32,3 +32,7 @@ def get_entity_settings_by_modelname(entity: str = None) -> dict:
         # lookup entity settings by name and by capitalized name
         return apis_entities.get(entity, apis_entities.get(entity.capitalize(), {}))
     return apis_entities
+
+
+def list_links_to_edit() -> bool:
+    return getattr(settings, "APIS_LIST_LINKS_TO_EDIT", False)


### PR DESCRIPTION
When this variable is set, the entity list views link to the edit views
of the individual entities.
The former `edit_v` session variable was removed.
