### PR TITLE
fix: readd exclude list of fields in detail view

### DIFF
--- a/apis_core/apis_entities/detail_generic.py
+++ b/apis_core/apis_entities/detail_generic.py
@@ -112,10 +112,28 @@ class GenericEntitiesDetailView(ViewPassesTestMixin, EntityInstanceMixin, View):
             no_merge_labels = []
 
         relevant_fields = []
+        # those are fields from TempEntityClass, this exclude list can be removed once TempEntityClass is dropped
+        exclude_fields = [
+            "start_date",
+            "start_start_date",
+            "start_end_date",
+            "end_date",
+            "end_start_date",
+            "end_end_date",
+            "tempentityclass_ptr",
+            "rootobject_ptr",
+            "collection",
+        ]
+        entity_settings = get_entity_settings_by_modelname(self.entity)
+        exclude_fields.extend(entity_settings.get("detail_view_exclude", []))
         for field in model_to_dict(self.instance).keys():
-            relevant_fields.append(
-                (self.instance._meta.get_field(field), getattr(self.instance, field))
-            )
+            if field not in exclude_fields:
+                relevant_fields.append(
+                    (
+                        self.instance._meta.get_field(field),
+                        getattr(self.instance, field),
+                    )
+                )
 
         return HttpResponse(
             template.render(

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -190,6 +190,7 @@ APIS_ENTITIES
                 },
             },
             "list_filters_exclude": ["lat", "lng", "status"],
+            "detail_view_exclude": ["notes", "references"],
         },}
 
 ``APIS_ENTITIES`` is the setting to define the behavior of the entities list views. Every entity has its own setting.
@@ -202,6 +203,7 @@ allows to merge several entities in one target entity at once.
 ``table_fields`` sets the default columns to show in the list views.
 ``additional_cols`` allows to set the columns that user can add to the result view.
 ``relations_per_page`` allows to set the number of relations listed before pagination begins
+``detail_view_exclude`` allows to set fields that are excluded from the default detail view
 
 ``list_filters``
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This excludes fields that are part of TempEntityClass - in the long run,
this can be removed. But given that there are still projects using
TempEntityClass, this is a temporary workaround
