### PR TITLE
fix: drop `collections` as default field from entities filter

### DIFF
--- a/apis_core/apis_entities/filters.py
+++ b/apis_core/apis_entities/filters.py
@@ -53,10 +53,6 @@ class GenericEntityListFilter(django_filters.FilterSet):
         method=related_property_name, label="Related property"
     )
 
-    collection = django_filters.ModelMultipleChoiceFilter(
-        queryset=Collection.objects.all()
-    )
-
     # TODO: look into how the date values can be intercepted so that they can be parsed with the same logic as in edit forms
     start_date = django_filters.DateFromToRangeFilter()
     end_date = django_filters.DateFromToRangeFilter()


### PR DESCRIPTION
`collections` is a field from TempEntityClass - it does not have to be
hardcoded in the filter. If it exists in the model, the filter will show
it anyway.

Closes: #354