### PR TITLE
fix: drop `get_child_class()` from AbstractEntity

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -88,13 +88,6 @@ class AbstractEntity(RootObject):
             kwargs={"entity": entity, "pk": self.id},
         )
 
-    def get_child_class(self):
-        child = self.get_child_entity()
-        if child:
-            return "{}".format(child.__class__.__name__)
-        else:
-            return "{}".format(child.__class__.__name__)
-
     def get_absolute_url(self):
         entity = self.__class__.__name__.lower()
         return reverse(


### PR DESCRIPTION
It is not used anywhere and it uses `get_child_entity` which was
apparently already dropped during
c60e6df4d53918dea6ed2be5b2d2225eb8fde894

Closes: #323
