### PR TITLE
fix: do not expect fields in EntitySerializer

### DIFF
--- a/apis_core/apis_entities/serializers_generic.py
+++ b/apis_core/apis_entities/serializers_generic.py
@@ -39,11 +39,7 @@ class TextSerializer(serializers.Serializer):
 class EntitySerializer(serializers.Serializer):
     id = serializers.IntegerField()
     url = serializers.SerializerMethodField(method_name="add_url")
-    name = serializers.CharField()
-    start_date = serializers.DateField()
-    end_date = serializers.DateField()
     uris = EntityUriSerializer(source="uri_set", many=True)
-    labels = LabelSerializer(source="label_set", many=True)
     revisions = serializers.SerializerMethodField(method_name="add_revisions")
 
     def add_revisions(self, obj):
@@ -167,6 +163,8 @@ class EntitySerializer(serializers.Serializer):
             )
         if add_texts:
             self.fields["text"] = TextSerializer(many=True)
+        if hasattr(self.instance, "label_set"):
+            self.labels = LabelSerializer(source="label_set", many=True)
 
 
 class RelationEntitySerializer(serializers.Serializer):


### PR DESCRIPTION
We are moving away from expecting fields in our entities, therefore it
makes sense to make the EntitySerializer a bit more flexible. By default
it serializes all the fields of the entity anyway - so we can simply
remove `name`, `start_date` and `end_date` in this case. The `label_set`
is a leftover of the legacy setup with TempEntityClass, we no check for
its existence before adding the field.

Closes: #383
