### PR TITLE
fix: drop object_revisions from generic entities edit view

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -103,7 +103,6 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
                 apis_bibsonomy = "|".join([x.strip() for x in apis_bibsonomy])
         else:
             apis_bibsonomy = False
-        object_revisions = Version.objects.get_for_object(self.instance)
         object_lod = Uri.objects.filter(root_object=self.instance)
         object_labels = Label.objects.filter(temp_entity__id=self.instance.id)
         tb_label = LabelTableEdit(
@@ -118,7 +117,6 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
             "form": form,
             "instance": self.instance,
             "right_card": side_bar,
-            "object_revisions": object_revisions,
             "object_lod": object_lod,
             "apis_bibsonomy": apis_bibsonomy,
         }


### PR DESCRIPTION
The variable is passed to the template via the context but not used
anywhere and it creates problems with ontologies not using reversion.
Therefore we drop the variable.

Closes: #407 