### PR TITLE
fix: cleanup entities detail template

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -110,10 +110,6 @@
 
                 {% block info-table %}
                   <table class="table table-hover">
-                    <tr>
-                      <th>Titel</th>
-                      <td>{{ object.name }}</td>
-                    </tr>
                     {% for field, value in relevant_fields %}
                       <tr>
                         <th>{{ field.verbose_name }}</th>
@@ -122,24 +118,26 @@
                         </td>
                       </tr>
                     {% endfor %}
-                    <tr>
-                      <th>Labels</th>
-                      <td>
-                        {% for x in no_merge_labels %}
-                          <li>
-                            <small>{{ x.label_type }}:</small>{{ x.label }}
-                          </li>
-                        {% endfor %}
-                      </td>
-                    </tr>
-                    <tr>
-                      <th>ID</th>
-                      <td>{{ object.id }}</td>
-                    </tr>
-                    <tr>
-                      <th>Type</th>
-                      <td>{{ object.kind }}</td>
-                    </tr>
+
+                    {% if no_merge_labels %}
+                      <tr>
+                        <th>Labels</th>
+                        <td>
+                          {% for x in no_merge_labels %}
+                            <li>
+                              <small>{{ x.label_type }}:</small>{{ x.label }}
+                            </li>
+                          {% endfor %}
+                        </td>
+                      </tr>
+                    {% endif %}
+
+                    {% if object.kind %}
+                      <tr>
+                        <th>Type</th>
+                        <td>{{ object.kind }}</td>
+                      </tr>
+                    {% endif %}
 
                     {% if object.start_date or object.end_date %}
                       <tr>
@@ -154,99 +152,104 @@
 
                         </td>
                       </tr>
+                    {% endif %}
+
+                    {% if object.lat and object.lng %}
                       <tr>
-                        <th>Notes</th>
-                        <td>{{ object.notes }}</td>
+                        <th>Lat/Lng</th>
+                        <td>{{ object.lat }} / {{ object.lng }}</td>
                       </tr>
-                      <tr>
-                        <th>References</th>
-                        <td>{{ object.references }}</td>
-                      {% endif %}
+                    {% endif %}
 
-                      {% if object.lat %}
-                        <tr>
-                          <th>Lat/Lng</th>
-                          <td>{{ object.lat }} / {{ object.lng }}</td>
-                        </tr>
-                      {% endif %}
+                  </table>
+                {% endblock info-table %}
 
-                    </table>
-                  {% endblock info-table %}
+                {% block info-metadata %}
+                  <table class="table table-hover">
 
-                  {% block info-metadata %}
-                    <table class="table table-hover">
+                    {% if object.collections.all %}
                       <tr>
                         <th>Collection(s)</th>
                         <td>
                           {% for x in object.collection.all %}<li>{{ x }}</li>{% endfor %}
                         </td>
                       </tr>
+                    {% endif %}
+
+                    <tr>
+                      <th>Uri(s)</th>
+                      <td>
+                        {% for x in object.uri_set.all %}
+                          <a href="{{ x }}">{{ x }}</a>
+                          <br />
+                        {% endfor %}
+                      </td>
+                    </tr>
+
+                    {% if object.notes %}
                       <tr>
-                        <th>Uri(s)</th>
-                        <td>
-                          {% for x in object.uri_set.all %}
-                            <a href="{{ x }}">{{ x }}</a>
-                            <br />
-                          {% endfor %}
-                        </td>
+                        <th>Notes</th>
+                        <td>{{ object.notes }}</td>
                       </tr>
+                    {% endif %}
 
-                      {% if object.notes %}
-                        <tr>
-                          <th>Notes</th>
-                          <td>{{ object.notes }}</td>
-                        </tr>
-                      {% endif %}
+                    {% if object.references %}
+                      <tr>
+                        <th>References</th>
+                        <td>{{ object.references }}</td>
+                      </tr>
+                    {% endif %}
 
-                    </table>
-                  {% endblock info-metadata %}
+                  </table>
+                {% endblock info-metadata %}
 
-                  {% block left-pane-additional %}
-                  {% endblock left-pane-additional %}
-                </div>
+                {% block left-pane-additional %}
+                {% endblock left-pane-additional %}
+
               </div>
             </div>
-            <div class="col-md-8">
-              <div class="card">
-                <div class="card-header">
-                  <h3>Relations</h3>
-                </div>
-                <div class="card-body">
+          </div>
+          <div class="col-md-8">
+            <div class="card">
+              <div class="card-header">
+                <h3>Relations</h3>
+              </div>
+              <div class="card-body">
 
-                  {% block relations %}
-                    {% for obj in right_card %}
+                {% block relations %}
+                  {% for obj in right_card %}
 
-                      {% if obj.1.data|length > 0 %}
-                        <h4>{{ obj.0 }}</h4>
-                        <div id="tab_{{ obj.2 }}">{% render_table obj.1 %}</div>
-                      {% endif %}
+                    {% if obj.1.data|length > 0 %}
+                      <h4>{{ obj.0 }}</h4>
+                      <div id="tab_{{ obj.2 }}">{% render_table obj.1 %}</div>
+                    {% endif %}
 
-                    {% endfor %}
-                  {% endblock relations %}
+                  {% endfor %}
+                {% endblock relations %}
 
-                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      <div class="card">
-
-        {% if iiif %}
-          <div class="card-body">
-            <div id="iiif" style="width: 100%; height: 400px"></div>
-          </div>
-        {% endif %}
-
-      </div>
     </div>
-  {% endblock content %}
+    <div class="card">
 
-  {% block scripts %}
-    {{ block.super }}
+      {% if iiif %}
+        <div class="card-body">
+          <div id="iiif" style="width: 100%; height: 400px"></div>
+        </div>
+      {% endif %}
 
-    {% if tei %}
-      <script type="text/javascript">
+    </div>
+  </div>
+{% endblock content %}
+
+{% block scripts %}
+  {{ block.super }}
+
+  {% if tei %}
+    <script type="text/javascript">
       var CETEIcean = new CETEI();
       var teiString = $("#teisource").text();
       CETEIcean.makeHTML5(teiString, function(data) {
@@ -254,17 +257,17 @@
         document.getElementById("teiviewer").appendChild(data)
         CETEIcean.addStyle(document, data);
       });
-      </script>
-    {% endif %}
+    </script>
+  {% endif %}
 
-    {% if iiif %}
-      <script type="text/javascript">
+  {% if iiif %}
+    <script type="text/javascript">
       var viewer = OpenSeadragon({
         id: "iiif",
         tileSources: "{{iiif_server }}{{iiif_info_json }}info.json",
         prefixUrl: "{{ openseadragon_img }}"
       });
-      </script>
-    {% endif %}
+    </script>
+  {% endif %}
 
-  {% endblock scripts %}
+{% endblock scripts %}


### PR DESCRIPTION
The detail template references a couple of attributes that can not be
expected of entities anymore. In addition, due to the reimplementation
of the `relevant_fields` logic in 13986b8 the template does not have to
list attributes manually. Therefore we remove some attributes from the
listing and others are now surrounded by {% if %}{% endif %} statements.

Closes: #396
