### PR TITLE
refactor: drop webpage_content_processors

### DIFF
--- a/apis_core/context_processors/webpage_content_processors.py
+++ b/apis_core/context_processors/webpage_content_processors.py
@@ -1,6 +1,0 @@
-from django.conf import settings
-
-
-def shared_url(request):
-    shared_url = getattr(settings, "SHARED_URL", "/static/")
-    return {"SHARED_URL": shared_url}


### PR DESCRIPTION
Its not used anywhere in the codebase since
0ce7df4e34efc31b5b3c80374b70889ffbe7938e
