### PR TITLE
fix: drop unused custom context processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ To use the APIS framework in your application, you will need to add the followin
 
 Also, add the following two [context processors](https://docs.djangoproject.com/en/4.2/ref/templates/api/#django.template.RequestContext):
 ```
-# we need this for listing entities in the base template
-"apis_core.context_processors.custom_context_processors.list_entities",
 # we need this for accessing `basetemplate`
 "apis_core.context_processors.custom_context_processors.list_apis_settings",
 ```

--- a/apis_core/context_processors/custom_context_processors.py
+++ b/apis_core/context_processors/custom_context_processors.py
@@ -1,29 +1,4 @@
-from operator import itemgetter
-
 from django.conf import settings
-
-from apis_core.utils import caching
-
-
-def list_entities(request):
-    """
-    Retrieve all models which inherit from AbstractEntity class
-    and make information about them available on the frontend.
-
-    :return a dictionary of context items
-    """
-    entities_classes = caching.get_all_entity_classes() or []
-    # create (uri, label) tuples for entities for use in templates
-    entities_links = [
-        (e.__name__.lower(), e._meta.verbose_name.title()) for e in entities_classes
-    ]
-    entities_links.sort(key=itemgetter(1))
-
-    return {"entities_links": entities_links, "request": request}
-
-
-def list_relations(request):
-    return {"relations_list": ["property", "triple"], "request": request}
 
 
 def list_apis_settings(request):

--- a/tests/settings_ci.py
+++ b/tests/settings_ci.py
@@ -57,8 +57,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                # we need this for listing entities in the base template
-                "apis_core.context_processors.custom_context_processors.list_entities",
                 # we need this for accessing `basetemplate`
                 "apis_core.context_processors.custom_context_processors.list_apis_settings",
             ],


### PR DESCRIPTION
We don't need them anymore since
0ce7df4e34efc31b5b3c80374b70889ffbe7938e and
51a0e5d42ab7651c3013793adb17949fa9debcb6
