### PR TITLE
fix: provide a fallback template if basetemplate is not set

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/create_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/create_generic.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load static %}
 {% load crispy_forms_tags %}
 

--- a/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/detail_views/detail_generic.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load static %}
 {% load django_tables2 %}
 

--- a/apis_core/apis_entities/templates/apis_entities/edit_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/edit_generic.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load static %}
 {% load django_tables2 %}
 {% load crispy_forms_tags %}

--- a/apis_core/apis_labels/templates/apis_labels/label_create.html
+++ b/apis_core/apis_labels/templates/apis_labels/label_create.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 
 {% block Titel %}Create Label{% endblock %}
 

--- a/apis_core/apis_labels/templates/apis_labels/labels_list.html
+++ b/apis_core/apis_labels/templates/apis_labels/labels_list.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 
 {% block Titel %}See all Labels{% endblock %}
 

--- a/apis_core/apis_metainfo/templates/apis_metainfo/uri_detail.html
+++ b/apis_core/apis_metainfo/templates/apis_metainfo/uri_detail.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load static %}
 {% load django_tables2 %}
 

--- a/apis_core/apis_metainfo/templates/browsing/create_base_template.html
+++ b/apis_core/apis_metainfo/templates/browsing/create_base_template.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 
 {% block title %}{% endblock %}
 

--- a/apis_core/apis_metainfo/templates/generic_list.html
+++ b/apis_core/apis_metainfo/templates/generic_list.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load static %}
 {% load django_tables2 %}
 {% load apis_metainfo_extras %}

--- a/apis_core/apis_metainfo/templates/registration/login.html
+++ b/apis_core/apis_metainfo/templates/registration/login.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load crispy_forms_tags %}
 
 {% block content %}

--- a/apis_core/apis_metainfo/templates/uri_create.html
+++ b/apis_core/apis_metainfo/templates/uri_create.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load crispy_forms_tags %}
 
 {% block content %}

--- a/apis_core/apis_relations/templates/apis_relations/relations_detail_generic.html
+++ b/apis_core/apis_relations/templates/apis_relations/relations_detail_generic.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 {% load static %}
 
 {% block title %}{{ object }}{% endblock %}

--- a/apis_core/core/templates/confirm_delete.html
+++ b/apis_core/core/templates/confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 
 {% block content %}
   <div class="modal-dialog">


### PR DESCRIPTION
This way we can drop the context_processor that provides the
`basetemplate` variable, but still let downstream projects override the
variable if they want to.
