### PR TITLE
fix: tooltips for class docstrings, whitespace issues

### DIFF
--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -156,9 +156,15 @@ class GenericListViewNew(
         context[self.context_filter_name] = self.filter
         context["entity"] = self.entity  # model slug
         context["app_name"] = "apis_entities"
-        context["docstring"] = f"{model.__doc__}"
-
         context["entity_create_stanbol"] = GenericEntitiesStanbolForm(self.entity)
+
+        # model.__doc__ defaults to "ClassName(attr1, attr2)" when there is no
+        # actual docstring, which is not helpful to output on the frontend
+        if (
+            f"{model.__doc__}"
+            != f"{model.__name__}({', '.join([f.name for f in model._meta.fields])})"
+        ):
+            context["docstring"] = f"{model.__doc__}"
 
         if "browsing" in settings.INSTALLED_APPS:
             from browsing.models import BrowsConf

--- a/apis_core/apis_metainfo/templates/apis_metainfo/tags/class_definition.html
+++ b/apis_core/apis_metainfo/templates/apis_metainfo/tags/class_definition.html
@@ -1,1 +1,5 @@
-<abbr title="{{ docstring }}">{{ class_name }}</abbr>
+{% if docstring %}
+  <abbr title="{{ docstring }}">{{ class_name }}</abbr>
+{% else %}
+  {{ class_name }}
+{% endif %}

--- a/apis_core/apis_metainfo/templates/generic_list.html
+++ b/apis_core/apis_metainfo/templates/generic_list.html
@@ -29,7 +29,7 @@
           <div class="card-header">
             <div class="row">
               <div class="col-sm">
-                <h2 class="mb-0">
+                <h2 class="mb-0" style="white-space: nowrap;">
                   Browse {% class_definition %}
 
                   {% block list_title %}{% endblock %}


### PR DESCRIPTION
- fixes linebreaks between text and HTML tags caused by templatetag
- checks for existence of proper docstring for classes (see PEP 257) instead of falling back on class definition

References:
https://peps.python.org/pep-0257/
