### PR TITLE
refactor: cleanup `apis_entities.edit_generic` + template

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -13,19 +13,12 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.generic import DeleteView
 from django_tables2 import RequestConfig
-from reversion.models import Version
-
 from apis_core.apis_labels.models import Label
-from apis_core.apis_metainfo.models import Uri
 from apis_core.apis_relations.models import TempTriple
-from apis_core.apis_relations.tables import (
-    get_generic_triple_table,
-    LabelTableEdit,
-)
+from apis_core.apis_relations.tables import get_generic_triple_table, LabelTableEdit
 from .forms import get_entities_form, GenericEntitiesStanbolForm
 from .views import set_session_variables
 from ..apis_vocabularies.models import TextType
-from apis_core.utils import caching
 from apis_core.utils import helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from apis_core.apis_entities.mixins import EntityMixin, EntityInstanceMixin
@@ -103,13 +96,10 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
                 apis_bibsonomy = "|".join([x.strip() for x in apis_bibsonomy])
         else:
             apis_bibsonomy = False
-        object_lod = Uri.objects.filter(root_object=self.instance)
         object_labels = Label.objects.filter(temp_entity__id=self.instance.id)
         tb_label = LabelTableEdit(
             data=object_labels, prefix=self.entity.title()[:2] + "L-"
         )
-        tb_label_open = request.GET.get("PL-page", None)
-        # side_bar.append(('Label', tb_label, 'PersonLabel', tb_label_open))
         RequestConfig(request, paginate={"per_page": 10}).configure(tb_label)
         template = get_template("apis_entities/edit_generic.html")
         context = {
@@ -117,7 +107,6 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
             "form": form,
             "instance": self.instance,
             "right_card": side_bar,
-            "object_lod": object_lod,
             "apis_bibsonomy": apis_bibsonomy,
         }
         form_merge_with = GenericEntitiesStanbolForm(self.entity, ent_merge_pk=self.pk)

--- a/apis_core/apis_entities/templates/apis_entities/edit_generic.html
+++ b/apis_core/apis_entities/templates/apis_entities/edit_generic.html
@@ -58,44 +58,6 @@
 
                       {% crispy form %}
 
-                      {% block linkedOpenData %}
-
-                        {% if object_lod %}
-                          <div class="card card-default">
-                            <div class="card-header" role="tab" id="headingSix">
-                              <h4 class="card-title">
-                                <a role="button"
-                                   data-toggle="collapse"
-                                   data-parent="#accordion"
-                                   href="#collapseOne3"
-                                   aria-expanded="false"
-                                   aria-controls="collapseOne3">Linked Open Data</a>
-                              </h4>
-                            </div>
-                            <div id="collapseOne3"
-                                 class="card-collapse collapse"
-                                 role="tabcard"
-                                 aria-labelledby="headingSix">
-                              <div id="tab_Revisions" class="card-body">
-                                <p>
-                                  {% for lod in object_lod %}
-
-                                    {% if forloop.last %}
-                                      <a href="{{ lod.uri }}">{{ lod.uri }}</a>
-                                    {% else %}
-                                      <a href="{{ lod.uri }}">{{ lod.uri }}</a>
-                                      <br />
-                                    {% endif %}
-
-                                  {% endfor %}
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        {% endif %}
-
-                      {% endblock %}
-
                       {% block editbuttons %}
                         <div class="mt-2">
                           <input class="btn btn-primary" type="submit" value="modify" />
@@ -110,6 +72,20 @@
                       {% endblock editbuttons %}
 
                     </form>
+                  </div>
+                  <div class="card-footer">
+
+                    {% block linkedOpenData %}
+                      <h5 class="card-title">Linked Open Data</h5>
+
+                      {% if instance.uri_set %}
+                        <ul>
+                          {% for uri in instance.uri_set.all %}<li>{{ uri.uri | urlize }}</li>{% endfor %}
+                        </ul>
+                      {% endif %}
+
+                    {% endblock %}
+
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This replaces some context data with attributes from the instance, it
removes any label specific code and drops some imports that were not
used.
