### PR TITLE
refactor: move duplicated triple code to `apis_core.utils.helpers`

### DIFF
--- a/apis_core/utils/helpers.py
+++ b/apis_core/utils/helpers.py
@@ -7,12 +7,16 @@ from typing import Type
 
 
 from apis_core.apis_entities.models import TempEntityClass
-from apis_core.apis_relations.models import Property
+from apis_core.apis_relations.models import Property, TempTriple
+from apis_core.utils.settings import get_entity_settings_by_modelname
+from apis_core.apis_relations.tables import get_generic_triple_table
 
 from django.apps import apps
 from django.db import DEFAULT_DB_ALIAS, router
+from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
+from django_tables2 import RequestConfig
 
 
 @functools.lru_cache
@@ -134,3 +138,47 @@ def datadump_serializer(additional_app_labels: list = [], serialier_format="json
         datadump_get_queryset(additional_app_labels),
         use_natural_foreign_keys=True,
     )
+
+
+def triple_sidebar(pk: int, entity_name: str, request, detail=True):
+    side_bar = []
+
+    triples_related_all = (
+        TempTriple.objects_inheritance.filter(Q(subj__pk=pk) | Q(obj__pk=pk))
+        .all()
+        .select_subclasses()
+    )
+
+    for entity_class in get_classes_with_allowed_relation_from(entity_name):
+        entity_content_type = ContentType.objects.get_for_model(entity_class)
+
+        other_entity_class_name = entity_class.__name__.lower()
+
+        triples_related_by_entity = triples_related_all.filter(
+            (Q(subj__self_contenttype=entity_content_type) & Q(obj__pk=pk))
+            | (Q(obj__self_contenttype=entity_content_type) & Q(subj__pk=pk))
+        )
+
+        table_class = get_generic_triple_table(
+            other_entity_class_name=other_entity_class_name,
+            entity_pk_self=pk,
+            detail=detail,
+        )
+
+        prefix = f"{other_entity_class_name}"
+        title_card = prefix
+        tb_object = table_class(data=triples_related_by_entity, prefix=prefix)
+        tb_object_open = request.GET.get(prefix + "page", None)
+        entity_settings = get_entity_settings_by_modelname(entity_class.__name__)
+        per_page = entity_settings.get("relations_per_page", 10)
+        RequestConfig(request, paginate={"per_page": per_page}).configure(tb_object)
+        tab_id = f"triple_form_{entity_name}_to_{other_entity_class_name}"
+        side_bar.append(
+            (
+                title_card,
+                tb_object,
+                tab_id,
+                tb_object_open,
+            )
+        )
+    return side_bar


### PR DESCRIPTION
This commit moves duplicated triple generation code that resided in both
the entities edit view and the entities detail view to the helpers
module so it can be reused by both views.

Closes: #480
