### PR TITLE
chore(deps): add crispy-bootstrap4 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To use the APIS framework in your application, you will need to add the followin
 
 # ui stuff used by APIS
 "crispy_forms",
+"crispy_bootstrap4",
 "django_filters",
 "django_tables2",
 "dal",

--- a/poetry.lock
+++ b/poetry.lock
@@ -251,6 +251,22 @@ files = [
 ]
 
 [[package]]
+name = "crispy-bootstrap4"
+version = "2023.1"
+description = "Bootstrap4 template pack for django-crispy-forms"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "crispy-bootstrap4-2023.1.tar.gz", hash = "sha256:d60e93eb6d82886c009eb174f2a4c78fdac602a1efadf0305471c84815bd973a"},
+    {file = "crispy_bootstrap4-2023.1-py3-none-any.whl", hash = "sha256:1a88e74f8d36d2dedeb40a66f246994f3ce5cd855017785d0291e741d3e7d7c2"},
+]
+
+[package.dependencies]
+django = ">=4.2"
+django-crispy-forms = ">=2.0"
+
+[[package]]
 name = "cssbeautifier"
 version = "1.14.8"
 description = "CSS unobfuscator and beautifier."
@@ -1663,4 +1679,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ffab5d0cf2b90320a80bb7ea8968f5702fdc2320317180f5394845b6d16644a3"
+content-hash = "c6f97b3c8fa25b6ec2cc0bc880d5bce05ce5fd9999a8723351fe9443c6a33ed5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ django-admin-csvexport = "^2.2"
 tablib = "^3.5.0"
 setuptools = "^68.2.2"
 apis-override-select2js = "^0.1.0"
+crispy-bootstrap4 = "^2023.1"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
BREAKING CHANGE: django-crispy-forms uses separate template packs since
version 2. we depend on crispy-bootstrap4 by default, but projects have
to add `crispy_bootstrap4` to the INSTALLED_APPS themselves.
