### PR TITLE
refactor!: drop `apis_vocabularies.models.LabelType`

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -189,7 +189,6 @@ class AbstractEntity(RootObject):
 
         # TODO: check if these imports can be put to top of module without
         #  causing circular import issues.
-        from apis_core.apis_vocabularies.models import LabelType
         from apis_core.apis_metainfo.models import Uri
 
         e_a = type(self).__name__
@@ -206,7 +205,6 @@ class AbstractEntity(RootObject):
             e_b = type(ent).__name__
             if e_a != e_b:
                 continue
-            lt, created = LabelType.objects.get_or_create(name="Legacy name (merge)")
             # TODO: if collections are removed, remove this as well
             if hasattr(ent, "collection"):
                 col_list = list(self.collection.all())

--- a/apis_core/apis_vocabularies/models.py
+++ b/apis_core/apis_vocabularies/models.py
@@ -130,13 +130,6 @@ class VocabsUri(models.Model):
 #     """Holds controlled vocabularies about event-types"""
 #     pass
 
-# TODO RDF: Remove this
-@reversion.register(follow=["vocabsbaseclass_ptr"])
-class LabelType(VocabsBaseClass):
-    """Holds controlled vocabularies about label-types"""
-
-    pass
-
 
 # TODO RDF: Remove this
 @reversion.register(follow=["vocabsbaseclass_ptr"])

--- a/apis_core/apis_vocabularies/serializers.py
+++ b/apis_core/apis_vocabularies/serializers.py
@@ -7,7 +7,6 @@ from .models import (
     CollectionType,
     VocabsBaseClass,
     VocabNames,
-    LabelType,
 )
 
 
@@ -184,7 +183,3 @@ class TextTypeSerializer(VocabsBaseSerializer):
 #         model = WorkType
 #
 #
-class LabelTypeSerializer(serializers.ModelSerializer):
-    class Meta:
-        fields = ("id", "name")
-        model = LabelType

--- a/apis_core/utils/test_caching.py
+++ b/apis_core/utils/test_caching.py
@@ -10,7 +10,6 @@ all_class_modules_and_names = {
     ],
     "apis_vocabularies": [
         "CollectionType",
-        "LabelType",
         "TextType",
         "VocabNames",
         "VocabsBaseClass",


### PR DESCRIPTION
Given that we don't use the `Label` model anymore since
0c44287eac678f40a24c98ffe8b7efb053487db4, we can safely remove
`LabelType`, too

Closes: #498
