### PR TITLE
refactor!: drop `apis_vocabularies.models.TextType`

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -17,7 +17,6 @@ from apis_core.apis_relations.models import TempTriple
 from apis_core.apis_relations.tables import get_generic_triple_table
 from .forms import get_entities_form, GenericEntitiesStanbolForm
 from .views import set_session_variables
-from ..apis_vocabularies.models import TextType
 from apis_core.utils import helpers
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from apis_core.apis_entities.mixins import EntityMixin, EntityInstanceMixin
@@ -84,17 +83,6 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
         form = form(instance=self.instance)
         if "apis_bibsonomy" in settings.INSTALLED_APPS:
             apis_bibsonomy = getattr(settings, "APIS_BIBSONOMY_FIELDS", [])
-            apis_bibsonomy_texts = getattr(settings, "APIS_BIBSONOMY_TEXTS", False)
-            if apis_bibsonomy_texts:
-                apis_bibsonomy.extend(
-                    [
-                        f"text_{self.pk}"
-                        for pk in TextType.objects.filter(
-                            name__in=apis_bibsonomy_texts
-                        ).values_list("pk", flat=True)
-                        if f"text_{self.pk}" not in apis_bibsonomy
-                    ]
-                )
             if isinstance(apis_bibsonomy, list):
                 apis_bibsonomy = "|".join([x.strip() for x in apis_bibsonomy])
         else:

--- a/apis_core/apis_entities/forms.py
+++ b/apis_core/apis_entities/forms.py
@@ -13,7 +13,6 @@ from django.forms import ModelMultipleChoiceField, ModelChoiceField
 from django.urls import reverse
 
 from apis_core.apis_metainfo.models import Uri, Collection
-from apis_core.apis_vocabularies.models import TextType
 from apis_core.utils import DateParser, caching, settings as apis_settings
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from .fields import ListSelect2, Select2Multiple

--- a/apis_core/apis_vocabularies/models.py
+++ b/apis_core/apis_vocabularies/models.py
@@ -137,20 +137,3 @@ class CollectionType(VocabsBaseClass):
     """e.g. reseachCollection, importCollection"""
 
     pass
-
-
-# TODO RDF: Remove this
-@reversion.register(follow=["vocabsbaseclass_ptr"])
-class TextType(VocabsBaseClass):
-    """used to store the Text types for the forms"""
-
-    entity = models.CharField(max_length=255)
-    collections = models.ManyToManyField("apis_metainfo.Collection", blank=True)
-    lang = models.CharField(
-        max_length=3,
-        blank=True,
-        null=True,
-        help_text="The ISO 639-3 (or 2) code for the label's language.",
-        verbose_name="ISO Code",
-        default="deu",
-    )

--- a/apis_core/apis_vocabularies/serializers.py
+++ b/apis_core/apis_vocabularies/serializers.py
@@ -3,7 +3,6 @@ from django.db.models.query import QuerySet
 from rest_framework import serializers
 
 from .models import (
-    TextType,
     CollectionType,
     VocabsBaseClass,
     VocabNames,
@@ -108,22 +107,6 @@ class VocabNamesSerializer(VocabsBaseSerializer):
 # Entity Types
 #
 ###########################################################
-
-
-class TextTypeSerializer(VocabsBaseSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name="apis:apis_api:texttype-detail", lookup_field="pk"
-    )
-    collections = serializers.HyperlinkedRelatedField(
-        view_name="apis:apis_api:collection-detail",
-        lookup_field="pk",
-        many=True,
-        read_only=True,
-    )
-
-    class Meta:
-        fields = "__all__"
-        model = TextType
 
 
 # TODO RDF: Check if this should be removed or adapted

--- a/apis_core/utils/test_caching.py
+++ b/apis_core/utils/test_caching.py
@@ -10,7 +10,6 @@ all_class_modules_and_names = {
     ],
     "apis_vocabularies": [
         "CollectionType",
-        "TextType",
         "VocabNames",
         "VocabsBaseClass",
         "VocabsUri",


### PR DESCRIPTION
Given that we removed `Text` in 063412fb28bb812325010bae333f19ea3cb7bd8d
we don't need `TextType` anymore either.

Closes: #499
