### PR TITLE
ci: allow longer lines in git commit messages

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   gitlint:
-    uses: acdh-oeaw/prosnet-workflows/.github/workflows/gitlint.yml@v0.3.3
+    uses: acdh-oeaw/prosnet-workflows/.github/workflows/gitlint.yml@v0.3.4
     with:
       comment: false


### PR DESCRIPTION
dependabot uses longer lines sometimes