### PR TITLE
fix(apis_entities): fix accidently removed form save

### DIFF
--- a/apis_core/apis_entities/edit_generic.py
+++ b/apis_core/apis_entities/edit_generic.py
@@ -50,6 +50,7 @@ class GenericEntitiesEditView(EntityInstanceMixin, View):
             form = get_entities_form(self.entity.title())
         form = form(request.POST, instance=self.instance)
         if form.is_valid():
+            form.save()
             return redirect(
                 reverse(
                     "apis:apis_entities:generic_entities_edit_view",


### PR DESCRIPTION
This was removed in ae6f2c4, because ruff was annoyed with the
assignment:
> entity2 = form.save()

because `entity2` was not used anywhere, but it turns out the
form.save() was actually important..
