### PR TITLE
feat(generic): allow to extend autocomplete results with custom results

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -211,3 +211,13 @@ class Autocomplete(
         if queryset:
             return queryset(self.model, self.q)
         return self.model.objects.filter(generate_search_filter(self.model, self.q))
+
+    def get_results(self, context):
+        external_only = self.kwargs.get("external_only", False)
+        results = [] if external_only else super().get_results(context)
+        ExternalAutocomplete = first_match_via_mro(
+            self.model, path="querysets", suffix="ExternalAutocomplete"
+        )
+        if ExternalAutocomplete:
+            results.extend(ExternalAutocomplete().get_results(self.q))
+        return results


### PR DESCRIPTION
This extens the `generic.views.Autocomplete` endpoint to allow adding
custom results to the autocomplete answer. It also adds an option to
*only* return custom results and not the defaults.
