### PR TITLE
fix: only show table actions if user has required permissions

### DIFF
--- a/apis_core/generic/helpers.py
+++ b/apis_core/generic/helpers.py
@@ -3,6 +3,7 @@ import inspect
 import importlib
 
 from django.db.models import CharField, TextField, Q, Model
+from django.contrib.auth import get_permission_codename
 
 
 def generate_search_filter(model, query):
@@ -69,3 +70,8 @@ def first_match_via_mro(model, path: str = "", suffix: str = ""):
     paths = list(map(lambda x: x[:-1] + [path] + x[-1:], mro_paths(model)))
     classes = [".".join(prefix) + suffix for prefix in paths]
     return next(filter(bool, map(class_from_path, classes)), None)
+
+
+def permission_fullname(action: str, model: object) -> str:
+    permission_codename = get_permission_codename(action, model._meta)
+    return f"{model._meta.app_label}.{permission_codename}"

--- a/apis_core/generic/tables.py
+++ b/apis_core/generic/tables.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from apis_core.generic.helpers import permission_fullname
 
 
 class CustomTemplateColumn(tables.TemplateColumn):
@@ -21,7 +22,7 @@ class CustomTemplateColumn(tables.TemplateColumn):
             exclude_from_export=self.exclude_from_export,
             verbose_name=self.verbose_name,
             *args,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -90,3 +91,12 @@ class GenericTable(tables.Table):
             kwargs["sequence"] = ["...", "view", "edit", "delete"]
 
         super().__init__(*args, **kwargs)
+
+    def before_render(self, request):
+        if model := getattr(self.Meta, "model"):
+            if not request.user.has_perm(permission_fullname("delete", model)):
+                self.columns.hide("delete")
+            if not request.user.has_perm(permission_fullname("edit", model)):
+                self.columns.hide("edit")
+            if not request.user.has_perm(permission_fullname("view", model)):
+                self.columns.hide("view")

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.contrib.auth import get_permission_codename
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView, FormView
@@ -15,7 +14,12 @@ from dal import autocomplete
 from .tables import GenericTable
 from .filtersets import filterset_factory, GenericFilterSet
 from .forms import GenericModelForm, GenericImportForm
-from .helpers import first_match_via_mro, template_names_via_mro, generate_search_filter
+from .helpers import (
+    first_match_via_mro,
+    template_names_via_mro,
+    generate_search_filter,
+    permission_fullname,
+)
 
 from apis_core.core.mixins import ListViewObjectFilterMixin
 
@@ -54,11 +58,7 @@ class GenericModelMixin:
 
     def get_permission_required(self):
         if hasattr(self, "permission_action_required"):
-            permission_codename = get_permission_codename(
-                self.permission_action_required, self.model._meta
-            )
-            permission = f"{self.model._meta.app_label}.{permission_codename}"
-            return [permission]
+            return [permission_fullname(self.permission_action_required, self.model)]
         return []
 
 


### PR DESCRIPTION
This introduces a wrapper `generic.helpers.permission_fullname` to
create the fullname of a permission based on the action and the model.
This is then used in the table class to hide columns that are not
can not use, due to missing permissions.
The wrapper is now also used in the views.GenericModelMixin.

Closes: #584
