### PR TITLE
feat: add a duplicate button to the generic table

### DIFF
--- a/apis_core/generic/tables.py
+++ b/apis_core/generic/tables.py
@@ -26,40 +26,43 @@ class CustomTemplateColumn(tables.TemplateColumn):
         )
 
 
-class DeleteColumn(CustomTemplateColumn):
+class ActionButton(CustomTemplateColumn):
+    orderable = False
+    exclude_from_export = True
+    verbose_name = ""
+    attrs = {"td": {"style": "width:1%;"}}
+
+
+class DeleteColumn(ActionButton):
     """
     A column showing a delete button
     """
 
     template_name = "columns/delete.html"
-    orderable = False
-    exclude_from_export = True
-    verbose_name = ""
-    attrs = {"td": {"style": "width:1%;"}}
 
 
-class EditColumn(CustomTemplateColumn):
+class EditColumn(ActionButton):
     """
     A column showing an edit button
     """
 
     template_name = "columns/edit.html"
-    orderable = False
-    exclude_from_export = True
-    verbose_name = ""
-    attrs = {"td": {"style": "width:1%;"}}
 
 
-class ViewColumn(CustomTemplateColumn):
+class ViewColumn(ActionButton):
     """
     A column showing a view button
     """
 
     template_name = "columns/view.html"
-    orderable = False
-    exclude_from_export = True
-    verbose_name = ""
-    attrs = {"td": {"style": "width:1%;"}}
+
+
+class DuplicateColumn(ActionButton):
+    """
+    A column showing a duplicate button
+    """
+
+    template_name = "columns/duplicate.html"
 
 
 class DescriptionColumn(CustomTemplateColumn):
@@ -81,6 +84,7 @@ class GenericTable(tables.Table):
     desc = DescriptionColumn()
     delete = DeleteColumn()
     view = ViewColumn()
+    duplicate = DuplicateColumn()
 
     class Meta:
         fields = ["id", "desc"]
@@ -88,7 +92,7 @@ class GenericTable(tables.Table):
     def __init__(self, *args, **kwargs):
         # if there is no custom sequence set, move `edit` and `delete` to the back
         if "sequence" not in kwargs:
-            kwargs["sequence"] = ["...", "view", "edit", "delete"]
+            kwargs["sequence"] = ["...", "view", "edit", "delete", "duplicate"]
 
         super().__init__(*args, **kwargs)
 
@@ -100,3 +104,7 @@ class GenericTable(tables.Table):
                 self.columns.hide("edit")
             if not request.user.has_perm(permission_fullname("view", model)):
                 self.columns.hide("view")
+            if not request.user.has_perm(permission_fullname("add", model)):
+                self.columns.hide("duplicate")
+            if not hasattr(model, "duplicate"):
+                self.columns.hide("duplicate")

--- a/apis_core/generic/templates/columns/duplicate.html
+++ b/apis_core/generic/templates/columns/duplicate.html
@@ -1,0 +1,4 @@
+{% load apisgeneric %}
+<a title="duplicate"
+   href="{% url 'apis_core:generic:duplicate' record|contenttype record.id %}"
+   style="color: blueviolet"><span class="material-symbols-outlined">content_copy</span></a>

--- a/apis_core/generic/urls.py
+++ b/apis_core/generic/urls.py
@@ -40,6 +40,7 @@ urlpatterns = [
                 path("create", views.Create.as_view(), name="create"),
                 path("delete/<int:pk>", views.Delete.as_view(), name="delete"),
                 path("update/<int:pk>", views.Update.as_view(), name="update"),
+                path("duplicate/<int:pk>", views.Duplicate.as_view(), name="duplicate"),
                 path("autocomplete", views.Autocomplete.as_view(), name="autocomplete"),
                 path("import", views.Import.as_view(), name="import"),
                 path(


### PR DESCRIPTION
This commit introduces a `duplicate` view in the generic app, which
simply calls the `duplicate()` method of the requested object and
redirects to the `Update` view of the created object.
We also introduce a `duplicate` button in the listview table, that is
only shown if the user has the permission to create the listed object
and if the object has the `duplicate()` method.

Closes: #586
