### PR TITLE
fix: exclude `metadata` field from legacy api viewset stuff

### DIFF
--- a/apis_core/api_routers.py
+++ b/apis_core/api_routers.py
@@ -169,6 +169,7 @@ def generic_serializer_creation_factory():
         "parent_class",
         "entity",
         "autofield",
+        "metadata",
     ]
     for cont in lst_cont:
         prefetch_rel = []


### PR DESCRIPTION
`metadata` is a JSONField, which leads to errors - we have to fix. This
is a hardcoded variable, but we have to throw away that whole
api_routers stuff anyway.
