### PR TITLE
fix: let the autocomplete form create objects

### DIFF
--- a/apis_core/generic/forms/fields.py
+++ b/apis_core/generic/forms/fields.py
@@ -1,27 +1,10 @@
 from django.forms import ModelChoiceField
-from django.core.exceptions import ValidationError
-from apis_core.generic.helpers import first_match_via_mro
-from apis_core.apis_metainfo.models import Uri
+from apis_core.utils.helpers import create_object_from_uri
 
 
 class ModelImportChoiceField(ModelChoiceField):
     def to_python(self, value):
-        if value.startswith("http"):
-            try:
-                uri = Uri.objects.get(uri=value)
-                return uri.root_object
-            except Uri.DoesNotExist:
-                Importer = first_match_via_mro(
-                    self.queryset.model,
-                    path="importers",
-                    suffix="Importer",
-                )
-                if Importer is not None:
-                    importer = Importer(value, self.queryset.model)
-                    instance = importer.create_instance()
-                    uri = Uri.objects.create(uri=importer.get_uri, root_object=instance)
-                    return instance
-                raise ValidationError(
-                    "Could not find an importer for: %(url)s", params={"url": value}
-                )
+        result = create_object_from_uri(value, self.queryset.model)
+        if result is not None:
+            return result
         return super().to_python(value)

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -20,6 +20,7 @@ from .helpers import (
     generate_search_filter,
     permission_fullname,
 )
+from apis_core.utils.helpers import create_object_from_uri
 
 from apis_core.core.mixins import ListViewObjectFilterMixin
 
@@ -210,6 +211,7 @@ class Autocomplete(
     """
 
     permission_action_required = "view"
+    create_field = "thisisnotimportant"  # because we are using create_object_from_uri
 
     def get_queryset(self):
         queryset = first_match_via_mro(
@@ -228,6 +230,9 @@ class Autocomplete(
         if ExternalAutocomplete:
             results.extend(ExternalAutocomplete().get_results(self.q))
         return results
+
+    def create_object(self, value):
+        return create_object_from_uri(value, self.queryset.model)
 
 
 class Import(GenericModelMixin, PermissionRequiredMixin, FormView):


### PR DESCRIPTION
This commit moves the logic of creating a model instance from an URI to
`apis_core.utils.helpers.create_object_from_uri`. This way it can be
reused - and this is exactly what we do in the
`apis_core.generic.views.Autocomplete` view. This view can now create
objects by receiving a POST with a value - it uses
`create_object_from_uri` to do this.

The ModelImportChoiceField now also uses this method to create the
object.
