### PR TITLE
Add add-to-project.yml workflow based on prosnet-workflows template

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 K Kollmann
+# SPDX-License-Identifier: MIT
+
+name: Add repository issues to Prosnet project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    uses: acdh-oeaw/prosnet-workflows/.github/workflows/add-to-project.yml@v0.4.0
+    secrets:
+      ADD_TO_PROJECT_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+    with:
+      PROJECT_NUM: 5


### PR DESCRIPTION
I'm actually not _entirely_ sure if GitHub really differentiates between strings and numbers in action variables, so left the `PROJECT_NUM` setting as-is and set the `GH_PROJECT_NUM` var. :eyes: 