### PR TITLE
refactor(utils): split up rdf import sparqlfiles and move them

### DIFF
--- a/apis_core/apis_entities/rdfimport/InstitutionFromDNB.toml
+++ b/apis_core/apis_entities/rdfimport/InstitutionFromDNB.toml
@@ -1,0 +1,56 @@
+##############################################
+# Create an entity `apis_ontology.Institution`
+# from a d-nb.info RDF endpoint
+##############################################
+model = "apis_ontology.Institution"
+filter_sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+ASK {
+  ?subject gndo:preferredNameForTheCorporateBody ?object .
+}
+"""
+[[attributes]]
+# name
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?name
+WHERE {
+  ?subject gndo:preferredNameForTheCorporateBody ?name
+}
+"""
+[[attributes]]
+# altName
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?altName
+WHERE {
+  ?subject gndo:variantNameForTheCorporateBody ?altName
+}
+"""
+[[attributes]]
+# place
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?place
+WHERE {
+  ?subject gndo:placeOfBusiness ?place
+}
+"""
+[[attributes]]
+# start_date_written
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?start_date_written
+WHERE {
+  ?subject gndo:dateOfEstablishment ?start_date_written
+}
+"""
+[[attributes]]
+# end_date_written
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?end_date_written
+WHERE {
+  ?subject gndo:dateOfTermination ?end_date_written
+}
+"""

--- a/apis_core/apis_entities/rdfimport/PersonFromDNB.toml
+++ b/apis_core/apis_entities/rdfimport/PersonFromDNB.toml
@@ -1,0 +1,66 @@
+#########################################
+# Create an entity `apis_ontology.Person`
+# from a d-nb.info RDF endpoint
+#########################################
+model = "apis_ontology.Person"
+filter_sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+ASK {
+  ?subject gndo:preferredNameForThePerson ?object .
+}
+"""
+[[attributes]]
+# name
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?name
+WHERE {
+  ?subject gndo:preferredNameForThePerson ?name .
+  OPTIONAL {
+    ?subject gndo:preferredNameEntityForThePerson ?med .
+    ?med gndo:forename ?first_name.
+    ?med gndo:surname ?name2 .
+    BIND(?name2 as ?name)
+  }
+  BIND(CONCAT(?name, ",", ?first_name) AS ?name)
+}
+"""
+[[attributes]]
+# profession
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?profession
+WHERE {
+  ?subject gndo:professionOrOccupation ?profession
+}
+"""
+[[attributes]]
+# date_of_birth
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?date_of_birth
+WHERE {
+  ?subject gndo:dateOfBirth ?start_date_written
+  BIND(?start_date_written AS ?date_of_birth)
+}
+"""
+[[attributes]]
+# date_of_death
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?date_of_death
+WHERE {
+  ?subject gndo:dateOfDeath ?end_date_written
+  BIND(?end_date_written AS ?date_of_death)
+}
+"""
+[[attributes]]
+# place_of_birth
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?place_of_birth
+WHERE {
+  ?subject gndo:placeOfBirth ?place_of_birth
+}
+"""
+

--- a/apis_core/apis_entities/rdfimport/PlaceFromDNB.toml
+++ b/apis_core/apis_entities/rdfimport/PlaceFromDNB.toml
@@ -1,0 +1,43 @@
+#########################################
+# Create an entity `apis_ontology.Place`
+# from a d-nb.info RDF endpoint
+#########################################
+model = "apis_ontology.Place"
+filter_sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+ASK {
+  ?subject gndo:preferredNameForThePlaceOrGeographicName ?object .
+}
+"""
+[[attributes]]
+# name
+sparql = """
+PREFIX gndo: <https://d-nb.info/standards/elementset/gnd#>
+SELECT ?name
+WHERE {
+  ?subject gndo:preferredNameForThePlaceOrGeographicName ?prefName
+  BIND(?prefName AS ?name)
+}
+"""
+[[attributes]]
+# lon
+sparql = '''
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+SELECT ?lon
+WHERE {
+  ?subject geo:hasGeometry ?geo1 .
+  ?geo1 geo:asWKT ?point .
+  BIND(REPLACE(str(?point), "Point \\( \\+(\\d+.\\d+).*", "$1") as ?lon)
+  }
+'''
+[[attributes]]
+# lat
+sparql = '''
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+SELECT ?lat
+WHERE {
+  ?subject geo:hasGeometry ?geo1 .
+  ?geo1 geo:asWKT ?point .
+  BIND(REPLACE(str(?point), "Point \\( \\+(\\d+.\\d+) \\+(\\d+.\\d+) .$", "$2") as ?lat)
+  }
+'''

--- a/apis_core/apis_entities/rdfimport/PlaceFromGeonames.toml
+++ b/apis_core/apis_entities/rdfimport/PlaceFromGeonames.toml
@@ -1,0 +1,74 @@
+#########################################
+# Create an entity `apis_ontology.Place`
+# from a geonames RDF endpoint
+##########################################
+model = "apis_ontology.Place"
+filter_sparql = """
+PREFIX gn: <http://www.geonames.org/ontology#>
+ASK {
+  ?subject gn:featureClass <https://www.geonames.org/ontology#P> .
+  ?subject gn:featureCode <https://www.geonames.org/ontology#P.PPL> .
+}
+"""
+[[attributes]]
+# name
+sparql = """
+PREFIX gn: <http://www.geonames.org/ontology#>
+SELECT ?name
+WHERE
+{
+  ?subject gn:name|gn:officialName|gn:alternateName ?prefName
+  FILTER (LANGMATCHES(LANG(?prefName), "de") || LANGMATCHES(LANG(?prefName), "en") || LANG(?prefName) = "")
+  BIND(?prefName AS ?name)
+}
+ORDER BY ?lang
+"""
+[[attributes]]
+# alternative_label
+sparql = """
+PREFIX gn: <http://www.geonames.org/ontology#>
+SELECT ?altName (LANG(?altName) AS ?lang)
+WHERE {
+  ?subject gn:alternateName ?altName
+  FILTER (LANGMATCHES(LANG(?altName), "de") || LANGMATCHES(LANG(?altName), "en") || LANG(?prefName) = "")
+}
+"""
+[[attributes]]
+# kind
+sparql = """
+PREFIX gn: <http://www.geonames.org/ontology#>
+SELECT ?kind
+WHERE {
+  ?subject gn:featureCode ?kind
+}
+"""
+[[attributes]]
+# lat
+sparql = """
+PREFIX wgs84_pos: <http://www.w3.org/2003/01/geo/wgs84_pos#>
+SELECT ?lat
+WHERE {
+  ?subject wgs84_pos:lat ?lat.
+  ?subject wgs84_pos:long ?long
+}
+"""
+[[attributes]]
+# long
+sparql = """
+PREFIX wgs84_pos: <http://www.w3.org/2003/01/geo/wgs84_pos#>
+SELECT ?long
+WHERE {
+  ?subject wgs84_pos:lat ?lat.
+  ?subject wgs84_pos:long ?long
+}
+"""
+[[attributes]]
+# parent
+sparql = """
+PREFIX gn: <http://www.geonames.org/ontology#>
+SELECT ?parent
+WHERE {
+  ?subject gn:parentCountry ?parent
+}
+"""
+

--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -198,16 +198,18 @@ class Uri(models.Model):
         self.uri = clean_uri(self.uri)
         if self.uri and not hasattr(self, "root_object"):
             try:
-                model, attributes = rdf.get_modelname_and_dict_from_uri(self.uri)
-                if model and attributes:
-                    app_label, model = model.split(".", 1)
+                definition, attributes = rdf.get_definition_and_attributes_from_uri(
+                    self.uri
+                )
+                if definition.getattr("model", False) and attributes:
+                    app_label, model = definition.getattr("model").split(".", 1)
                     ct = ContentType.objects.get_by_natural_key(app_label, model)
                     obj = ct.model_class()(**attributes)
                     obj.save()
                     self.root_object = obj
                 else:
                     raise ImproperlyConfigured(
-                        f"{self.uri}: found model <{model}> and attributes <{attributes}>"
+                        f"{self.uri}: did not find matching rdf defintion"
                     )
             except Exception as e:
                 raise ValidationError(f"{e}: {self.uri}")

--- a/apis_core/utils/settings.py
+++ b/apis_core/utils/settings.py
@@ -17,12 +17,6 @@ def clean_uri_mapping_file() -> Path:
     return Path(mapping_file)
 
 
-def rdf_object_mapping_file() -> Path:
-    default = default_settings() / "RDF_default_settings.toml"
-    mapping_file = getattr(settings, "APIS_RDF_YAML_SETTINGS", default)
-    return Path(mapping_file)
-
-
 def get_entity_settings_by_modelname(entity: str = None) -> dict:
     """
     return the settings for a specific entity or the dict for all entities

--- a/apis_core/utils/test_rdf.py
+++ b/apis_core/utils/test_rdf.py
@@ -13,7 +13,7 @@ testdata = Path(__file__).parent / "testdata"
 
 
 class RdfTest(TestCase):
-    def test_get_modelname_from_dict_place_from_geonames(self):
+    def test_get_definition_from_dict_place_from_geonames(self):
         achensee = {
             "kind": "https://www.geonames.org/ontology#P.PPL",
             "lat": "47.5",
@@ -23,19 +23,19 @@ class RdfTest(TestCase):
         }
         # https://www.geonames.org/2783029/achensee.html
         uri = str(testdata / "achensee.rdf")
-        modelname, attributes = rdf.get_modelname_and_dict_from_uri(uri)
-        self.assertEqual(modelname, "apis_ontology.Place")
+        defintion, attributes = rdf.get_definition_and_attributes_from_uri(uri)
+        self.assertEqual(defintion["model"], "apis_ontology.Place")
         self.assertEqual(achensee, attributes)
 
-    def test_get_modelname_from_dict_place_from_dnb(self):
+    def test_get_definition_from_dict_place_from_dnb(self):
         wien = {"name": "Wien", "lat": "048.208199", "lon": "016.371690"}
         # https://d-nb.info/gnd/4066009-6
         uri = str(testdata / "wien.rdf")
-        modelname, attributes = rdf.get_modelname_and_dict_from_uri(uri)
-        self.assertEqual(modelname, "apis_ontology.Place")
+        defintion, attributes = rdf.get_definition_and_attributes_from_uri(uri)
+        self.assertEqual(defintion["model"], "apis_ontology.Place")
         self.assertEqual(wien, attributes)
 
-    def test_get_modelname_from_dict_person_from_dnb(self):
+    def test_get_definition_from_dict_person_from_dnb(self):
         pierre = {
             "name": "Ramus,Pierre",
             "profession": "https://d-nb.info/gnd/4053309-8",
@@ -45,11 +45,11 @@ class RdfTest(TestCase):
         }
         # https://d-nb.info/gnd/118833197
         uri = str(testdata / "ramus.rdf")
-        modelname, attributes = rdf.get_modelname_and_dict_from_uri(uri)
-        self.assertEqual(modelname, "apis_ontology.Person")
+        defintion, attributes = rdf.get_definition_and_attributes_from_uri(uri)
+        self.assertEqual(defintion["model"], "apis_ontology.Person")
         self.assertEqual(pierre, attributes)
 
-    def test_get_modelname_from_dict_institution_from_dnb(self):
+    def test_get_definition_from_dict_institution_from_dnb(self):
         pierre_ges = {
             "name": "Pierre-Ramus-Gesellschaft",
             "altName": "Pierre Ramus-Gesellschaft",
@@ -57,11 +57,11 @@ class RdfTest(TestCase):
         }
         # https://d-nb.info/gnd/415006-5
         uri = str(testdata / "ramus_gesellschaft.rdf")
-        modelname, attributes = rdf.get_modelname_and_dict_from_uri(uri)
-        self.assertEqual(modelname, "apis_ontology.Institution")
+        defintion, attributes = rdf.get_definition_and_attributes_from_uri(uri)
+        self.assertEqual(defintion["model"], "apis_ontology.Institution")
         self.assertEqual(pierre_ges, attributes)
 
-    def test_get_modelname_from_dict_institution_from_dnb2(self):
+    def test_get_definition_from_dict_institution_from_dnb2(self):
         pierre_ges = {
             "name": "Akademie der Wissenschaften in Wien",
             "altName": "Akademie der Wissenschaften (Wien)",
@@ -71,6 +71,6 @@ class RdfTest(TestCase):
         }
         # https://d-nb.info/gnd/35077-1
         uri = str(testdata / "oeaw.rdf")
-        modelname, attributes = rdf.get_modelname_and_dict_from_uri(uri)
-        self.assertEqual(modelname, "apis_ontology.Institution")
+        defintion, attributes = rdf.get_definition_and_attributes_from_uri(uri)
+        self.assertEqual(defintion["model"], "apis_ontology.Institution")
         self.assertEqual(pierre_ges, attributes)


### PR DESCRIPTION
The sparql files now reside in `apis_entities/rdfimport` and the list of
sparqlfiles can be extended, resp. the existing ones overridden, by
putting `.toml` files in any `rdfimport` folder of a Djang app.

The function for parsing the RDF endpoint was renamed to
`get_defintion_and_attributes_from_uri`. Given the new logic to iterate
through the app `rdfimport` folders, it does not use the
`APIS_RDF_YAML_SETTINGS` setting anymore, which was therefore dropped
(together with the corresponding function from `utils.settins`)

Closes: #603 