### PR TITLE
feat: add collection name as css class to collection templates

### DIFF
--- a/apis_core/collections/templates/collections/collection_object_parent.html
+++ b/apis_core/collections/templates/collections/collection_object_parent.html
@@ -2,7 +2,7 @@
   <a href="{% url "collectionobjectparent" content_type.id object.id collectionobject.id %}?to={{ request.get_full_path }}"
      hx-get="{% url "collectionobjectparent" content_type.id object.id collectionobject.id %}"
      hx-swap="outerHTML"
-     class="btn btn-sm btn-outline-dark"
+     class="btn btn-sm btn-outline-dark col-{{ collectionobject.collection.name|slugify }}"
      title="Click to change to {{ collectionobject.collection.parent }}"
      hx-confirm="Change {{ object }} from {{ collectionobject.collection }} to {{ collectionobject.collection.parent }}?">{{ collectionobject.collection }}</a>
 {% else %}

--- a/apis_core/collections/templates/collections/collection_toggle.html
+++ b/apis_core/collections/templates/collections/collection_toggle.html
@@ -1,3 +1,3 @@
 <a href="{% url "collectiontoggle" content_type.id object.id collection.id %}?to={{ request.get_full_path }}" hx-get="{% url "collectiontoggle" content_type.id object.id collection.id %}" hx-swap="outerHTML" class="btn btn-sm 
   {% if exists %}btn-success{% else %}btn-outline-secondary{% endif %}
- ">{{ collection.name }}</a>
+ col-{{ collection.name|slugify }}">{{ collection.name }}</a>


### PR DESCRIPTION
That way we can style using css files without overriding the whole
template.

Closes: #604
