### PR TITLE
fix: don't rely on APIS_BASE_URI for editing relations

### DIFF
--- a/apis_core/apis_relations/forms.py
+++ b/apis_core/apis_relations/forms.py
@@ -134,9 +134,6 @@ class GenericTripleForm(forms.ModelForm):
             str(
                 Uri.objects.filter(
                     root_object=entity_instance_other,
-                    uri__startswith=getattr(
-                        settings, "APIS_BASE_URI", "http://apis.info/"
-                    ),
                 ).first()
             ),
             f"<span ><small>db</small> {str(entity_instance_other)}</span>",


### PR DESCRIPTION
The form for editing relations loads the form and sets the
`other_entity` value to the URI of the other entity. For that it checked
if the URI startswith APIS_BASE_URI - which does not work if the
APIS_BASE_URI is not set. But it doesn't make any sense to make that
`startwith` check. Any URI in the list of URIs should work.
