### PR TITLE
feat(generic): display foreign key fields as value instead of id

### DIFF
--- a/apis_core/generic/templatetags/apisgeneric.py
+++ b/apis_core/generic/templatetags/apisgeneric.py
@@ -25,6 +25,8 @@ def modeldict(instance, fields=None, exclude=None):
             continue
         field = instance._meta.get_field(f.name)
         data[field] = instance._get_FIELD_display(field)
+        if getattr(field, "remote_field", False):
+            data[field] = getattr(instance, field.name)
         if getattr(field, "m2m_field_name", False):
             values = getattr(instance, field.name).all()
             data[field] = ", ".join([str(value) for value in values])


### PR DESCRIPTION
The `modeldict` method tries to "do the right thing" when it comes to
displaying attribute values of models. When there is a foreign key, the
method should replace the ID with the value of the model instance it
points to.
