### PR TITLE
fix(apis_metainfo): set the `alters_data` attribute of duplicate

### DIFF
--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -85,6 +85,8 @@ class RootObject(models.Model):
         signals.post_duplicate.send(sender=origin, instance=self, duplicate=duplicate)
         return duplicate
 
+    duplicate.alters_data = True
+
 
 @reversion.register()
 class Collection(models.Model):


### PR DESCRIPTION
This is used to signal that this method does not only return a value,
but does indeed modify data (in this case create new model instances).
