### PR TITLE
fix(apis_entities): hide duplicate button on missing permission

### DIFF
--- a/apis_core/apis_entities/tables.py
+++ b/apis_core/apis_entities/tables.py
@@ -1,3 +1,4 @@
+from apis_core.generic.helpers import permission_fullname
 from apis_core.generic.tables import GenericTable, ActionColumn
 
 
@@ -14,3 +15,9 @@ class AbstractEntityTable(GenericTable):
 
     class Meta(GenericTable.Meta):
         sequence = ("...", "view", "edit", "noduplicate", "delete")
+
+    def before_render(self, request):
+        super().before_render(request)
+        if model := getattr(self.Meta, "model"):
+            if not request.user.has_perm(permission_fullname("create", model)):
+                self.columns.hide("noduplicate")


### PR DESCRIPTION
If the user does not have the `create` permission, which is required to
duplicate an entity, we hide the button.
