### PR TITLE
fix(generic,core): move htmx setup from generic template to base.html

### DIFF
--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -249,6 +249,14 @@
       <script type="text/javascript"
               src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.13.1/js/bootstrap-select.min.js"></script>
       <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+      <script>
+        document.body.addEventListener('htmx:beforeSwap', function(event) {
+          if (event.detail.xhr.status === 204) {
+            // Swap content even when the response is empty.
+            event.detail.shouldSwap = true;
+          }
+        });
+      </script>
     {% endblock %}
 
     {% block scripts2 %}

--- a/apis_core/generic/templates/generic/generic_list.html
+++ b/apis_core/generic/templates/generic/generic_list.html
@@ -4,18 +4,6 @@
 {% load apisgeneric %}
 {% load apiscore %}
 
-{% block scripts %}
-  {{ block.super }}
-  <script>
-document.body.addEventListener('htmx:beforeSwap', function(event) {
-  if (event.detail.xhr.status === 204) {
-    // Swap content even when the response is empty.
-    event.detail.shouldSwap = true;
-  }
-});
-  </script>
-{% endblock scripts %}
-
 {% if filter %}
 
   {% block col %}


### PR DESCRIPTION
This setting allows htmx to act on responses that are empty, like the
ones it gets when it sends a DELETE to the API. That is something we
want to use in multiple places in APIS, not only in the generic app.
