### PR TITLE
refactor(generic): improve action buttons

### DIFF
--- a/apis_core/apis_entities/static/columns/actions.css
+++ b/apis_core/apis_entities/static/columns/actions.css
@@ -1,0 +1,27 @@
+.action-container {
+  line-height: 0;
+  width: 0;
+  min-width: fit-content;
+  height: 0;
+  min-height: fit-content;
+}
+
+.action-container span:hover {
+  color: black;
+}
+
+.action-delete {
+  color: #982530;
+}
+
+.action-view {
+  color: #004fa3;
+}
+
+.action-edit {
+  color: #664d03;
+}
+
+.action-duplicate {
+  color: #165d27;
+}

--- a/apis_core/apis_entities/templates/columns/duplicate.html
+++ b/apis_core/apis_entities/templates/columns/duplicate.html
@@ -2,5 +2,8 @@
 {% with record|opts as opts %}
   <a title="duplicate"
      href="{% url 'apis_core:apis_entities:generic_entities_duplicate_view' opts.verbose_name record.id %}"
-     style="color: blueviolet"><span class="material-symbols-outlined">content_copy</span></a>
+     class="action-duplicate d-inline-block">
+    <span class="material-symbols-outlined" role="img" aria-hidden="true">content_copy</span>
+    <span class="sr-only">duplicate</span>
+  </a>
 {% endwith %}

--- a/apis_core/generic/static/columns/actions.css
+++ b/apis_core/generic/static/columns/actions.css
@@ -1,0 +1,23 @@
+.action-container {
+  line-height: 0;
+  width: 0;
+  min-width: fit-content;
+  height: 0;
+  min-height: fit-content;
+}
+
+.action-container span:hover {
+  color: black;
+}
+
+.action-delete {
+  color: #982530;
+}
+
+.action-view {
+  color: #004fa3;
+}
+
+.action-edit {
+  color: #664d03;
+}

--- a/apis_core/generic/tables.py
+++ b/apis_core/generic/tables.py
@@ -35,7 +35,7 @@ class ActionColumn(CustomTemplateColumn):
     orderable = False
     exclude_from_export = True
     verbose_name = ""
-    attrs = {"td": {"style": "width:1%;"}}
+    attrs = {"td": {"class": "action-container"}}
 
 
 class DeleteColumn(ActionColumn):

--- a/apis_core/generic/templates/columns/delete.html
+++ b/apis_core/generic/templates/columns/delete.html
@@ -1,8 +1,11 @@
 {% load apisgeneric %}
 <a title="delete"
-   hx-delete="{% url "apis_core:generic:genericmodelapi-detail" record|contenttype record.id %}"
+   hx-delete="{% url 'apis_core:generic:genericmodelapi-detail' record|contenttype record.id %}"
    hx-confirm="Are your sure you want to delete {{ record }}?"
    hx-target="closest tr"
    hx-swap="outerHTML swap:0.3s"
    href="{% url 'apis_core:generic:delete' record|contenttype record.id %}"
-   class="text-danger"><span class="material-symbols-outlined">delete</span></a>
+   class="action-delete d-inline-block">
+  <span class="material-symbols-outlined" role="img" aria-hidden="true">delete</span>
+  <span class="sr-only">delete</span>
+</a>

--- a/apis_core/generic/templates/columns/edit.html
+++ b/apis_core/generic/templates/columns/edit.html
@@ -1,4 +1,7 @@
 {% load apisgeneric %}
 <a title="edit"
    href="{% url 'apis_core:generic:update' record|contenttype record.id %}"
-   class="text-warning"><span class="material-symbols-outlined">edit</span></a>
+   class="action-edit d-inline-block">
+  <span class="material-symbols-outlined" role="img" aria-hidden="true">edit</span>
+  <span class="sr-only">edit</span>
+</a>

--- a/apis_core/generic/templates/columns/view.html
+++ b/apis_core/generic/templates/columns/view.html
@@ -1,4 +1,7 @@
 {% load apisgeneric %}
 <a title="view"
    href="{% url 'apis_core:generic:detail' record|contenttype record.id %}"
-   class="text-success"><span class="material-symbols-outlined">visibility</span></a>
+   class="action-view d-inline-block">
+  <span class="material-symbols-outlined" role="img" aria-hidden="true">visibility</span>
+  <span class="sr-only">view</span>
+</a>

--- a/apis_core/generic/templates/generic/generic_content.html
+++ b/apis_core/generic/templates/generic/generic_content.html
@@ -1,4 +1,5 @@
 {% extends basetemplate|default:"base.html" %}
+{% load static %}
 
 {% block content %}
   <div class="container-fluid">
@@ -16,3 +17,8 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block styles %}
+  {% include "partials/bootstrap4_css.html" %}
+  <link rel="stylesheet" href="{% static 'columns/actions.css' %} " />
+{% endblock styles %}


### PR DESCRIPTION
This is a first attempt at improving the action buttons. Can be split into smaller PRs if that's better.

What this currently does is:

- replace hardcoded CSS for relevant elements (`a`, `td`) with classes to allow easier overriding,
- change how the icons (and alternative text) are integrated into the button links -> accessibility; makes buttons tabbable ~~like all other links~~ more nicely,
- change the colour scheme to make more logical sense -> use regular link colour for "view" button because it's the most neutral (it doesn't "do" anything); switch "duplicate" button in `apis_entities` to green because it actually adds new content,
- adapt color of buttons for accessibility -> use colour contrast that is WCAG AAA compliant.

If we offered a way to switch the accessibility level of the APIS interface (haven't seen them in a while, but know that gov websites used to have e.g. buttons labelled "AA", "AAA"), the "duller" looking colours could be kept in separate stylesheets. I'm actually assuming there _are_ projects which have to fulfil certain accessibility criteria due to how they are funded (?!), so I'm wondering if we shouldn't actually develop for accessibility out of the box.