### PR TITLE
fix(apis_entities): use `modelname` instead of `verbose_name`

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
@@ -1,39 +1,41 @@
 {% load apiscore %}
 {% with object|opts as opts %}
-  {% with opts.app_label|add:"."|add:opts.verbose_name|add:"_create" as object_create_perm %}
-    {% with opts.app_label|add:"."|add:opts.verbose_name|add:"_delete" as object_delete_perm %}
+  {% with opts.object_name|lower as modelname %}
+    {% with opts.app_label|add:"."|add:modelname|add:"_create" as object_create_perm %}
+      {% with opts.app_label|add:"."|add:modelname|add:"_delete" as object_delete_perm %}
 
-      {% if object_delete_perm in perms or object_create_perm in perms %}
-        <ul class="nav nav-tabs card-header-tabs float-right">
-          <li class="nav-item">
-            <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">Actions</a>
-            <div class="dropdown-menu">
+        {% if object_delete_perm in perms or object_create_perm in perms %}
+          <ul class="nav nav-tabs card-header-tabs float-right">
+            <li class="nav-item">
+              <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#">Actions</a>
+              <div class="dropdown-menu">
 
-              {% if object_delete_perm in perms %}
-                <a class="dropdown-item text-danger"
-                   href="{% url "apis_core:apis_entities:generic_entities_delete_view" opts.verbose_name object.id %}">
-                  <span class="material-symbols-outlined material-symbols-align">delete</span> Delete
-                </a>
-              {% endif %}
+                {% if object_delete_perm in perms %}
+                  <a class="dropdown-item text-danger"
+                     href="{% url "apis_core:apis_entities:generic_entities_delete_view" modelname object.id %}">
+                    <span class="material-symbols-outlined material-symbols-align">delete</span> Delete
+                  </a>
+                {% endif %}
 
-              {% if object_create_perm in perms %}
-                <a class="dropdown-item"
-                   style="color: blueviolet"
-                   href="{% url "apis_core:apis_entities:generic_entities_duplicate_view" opts.verbose_name object.id %}">
-                  <span class="material-symbols-outlined material-symbols-align">content_copy</span> Duplicate
-                </a>
-                <a class="dropdown-item"
-                   style="color: dodgerblue"
-                   href="{% url "apis_core:apis_entities:generic_entities_merge_view" opts.verbose_name object.id %}">
-                  <span class="material-symbols-outlined material-symbols-align">cell_merge</span> Merge
-                </a>
-              {% endif %}
+                {% if object_create_perm in perms %}
+                  <a class="dropdown-item"
+                     style="color: blueviolet"
+                     href="{% url "apis_core:apis_entities:generic_entities_duplicate_view" modelname object.id %}">
+                    <span class="material-symbols-outlined material-symbols-align">content_copy</span> Duplicate
+                  </a>
+                  <a class="dropdown-item"
+                     style="color: dodgerblue"
+                     href="{% url "apis_core:apis_entities:generic_entities_merge_view" modelname object.id %}">
+                    <span class="material-symbols-outlined material-symbols-align">cell_merge</span> Merge
+                  </a>
+                {% endif %}
 
-            </div>
-          </li>
-        </ul>
-      {% endif %}
+              </div>
+            </li>
+          </ul>
+        {% endif %}
 
+      {% endwith %}
     {% endwith %}
   {% endwith %}
 {% endwith %}

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
@@ -1,23 +1,25 @@
 {% load apiscore %}
 {% with object|opts as opts %}
-  {% with opts.app_label|add:"."|add:opts.verbose_name|add:"_change" as object_change_perm %}
-    {% url "apis_core:apis_entities:generic_entities_detail_view" opts.verbose_name object.id as detailurl %}
-    {% url "apis_core:apis_entities:generic_entities_edit_view" opts.verbose_name object.id as editurl %}
+  {% with opts.object_name|lower as modelname %}
+    {% with opts.app_label|add:"."|add:modelname|add:"_change" as object_change_perm %}
+      {% url "apis_core:apis_entities:generic_entities_detail_view" modelname object.id as detailurl %}
+      {% url "apis_core:apis_entities:generic_entities_edit_view" modelname object.id as editurl %}
 
-    {% if object_change_perm in perms %}
-      <ul class="nav nav-tabs card-header-tabs float-left">
-        <li class="nav-item">
-          <a class="nav-link text-success 
-            {% if request.path == detailurl %}active{% endif %}
-           " href="{{ detailurl }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>View</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link text-warning 
-            {% if request.path == editurl %}active{% endif %}
-           " href="{{ editurl }}"><span class="material-symbols-outlined material-symbols-align">edit</span>Edit</a>
-        </li>
-      </ul>
-    {% endif %}
+      {% if object_change_perm in perms %}
+        <ul class="nav nav-tabs card-header-tabs float-left">
+          <li class="nav-item">
+            <a class="nav-link text-success 
+              {% if request.path == detailurl %}active{% endif %}
+             " href="{{ detailurl }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>View</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link text-warning 
+              {% if request.path == editurl %}active{% endif %}
+             " href="{{ editurl }}"><span class="material-symbols-outlined material-symbols-align">edit</span>Edit</a>
+          </li>
+        </ul>
+      {% endif %}
 
+    {% endwith %}
   {% endwith %}
 {% endwith %}


### PR DESCRIPTION
In the actions templates we used `verbose_name` to create the urls that
point to the entity views - but the `verbose_name` is more meant as a
presentation string, than part of an URI. We use the modelname now
instead.
