### PR TITLE
refactor(apis_relations): use name_forward for property where applicable

### DIFF
--- a/apis_core/apis_entities/filtersets.py
+++ b/apis_core/apis_entities/filtersets.py
@@ -23,7 +23,7 @@ ABSTRACT_ENTITY_FILTERS_EXCLUDE = [
 
 
 def related_property(queryset, name, value):
-    p = Property.objects.get(name=value)
+    p = Property.objects.get(name_forward=value)
     queryset = queryset.filter(triple_set_from_subj__prop=p).distinct()
     return queryset
 
@@ -37,7 +37,7 @@ class AbstractEntityFilterSet(GenericFilterSet):
         method=related_entity_name, label="Related entity"
     )
     related_property = django_filters.ModelChoiceFilter(
-        queryset=Property.objects.all().order_by("name"),
+        queryset=Property.objects.all().order_by("name_forward"),
         label="Related Property",
         method=related_property,
     )

--- a/apis_core/apis_relations/forms.py
+++ b/apis_core/apis_relations/forms.py
@@ -97,13 +97,13 @@ class GenericTripleForm(forms.ModelForm):
     ):
         # the more important function here when writing data from an user input via an ajax call into this form.
         # Because here the direction of the property is respected. Hence the subject and object position of the
-        # triple and the property name or name_reverse are loaded correctly here.
+        # triple and the property name_forward or name_reverse are loaded correctly here.
 
         if property_direction == PropertyAutocomplete.SELF_SUBJ_OTHER_OBJ_STR:
 
             triple_subj = entity_instance_self
             triple_obj = entity_instance_other
-            property_direction_name = property_instance.name
+            property_direction_name = property_instance.name_forward
 
         elif property_direction == PropertyAutocomplete.SELF_OBJ_OTHER_SUBJ_STR:
 

--- a/apis_core/apis_relations/management/commands/create_relationships.py
+++ b/apis_core/apis_relations/management/commands/create_relationships.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             #  below msg. purposefully only mentions "labels".
             self.stdout.write("The following labels now exist:")
             for p in props:
-                self.stdout.write(self.style.SUCCESS(f"{p.name}"), ending="")
+                self.stdout.write(self.style.SUCCESS(f"{p.name_forward}"), ending="")
                 self.stdout.write(f" ... {p.name_reverse}")
         else:
             # construct_properties() starts out by deleting all existing

--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -79,15 +79,15 @@ class Property(RootObject):
     )
 
     def __str__(self):
-        return self.name
+        return self.name_forward
 
     def save(self, *args, **kwargs):
         if self.name_reverse != unicodedata.normalize("NFC", self.name_reverse):
             self.name_reverse = unicodedata.normalize("NFC", self.name_reverse)
         if self.name_reverse == "" or self.name_reverse is None:
-            self.name_reverse = self.name + " [REVERSE]"
+            self.name_reverse = self.name_forward + " [REVERSE]"
         # TODO RDF: Temporary hack, remove this once better solution is found
-        self.name_forward = self.name
+        self.name = self.name_forward
         super(Property, self).save(*args, **kwargs)
         return self
 
@@ -264,7 +264,7 @@ class Triple(GenericModel, models.Model):
             "relation_pk": self.pk,
             "subj": self.subj.name,
             "obj": self.obj.name,
-            "prop": self.prop.name,
+            "prop": self.prop.name_forward,
         }
 
     def save(self, *args, **kwargs):

--- a/apis_core/apis_relations/tables.py
+++ b/apis_core/apis_relations/tables.py
@@ -163,7 +163,7 @@ def get_generic_triple_table(other_entity_class_name, entity_pk_self, detail):
                 ),
                 other_prop=Case(
                     # **kwargs pattern is needed here as the key-value pairs change with each relation class and entity instance.
-                    When(**{"subj__pk": entity_pk_self, "then": "prop__name"}),
+                    When(**{"subj__pk": entity_pk_self, "then": "prop__name_forward"}),
                     When(**{"obj__pk": entity_pk_self, "then": "prop__name_reverse"}),
                 ),
             )

--- a/apis_core/utils/caching.py
+++ b/apis_core/utils/caching.py
@@ -204,7 +204,7 @@ def get_autocomplete_property_choices(
         rbc_self_subj_other_obj = Property.objects.filter(
             subj_class=model_self_contenttype,
             obj_class=model_other_contenttype,
-            name__icontains=search_name_str,
+            name_forward__icontains=search_name_str,
         )
         rbc_self_obj_other_subj = Property.objects.filter(
             subj_class=model_other_contenttype,
@@ -228,7 +228,7 @@ def get_autocomplete_property_choices(
                 {
                     # misuse of the id item as explained above
                     "id": f"id:{rbc.pk}__direction:{PropertyAutocomplete.SELF_SUBJ_OTHER_OBJ_STR}",
-                    "text": rbc.name,
+                    "text": rbc.name_forward,
                 }
             )
         for rbc in rbc_self_obj_other_subj:

--- a/apis_core/utils/filtermethods.py
+++ b/apis_core/utils/filtermethods.py
@@ -73,9 +73,9 @@ def related_property_name(queryset, name, value):
     lookup, value = construct_lookup(value)
 
     queryset = queryset.filter(
-        Q(**{f"triple_set_from_obj__prop__name{lookup}": value})
+        Q(**{f"triple_set_from_obj__prop__name_forward{lookup}": value})
         | Q(**{f"triple_set_from_obj__prop__name_reverse{lookup}": value})
-        | Q(**{f"triple_set_from_subj__prop__name{lookup}": value})
+        | Q(**{f"triple_set_from_subj__prop__name_forward{lookup}": value})
         | Q(**{f"triple_set_from_subj__prop__name_reverse{lookup}": value})
     ).distinct()
 


### PR DESCRIPTION
This commit replaces all references to `Property.name` with
`Property.name_forward`, because `.name` will be removed in the near
future.

cherry picked from apis-core-rdf#630 by birger
