### PR TITLE
refactor(apis_metainfo,apis_entities)!: drop __str___ overrides

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -33,12 +33,6 @@ class AbstractEntity(RootObject):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def __str__(self):
-        if self.name != "":
-            return self.name
-        else:
-            return "no name provided"
-
     @classmethod
     def get_or_create_uri(cls, uri):
         uri = str(uri)

--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -46,12 +46,6 @@ class RootObject(GenericModel, models.Model):
             self.self_contenttype = caching.get_contenttype_of_class(self.__class__)
         super().save(*args, **kwargs)
 
-    def __str__(self):
-        if self.name != "":
-            return self.name
-        else:
-            return "no name provided"
-
     def duplicate(self):
         origin = self.__class__
         signals.pre_duplicate.send(sender=origin, instance=self)

--- a/apis_core/apis_metainfo/test_models.py
+++ b/apis_core/apis_metainfo/test_models.py
@@ -11,12 +11,6 @@ class ModelTestCase(TestCase):
         RootObject.objects.create(self_contenttype=user_type, name="foo")
         RootObject.objects.create(self_contenttype=user_type)
 
-    def test_root_object(self):
-        rfoo = RootObject.objects.get(name="foo")
-        rnone = RootObject.objects.get(name="")
-        self.assertEqual(str(rfoo), "foo")
-        self.assertEqual(str(rnone), "no name provided")
-
     def test_uri(self):
         ufoo = Uri.objects.create()
         self.assertEqual(str(ufoo), "None")


### PR DESCRIPTION
The `RootObject` and the `AbstractEntity` models had an override for the
`__str__` method, that referenced the models `.name` field. We are
planning on removing the `.name` field and the `__str__` methods should
be implemented in child classes anyway, so this commit removes the
overrides from `RootObject` and `AbstractEntity`
It also deletes the test, as we are now using Django's default
behaviour.

cherry picked from apis-core-rdf#630 by birger
