### PR TITLE
feat(generic): add generic RDF renderers and serializers

### DIFF
--- a/apis_core/generic/api_views.py
+++ b/apis_core/generic/api_views.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from .serializers import serializer_factory, GenericHyperlinkedModelSerializer
-from .helpers import module_paths, first_member_match
+from .helpers import module_paths, first_member_match, makeclassprefix
 from .filterbackends import GenericFilterBackend
 
 
@@ -31,6 +31,12 @@ class ModelViewSet(viewsets.ModelViewSet):
         serializer_class_modules = module_paths(
             self.model, path="serializers", suffix="Serializer"
         )
+        prefix = makeclassprefix(self.request.accepted_renderer.format)
+        serializer_class_modules = (
+            module_paths(self.model, path="serializers", suffix=f"{prefix}Serializer")
+            + serializer_class_modules
+        )
+
         serializer_class = first_member_match(
             serializer_class_modules,
             getattr(renderer, "serializer", GenericHyperlinkedModelSerializer),

--- a/apis_core/generic/helpers.py
+++ b/apis_core/generic/helpers.py
@@ -78,6 +78,13 @@ def module_paths(model, path: str = "", suffix: str = "") -> list:
 
 
 @functools.lru_cache
+def makeclassprefix(string: str) -> str:
+    string = "".join([c if c.isidentifier() else " " for c in string])
+    string = "".join([word.strip().capitalize() for word in string.split(" ")])
+    return string
+
+
+@functools.lru_cache
 def import_string(dotted_path):
     try:
         return module_loading.import_string(dotted_path)

--- a/apis_core/generic/renderers.py
+++ b/apis_core/generic/renderers.py
@@ -1,0 +1,32 @@
+from rest_framework import renderers
+from rdflib import Graph
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class GenericRDFBaseRenderer(renderers.BaseRenderer):
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        g = Graph()
+        for result in data.get("results", []):
+            match result:
+                case tuple(_, _, _):
+                    g.add(result)
+                case other:
+                    logger.debug("Could not add %s to RDF graph: not a tuple", other)
+        return g.serialize(format=self.media_type)
+
+
+class GenericRDFXMLRenderer(GenericRDFBaseRenderer):
+    media_type = "application/rdf+xml"
+    format = "rdf+xml"
+
+
+class GenericRDFTurtleRenderer(GenericRDFBaseRenderer):
+    media_type = "text/turtle"
+    format = "rdf+turtle"
+
+
+class GenericRDFN3Renderer(GenericRDFBaseRenderer):
+    media_type = "text/n3"
+    format = "rdf+n3"


### PR DESCRIPTION
**feat(generic): allow apiview to use custom serializers & renderers**

The commit configures the generic API view to look for more differently
configured serializers. The serializers can now also be prefixed with
the requested format, as configured in the renderer.

**feat(generic): ship generic RDF renderers**

They can be enabled as described in the upstream DRF framework
documentation:
https://www.django-rest-framework.org/api-guide/renderers/#setting-the-renderers
They expect the renderer to put triples in the data object and they
build the graph based on these triples.

**feat(generic): allow to specify a dialect when requesting data**

If a dialect is either specified via the `dialect` parameter or the
`DIALECT` HTTP header, only renderer that have that dialect listed in
their `.dialects` class attribute are considered.
If no dialect is specified, only renderers that have the `.dialects`
class attribute *not* set or have `None` in the list are considered.