### PR TITLE
fix(utils): make rdfimport parent model check more loose

### DIFF
--- a/apis_core/utils/rdf.py
+++ b/apis_core/utils/rdf.py
@@ -20,7 +20,7 @@ def definition_matches_model(definition: str, model: object) -> bool:
             module, cls = definition.get("superclass").rsplit(".", 1)
             module = importlib.import_module(module)
             parent = getattr(module, cls)
-            if issubclass(type(model), parent):
+            if issubclass(type(model), parent) or issubclass(model, parent):
                 return True
         except Exception as e:
             logger.error("superclass %s led to: %s", definition.get("superclass"), e)


### PR DESCRIPTION
The check was designed to check the type of the passed object is a
sublcass of the superclass, but we usually pass a class and not an
instance, so lets also check the class itself.
