### PR TITLE
fix(apis_entities): don't duplicate equal values when mergin charfield

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -124,11 +124,11 @@ class AbstractEntity(RootObject):
         )
 
     def merge_charfield(self, other, field):
-        print(field)
         res = getattr(self, field.name)
         if not field.choices:
-            if getattr(other, field.name):
-                res += " (" + getattr(other, field.name) + ")"
+            otherres = getattr(other, field.name, res)
+            if otherres != res:
+                res += f" ({otherres})"
         setattr(self, field.name, res)
 
     def merge_textfield(self, other, field):


### PR DESCRIPTION
When merging two charfields, the approach was to concatenate the values.
But this makes only sense if the values differ. So we add a check that
keeps the value as it is, if both values are the same.
