### PR TITLE
refactor(generic): move url methods to GenericModel

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -51,34 +51,15 @@ class AbstractEntity(RootObject):
     def get_entity_list_filter(cls):
         return None
 
-    @classmethod
-    def get_listview_url(self):
-        entity = self.__name__.lower()
-        return reverse(
-            "apis_core:apis_entities:generic_entities_list",
-            kwargs={"contenttype": entity},
-        )
-
-    @classmethod
-    def get_createview_url(self):
-        entity = self.__name__.lower()
-        return reverse(
-            "apis_core:apis_entities:generic_entities_create_view",
-            kwargs={"entity": entity},
-        )
-
     def get_edit_url(self):
-        entity = self.__class__.__name__.lower()
+        """
+        We override the edit url, because entities have a
+        custom view that includes the relations
+        """
+        ct = ContentType.objects.get_for_model(self)
         return reverse(
             "apis_core:apis_entities:generic_entities_edit_view",
-            kwargs={"contenttype": entity, "pk": self.id},
-        )
-
-    def get_absolute_url(self):
-        entity = self.__class__.__name__.lower()
-        return reverse(
-            "apis_core:apis_entities:generic_entities_detail_view",
-            kwargs={"contenttype": entity, "pk": self.id},
+            args=[ct.model, self.id],
         )
 
     def get_prev_url(self):
@@ -108,13 +89,6 @@ class AbstractEntity(RootObject):
             )
         else:
             return False
-
-    def get_delete_url(self):
-        entity = self.__class__.__name__.lower()
-        return reverse(
-            "apis_core:apis_entities:generic_entities_delete_view",
-            kwargs={"contenttype": entity, "pk": self.id},
-        )
 
     def get_duplicate_url(self):
         entity = self.__class__.__name__.lower()

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
@@ -2,20 +2,18 @@
 {% with object|opts as opts %}
   {% with opts.object_name|lower as modelname %}
     {% with opts.app_label|add:"."|add:modelname|add:"_change" as object_change_perm %}
-      {% url "apis_core:apis_entities:generic_entities_detail_view" modelname object.id as detailurl %}
-      {% url "apis_core:apis_entities:generic_entities_edit_view" modelname object.id as editurl %}
 
       {% if object_change_perm in perms %}
         <ul class="nav nav-tabs card-header-tabs float-left">
           <li class="nav-item">
             <a class="nav-link text-success 
-              {% if request.path == detailurl %}active{% endif %}
-             " href="{{ detailurl }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>View</a>
+              {% if request.path == object.get_absolute_url %}active{% endif %}
+             " href="{{ object.get_absolute_url }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>View</a>
           </li>
           <li class="nav-item">
             <a class="nav-link text-warning 
-              {% if request.path == editurl %}active{% endif %}
-             " href="{{ editurl }}"><span class="material-symbols-outlined material-symbols-align">edit</span>Edit</a>
+              {% if request.path == object.get_edit_url %}active{% endif %}
+             " href="{{ object.get_edit_url }}"><span class="material-symbols-outlined material-symbols-align">edit</span>Edit</a>
           </li>
         </ul>
       {% endif %}

--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -5,7 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.forms import model_to_dict
-from django.urls import reverse
 from model_utils.managers import InheritanceManager
 from apis_core.utils.normalize import clean_uri
 from django.core.exceptions import ValidationError, ImproperlyConfigured
@@ -169,23 +168,6 @@ class Uri(GenericModel, models.Model):
             "uri": self.uri,
         }
         return result
-
-    @classmethod
-    def get_listview_url(self):
-        return reverse("apis_core:apis_metainfo:uri_browse")
-
-    @classmethod
-    def get_createview_url(self):
-        return reverse("apis_core:apis_metainfo:uri_create")
-
-    def get_absolute_url(self):
-        return reverse("apis_core:apis_metainfo:uri_detail", kwargs={"pk": self.id})
-
-    def get_delete_url(self):
-        return reverse("apis_core:apis_metainfo:uri_delete", kwargs={"pk": self.id})
-
-    def get_edit_url(self):
-        return reverse("apis_core:apis_metainfo:uri_edit", kwargs={"pk": self.id})
 
     def save(self, *args, **kwargs):
         self.clean()

--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -1,2 +1,26 @@
+from django.urls import reverse
+from django.contrib.contenttypes.models import ContentType
+
+
 class GenericModel:
-    pass
+    @classmethod
+    def get_listview_url(cls):
+        ct = ContentType.objects.get_for_model(cls)
+        return reverse("apis_core:generic:list", args=[ct])
+
+    @classmethod
+    def get_createview_url(cls):
+        ct = ContentType.objects.get_for_model(cls)
+        return reverse("apis_core:generic:create", args=[ct])
+
+    def get_edit_url(self):
+        ct = ContentType.objects.get_for_model(self)
+        return reverse("apis_core:generic:update", args=[ct, self.id])
+
+    def get_absolute_url(self):
+        ct = ContentType.objects.get_for_model(self)
+        return reverse("apis_core:generic:detail", args=[ct, self.id])
+
+    def get_delete_url(self):
+        ct = ContentType.objects.get_for_model(self)
+        return reverse("apis_core:generic:delete", args=[ct, self.id])

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -156,10 +156,7 @@ class Create(GenericModelMixin, PermissionRequiredMixin, CreateView):
         return modelform_factory(self.model, form_class)
 
     def get_success_url(self):
-        return reverse(
-            "apis:generic:update",
-            args=[self.kwargs.get("contenttype"), getattr(self.object, "pk")],
-        )
+        return self.object.get_edit_url()
 
 
 class Delete(GenericModelMixin, PermissionRequiredMixin, DeleteView):
@@ -205,10 +202,7 @@ class Update(GenericModelMixin, PermissionRequiredMixin, UpdateView):
         return modelform_factory(self.model, form_class)
 
     def get_success_url(self):
-        return reverse(
-            "apis:generic:update",
-            args=[self.kwargs.get("contenttype"), getattr(self.object, "pk")],
-        )
+        return self.object.get_edit_url()
 
 
 class Autocomplete(
@@ -272,7 +266,4 @@ class Import(GenericModelMixin, PermissionRequiredMixin, FormView):
         return super().form_valid(form)
 
     def get_success_url(self):
-        return reverse(
-            "apis:generic:detail",
-            args=[self.request.resolver_match.kwargs["contenttype"], self.object.id],
-        )
+        return self.object.get_absolute_url()


### PR DESCRIPTION
We ship generic views with the generic app and those views are activated
for a model that inherits from GenericModel. Therefore we can now also
add methods to GenericModel that return canonical urls for those views.
