### PR TITLE
refactor(utils): use contenttype instead of model name for helper

### DIFF
--- a/apis_core/apis_entities/templatetags/apis_templatetags.py
+++ b/apis_core/apis_entities/templatetags/apis_templatetags.py
@@ -53,6 +53,4 @@ def entities_verbose_name_plural_listview_url():
 @register.simple_tag(takes_context=True)
 def object_relations(context, detail=True):
     obj = context["object"]
-    return triple_sidebar(
-        obj.pk, obj.__class__.__name__.lower(), context["request"], detail
-    )
+    return triple_sidebar(obj, context["request"], detail)

--- a/apis_core/history/templatetags/apis_history_templatetags.py
+++ b/apis_core/history/templatetags/apis_history_templatetags.py
@@ -10,9 +10,7 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def object_relations_history(context, detail=True):
     obj = context["object"]
-    return triple_sidebar_history(
-        obj.pk, obj.__class__.__name__.lower(), context["request"], detail
-    )
+    return triple_sidebar_history(obj, context["request"], detail)
 
 
 @register.filter

--- a/apis_core/history/utils.py
+++ b/apis_core/history/utils.py
@@ -1,52 +1,46 @@
 from apis_core.apis_relations.tables import get_generic_triple_table
-from apis_core.utils.helpers import get_classes_with_allowed_relation_from
+from apis_core.utils.helpers import get_content_types_with_allowed_relation_from
 from apis_core.utils.settings import get_entity_settings_by_modelname
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django_tables2 import RequestConfig
 
 
-def triple_sidebar_history(pk: int, entity_name: str, request, detail=True):
+def triple_sidebar_history(obj: object, request, detail=True):
     side_bar = []
-    entity_name = entity_name.replace("version", "")
 
-    historical_entity = (
-        ContentType.objects.get(model=entity_name)
-        .model_class()
-        .history.get(history_id=pk)
-    )
-    triples_related_all = historical_entity.get_triples_for_version()
-    if historical_entity.version_tag is not None:
+    triples_related_all = obj.get_triples_for_version()
+    if obj.version_tag is not None:
         triples_related_all = triples_related_all.filter(
-            Q(version_tag=historical_entity.version_tag)
-            | Q(version_tag__contains=f"{historical_entity.version_tag},")
+            Q(version_tag=obj.version_tag)
+            | Q(version_tag__contains=f"{obj.version_tag},")
         )
-    pk = historical_entity.instance.pk
-
-    for entity_class in get_classes_with_allowed_relation_from(entity_name):
-        entity_content_type = ContentType.objects.get_for_model(entity_class)
-
-        other_entity_class_name = entity_class.__name__.lower()
-
+    content_type = ContentType.objects.get_for_model(obj.instance_type)
+    for other_content_type in get_content_types_with_allowed_relation_from(
+        content_type
+    ):
         triples_related_by_entity = triples_related_all.filter(
-            (Q(subj__self_contenttype=entity_content_type) & Q(obj__pk=pk))
-            | (Q(obj__self_contenttype=entity_content_type) & Q(subj__pk=pk))
+            (Q(subj__self_contenttype=other_content_type) & Q(obj__pk=obj.instance.pk))
+            | (
+                Q(obj__self_contenttype=other_content_type)
+                & Q(subj__pk=obj.instance.pk)
+            )
         )
 
         table_class = get_generic_triple_table(
-            other_entity_class_name=other_entity_class_name,
-            entity_pk_self=pk,
+            other_entity_class_name=other_content_type.model,
+            entity_pk_self=obj.instance.pk,
             detail=detail,
         )
 
-        prefix = f"{other_entity_class_name}"
-        title_card = prefix
+        prefix = f"{other_content_type.model}"
+        title_card = other_content_type.name
         tb_object = table_class(data=triples_related_by_entity, prefix=prefix)
         tb_object_open = request.GET.get(prefix + "page", None)
-        entity_settings = get_entity_settings_by_modelname(entity_class.__name__)
+        entity_settings = get_entity_settings_by_modelname(content_type.model)
         per_page = entity_settings.get("relations_per_page", 10)
         RequestConfig(request, paginate={"per_page": per_page}).configure(tb_object)
-        tab_id = f"triple_form_{entity_name}_to_{other_entity_class_name}"
+        tab_id = f"triple_form_{content_type.model}_to_{other_content_type.model}"
         side_bar.append(
             (
                 title_card,


### PR DESCRIPTION
The `get_classes_with_allowed_relation_from` method created a list of
possible related models based on the name of one model. It then returned
the names of those models as strings. It makes more sense to simply use
contenttypes instead of model names, especially since the Property model
stores the possible subj and obj classes as ContentTypes.
This commit refactors the method and also updates `triple_sidebar` which
is the only funciton that uses the
`get_classes_with_allowed_relation_from` method.

Closes: #254
