### PR TITLE
fix(generic): select shown columns in column filter

### DIFF
--- a/apis_core/apis_entities/filtersets.py
+++ b/apis_core/apis_entities/filtersets.py
@@ -4,9 +4,12 @@ from apis_core.generic.filtersets import GenericFilterSet, GenericFilterSetForm
 from apis_core.utils.filtermethods import related_entity_name
 from apis_core.apis_relations.models import Property
 
-ABSTRACT_ENTITY_FILTERS_EXCLUDE = [
+ABSTRACT_ENTITY_COLUMNS_EXCLUDE = [
     "rootobject_ptr",
     "self_contenttype",
+]
+
+ABSTRACT_ENTITY_FILTERS_EXCLUDE = ABSTRACT_ENTITY_COLUMNS_EXCLUDE + [
     "review",
     "start_date",
     "start_start_date",
@@ -29,7 +32,7 @@ def related_property(queryset, name, value):
 
 
 class AbstractEntityFilterSetForm(GenericFilterSetForm):
-    columns_exclude = ABSTRACT_ENTITY_FILTERS_EXCLUDE
+    columns_exclude = ABSTRACT_ENTITY_COLUMNS_EXCLUDE
 
 
 class AbstractEntityFilterSet(GenericFilterSet):

--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -1,3 +1,5 @@
+from apis_core.generic.helpers import first_member_match, module_paths
+from apis_core.generic.tables import GenericTable
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -45,6 +47,14 @@ class GenericFilterSetForm(forms.Form):
             for field in model._meta.fields
             if field.name not in self.columns_exclude
         ]
+        if not self.is_bound:
+            table_modules = module_paths(model, path="tables", suffix="Table")
+            table_class = first_member_match(table_modules, GenericTable)
+            self.fields["columns"].initial = [
+                field
+                for field in table_class.Meta.fields
+                if field not in self.columns_exclude
+            ]
 
         self.helper = FormHelper()
         self.helper.form_method = "GET"

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -103,13 +103,20 @@ class List(
 
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()
-        columns = self.request.GET.getlist("columns", [])
+        columns = self.request.GET.getlist(
+            "columns", self.filterset.form.fields["columns"].initial
+        )
         column_fields = [
             field for field in self.model._meta.fields if field.name in columns
         ]
+        table_class = self.get_table_class()
         kwargs["extra_columns"] = [
             (field.name, library.column_for_field(field, accessor=field.name))
             for field in column_fields
+            if field.name not in table_class.base_columns
+        ]
+        kwargs["exclude"] = [
+            field.name for field in self.model._meta.fields if field.name not in columns
         ]
         return kwargs
 


### PR DESCRIPTION
Handing through the table class to the filterset might be a more elegant solution than calling the mro resolver again, but given that this is cached anyway its the easier solution.

resolves #735


