### PR TITLE
fix: fix css for select2 autocompletes

### DIFF
--- a/apis_core/core/templates/partials/bootstrap4_css.html
+++ b/apis_core/core/templates/partials/bootstrap4_css.html
@@ -3,3 +3,9 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
       integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N"
       crossorigin="anonymous">
+{# this is an override to partially fix an css issue with select2, shoule be removed when move to boostrap5 #}
+<style>
+     .select2-container--default .select2-selection span.select2-selection__rendered {
+        line-height: initial;
+      }
+</style>


### PR DESCRIPTION
please note: this is a preliminary fix and should be removed when moving to bootstrap5, see the comments in the corresponding issue

resolves #330
