### PR TITLE
fix(relations): Property fields unicode normalization

### DIFF
--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -81,10 +81,12 @@ class Property(RootObject):
         return self.name_forward
 
     def save(self, *args, **kwargs):
-        if self.name_reverse != unicodedata.normalize("NFC", self.name_reverse):
-            self.name_reverse = unicodedata.normalize("NFC", self.name_reverse)
-        if self.name_reverse == "" or self.name_reverse is None:
-            self.name_reverse = self.name_forward + " [REVERSE]"
+        if self.name_reverse == "":
+            self.name_reverse = f"{self.name_forward} [INVERSE]"
+
+        self.name_forward = unicodedata.normalize("NFC", str(self.name_forward))
+        self.name_reverse = unicodedata.normalize("NFC", str(self.name_reverse))
+
         super(Property, self).save(*args, **kwargs)
         return self
 


### PR DESCRIPTION
- Set default value for missing name_reverse field before attempting unicode normalisation
- Run unicode normalisation on string representations of the two name fields