### PR TITLE
fix(core): add a model_meta templatetag filter

### DIFF
--- a/apis_core/core/templatetags/apiscore.py
+++ b/apis_core/core/templatetags/apiscore.py
@@ -18,3 +18,8 @@ def page_range(paginator, number):
 @register.filter
 def opts(obj):
     return obj._meta
+
+
+@register.filter
+def model_meta(content_type, field):
+    return getattr(content_type.model_class()._meta, field)


### PR DESCRIPTION
This filter allows to access a models Meta options
(https://docs.djangoproject.com/en/5.0/ref/models/options/) in a
template via a ContentType object.
