### PR TITLE
refactor(apis_entities): use verbose_name_plural in the entity list menu

### DIFF
--- a/apis_core/apis_entities/templatetags/apis_templatetags.py
+++ b/apis_core/apis_entities/templatetags/apis_templatetags.py
@@ -2,6 +2,8 @@ from operator import itemgetter
 from django import template
 from apis_core.utils import caching
 from apis_core.utils.helpers import triple_sidebar
+from django.contrib.contenttypes.models import ContentType
+from apis_core.apis_entities.models import AbstractEntity
 
 register = template.Library()
 
@@ -27,6 +29,26 @@ def entities_list_links():
     entities_links.sort(key=itemgetter(1))
 
     return entities_links
+
+
+def is_entity(content_type: ContentType):
+    model_class = content_type.model_class()
+    return model_class is not None and issubclass(model_class, AbstractEntity)
+
+
+@register.simple_tag
+def entities_content_types():
+    """
+    Retrieve all models which inherit from AbstractEntity class
+    and return their ContentType.
+    """
+    entities = list(
+        filter(
+            lambda content_type: is_entity(content_type),
+            ContentType.objects.all(),
+        )
+    )
+    return entities
 
 
 @register.simple_tag(takes_context=True)

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -101,10 +101,10 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
                       {% block entities-menu-items %}
-                        {% entities_list_links as entities_links %}
-                        {% for ent in entities_links %}
+                        {% entities_content_types as entities %}
+                        {% for content_type in entities %}
                           <a class="dropdown-item"
-                             href="{% url 'apis:apis_entities:generic_entities_list' ent.0 %}">{{ ent.1 }}</a>
+                             href="{% url 'apis:generic:list' content_type %}">{{ content_type|model_meta:"verbose_name_plural" }}</a>
                         {% endfor %}
                       {% endblock entities-menu-items %}
 


### PR DESCRIPTION
A new `entities_content_types` templatetag is being introduces, which
lists all content types that inherit from `AbstractEntity`. This is now
being used in the base template to get a list of entities for the
entities menu item.