### PR TITLE
fix(history): sort history data directly in model, not in templatetag

### DIFF
--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -160,6 +160,7 @@ class VersionMixin(models.Model):
             data.append(entry)
             prev_entry = entry
         data += [x for x in self.history.all()]
+        data = sorted(data, key=lambda x: x.history_date, reverse=True)
         return data
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/apis_core/history/templatetags/apis_history_templatetags.py
+++ b/apis_core/history/templatetags/apis_history_templatetags.py
@@ -1,6 +1,4 @@
-from datetime import datetime
 from apis_core.history.serializers import HistoryLogSerializer
-from apis_core.history.views import convert_timestamps
 from django import template
 from apis_core.history.utils import triple_sidebar_history
 
@@ -18,9 +16,4 @@ def object_relations_history(context, detail=True):
 @register.filter
 def get_history_data(obj):
     data = HistoryLogSerializer(obj.get_history_data(), many=True).data
-    data = sorted(
-        [convert_timestamps(x) for x in data],
-        key=lambda x: datetime.strptime(x["timestamp"], "%d.%m.%Y %H:%M"),
-        reverse=True,
-    )
     return data


### PR DESCRIPTION
This way we don't have to parse the timestamp

Closes: #784
