### PR TITLE
fix(history): add a get_absolute_url method to APISHistoryTableBase

### DIFF
--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -96,6 +96,10 @@ class APISHistoryTableBase(models.Model, GenericModel):
                 triple.save()
         self.save()
 
+    def get_absolute_url(self):
+        ct = ContentType.objects.get_for_model(self)
+        return reverse("apis_core:generic:detail", args=[ct, self.history_id])
+
 
 class VersionMixin(models.Model):
     history = APISHistoricalRecords(


### PR DESCRIPTION
The historical models use `history_id` as id instead of the `id` of the
instance they refer to. We therefore override the `get_absolute_url`
method, so that it points to the historical record and not to the
instance it refers to.
