### PR TITLE
refactor(history): use django-tables2 for history table

### DIFF
--- a/apis_core/history/static/css/history.css
+++ b/apis_core/history/static/css/history.css
@@ -1,0 +1,9 @@
+.diff-remove {
+  background: #ffebe9;
+}
+.diff-insert {
+  background: #dafbe1;
+}
+.difftable td {
+  width: 40%;
+}

--- a/apis_core/history/tables.py
+++ b/apis_core/history/tables.py
@@ -29,3 +29,26 @@ class APISHistoryTableBaseTable(tables.Table):
 
     class Meta:
         fields = ["history_id", "desc", "most_recent", "view"]
+
+
+class HistoryGenericTable(tables.Table):
+    model = tables.Column(empty_values=())
+    fields_changed = tables.Column(empty_values=())
+    instance = tables.Column(linkify=lambda record: record.get_absolute_url())
+    fields_changed = tables.TemplateColumn(
+        template_name="history/columns/fields_changed.html"
+    )
+
+    class Meta:
+        fields = [
+            "model",
+            "instance",
+            "tag",
+            "fields_changed",
+            "history_type",
+            "history_date",
+            "history_user",
+        ]
+
+    def render_model(self, record):
+        return record.instance.__class__.__name__

--- a/apis_core/history/templates/history/change_history.html
+++ b/apis_core/history/templates/history/change_history.html
@@ -2,90 +2,14 @@
 {% load django_tables2 %}
 {% load apis_history_templatetags %}
 {% load apiscore %}
+{% load static %}
+
+{% block styles %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'css/history.css' %}" />
+{% endblock styles %}
 
 {% block card-body %}
-  <table class="table table-sm">
-    <thead>
-      <tr>
-        <th>Model</th>
-        <th>Instance</th>
-        <th>Version</th>
-        <th>Fields changed</th>
-        <th>Change</th>
-        <th>When</th>
-        <th>By</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% with object|get_history_data as changelog %}
-        {% for change in changelog %}
-          <tr>
-            <td>{{ change.model }}</td>
-            <td>
-              <a href="/apis/{{ change.module }}.version{{ change.model|lower }}/{{ change.history_id }}">{{ change.instance }}</a>
-            </td>
-            <td>
-
-              {% if change.version_tag == None %}
-                -
-              {% else %}
-                {{ change.version_tag }}
-              {% endif %}
-
-            </td>
-            <td>
-              <details>
-                <summary>
-                  {% for c2 in change.diff.changed_fields %}
-                    {{ c2 }}
-
-                    {% if forloop.last %}
-                    {% else %}
-                      ,
-                    {% endif %}
-
-                  {% endfor %}
-                </summary>
-                <table class="table table-m0">
-                  <tr>
-                    <th>field</th>
-                    <th>old</th>
-                    <th>new</th>
-                  </tr>
-                  <tbody>
-                    {% for c2 in change.diff.changes %}
-                      <tr>
-                        <td>{{ c2.field }}</td>
-                        <td>
-
-                          {% if c2.old == None %}
-                            -
-                          {% else %}
-                            {{ c2.old }}
-                          {% endif %}
-
-                        </td>
-                        <td>
-
-                          {% if c2.new == None %}
-                            -
-                          {% else %}
-                            {{ c2.new }}
-                          {% endif %}
-
-                        </td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </details>
-            </td>
-            <td>{{ change.action }}</td>
-            <td>{{ change.timestamp }}</td>
-            <td>{{ change.user }}</td>
-          </tr>
-        {% endfor %}
-      {% endwith %}
-    </tbody>
-  </table>
+  {% load django_tables2 %}
+  {% render_table table %}
 {% endblock card-body %}

--- a/apis_core/history/templates/history/columns/fields_changed.html
+++ b/apis_core/history/templates/history/columns/fields_changed.html
@@ -1,0 +1,29 @@
+{% load apis_history_templatetags %}
+<details>
+  <summary>
+    {% for change in record.get_diff %}
+      {{ change.field }}
+
+      {% if not forloop.last %},{% endif %}
+
+    {% endfor %}
+  </summary>
+  <table class="table table-sm table-hover table-bordered difftable">
+    <thead>
+      <tr>
+        <th></th>
+        <th>Old value</th>
+        <th>New value</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for change in record.get_diff %}
+        <tr>
+          <th>{{ change.field }}</th>
+          <td>{{ change|get_diff_old }}</td>
+          <td>{{ change|get_diff_new }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</details>

--- a/apis_core/history/templatetags/apis_history_templatetags.py
+++ b/apis_core/history/templatetags/apis_history_templatetags.py
@@ -1,6 +1,8 @@
 from apis_core.history.serializers import HistoryLogSerializer
 from django import template
 from apis_core.history.utils import triple_sidebar_history
+from django.utils.safestring import mark_safe
+from apis_core.utils.helpers import get_html_diff
 
 register = template.Library()
 
@@ -17,3 +19,13 @@ def object_relations_history(context, detail=True):
 def get_history_data(obj):
     data = HistoryLogSerializer(obj.get_history_data(), many=True).data
     return data
+
+
+@register.filter
+def get_diff_old(change, shorten=0):
+    return mark_safe(get_html_diff(a=change.old, b=change.new, show_b=False))
+
+
+@register.filter
+def get_diff_new(change, shorten=0):
+    return mark_safe(get_html_diff(a=change.old, b=change.new, show_a=False))

--- a/apis_core/history/views.py
+++ b/apis_core/history/views.py
@@ -1,13 +1,25 @@
 from apis_core.generic.views import GenericModelMixin
+from apis_core.generic.helpers import module_paths, first_member_match
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.views.generic.detail import DetailView
 from django.utils import timezone
+from django_tables2 import SingleTableMixin
+from django_tables2.tables import table_factory
+from .tables import HistoryGenericTable
 
 
-class ChangeHistoryView(GenericModelMixin, DetailView):
+class ChangeHistoryView(GenericModelMixin, SingleTableMixin, DetailView):
     template_name = "history/change_history.html"
+
+    def get_table_class(self):
+        table_modules = module_paths(self.model, path="tables", suffix="HistoryTable")
+        table_class = first_member_match(table_modules, HistoryGenericTable)
+        return table_factory(self.model, table_class)
+
+    def get_table_data(self):
+        return self.get_object().get_history_data()
 
 
 def create_new_version(request, contenttype, pk):


### PR DESCRIPTION
The table contains a custom `fields_changed` column, which uses new
`get_diff_old` and `get_diff_new` templatetags for displaying the change
between two values.
