### PR TITLE
fix(history): use signal instead of method for setting timestamp

### DIFF
--- a/apis_core/history/apps.py
+++ b/apis_core/history/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class HistoryConfig(AppConfig):
     name = "apis_core.history"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -148,11 +148,6 @@ class VersionMixin(models.Model):
             self._history_date = timezone.now()
         return super().save(*args, **kwargs)
 
-    def delete(self, *args, **kwargs) -> tuple[int, dict[str, int]]:
-        if self._history_date is None:
-            self._history_date = datetime.now()
-        return super().delete(*args, **kwargs)
-
     def get_history_url(self):
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:history:history", args=[ct, self.id])

--- a/apis_core/history/signals.py
+++ b/apis_core/history/signals.py
@@ -1,0 +1,9 @@
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+from django.utils import timezone
+
+
+@receiver(pre_delete)
+def set_history_date(sender, instance, using, origin, **kwargs):
+    if getattr(instance, "_history_date", None) is None:
+        instance._history_date = timezone.now()


### PR DESCRIPTION
When doing a CASCADING delete, the `delete` method of an instance is not
called, but the `pre_delete` signal is triggered. We want to set the
current date for the `_history_date` attribute, if it is None. To do
that also in cascading deletes, we use the pre_delete signal.

Closes: #814
