### PR TITLE
fix(history): implement history_date fallback directly in property

### DIFF
--- a/apis_core/history/apps.py
+++ b/apis_core/history/apps.py
@@ -3,6 +3,3 @@ from django.apps import AppConfig
 
 class HistoryConfig(AppConfig):
     name = "apis_core.history"
-
-    def ready(self):
-        from . import signals  # noqa: F401

--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -133,7 +133,7 @@ class VersionMixin(models.Model):
 
     @property
     def _history_date(self):
-        return self.__history_date
+        return self.__history_date or timezone.now()
 
     @_history_date.setter
     def _history_date(self, value):
@@ -142,11 +142,6 @@ class VersionMixin(models.Model):
 
     class Meta:
         abstract = True
-
-    def save(self, *args, **kwargs) -> None:
-        if self._history_date is None:
-            self._history_date = timezone.now()
-        return super().save(*args, **kwargs)
 
     def get_history_url(self):
         ct = ContentType.objects.get_for_model(self)

--- a/apis_core/history/signals.py
+++ b/apis_core/history/signals.py
@@ -1,9 +1,0 @@
-from django.db.models.signals import pre_delete
-from django.dispatch import receiver
-from django.utils import timezone
-
-
-@receiver(pre_delete)
-def set_history_date(sender, instance, using, origin, **kwargs):
-    if getattr(instance, "_history_date", None) is None:
-        instance._history_date = timezone.now()


### PR DESCRIPTION
Setting the history_date fallback directly in the property lets us drop
the `save()` override and the `pre_delete` signal, because those only
implemented a check if the history_date was None.
