### PR TITLE
feat(generic): introduce success_url getters for create and update

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -26,6 +26,12 @@ class GenericModel:
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:generic:delete", args=[ct, self.id])
 
+    def get_create_success_url(self):
+        return self.get_absolute_url()
+
+    def get_update_success_url(self):
+        return self.get_edit_url()
+
     @classmethod
     def get_change_permission(self):
         return permission_fullname("change", self)

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -154,7 +154,7 @@ class Create(GenericModelMixin, PermissionRequiredMixin, CreateView):
         return modelform_factory(self.model, form_class)
 
     def get_success_url(self):
-        return self.object.get_edit_url()
+        return self.object.get_create_success_url()
 
 
 class Delete(GenericModelMixin, PermissionRequiredMixin, DeleteView):
@@ -198,7 +198,7 @@ class Update(GenericModelMixin, PermissionRequiredMixin, UpdateView):
         return modelform_factory(self.model, form_class)
 
     def get_success_url(self):
-        return self.object.get_edit_url()
+        return self.object.get_update_success_url()
 
 
 class Autocomplete(


### PR DESCRIPTION
This way they can be overridden by the inheriting object.
The create_success_url now points to the absolute_url of the instance.

Closes: #834
