### PR TITLE
ci(workflows): update link to release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v3
         with:
           release-type: python
           package-name: apis-core-rdf


### PR DESCRIPTION
Update link to release-please GitHub action after
Google moved repos/archived the last known repository.