### PR TITLE
fix(apis_entities,core): add templatetag for generating entitymenu

### DIFF
--- a/apis_core/apis_entities/templatetags/apis_templatetags.py
+++ b/apis_core/apis_entities/templatetags/apis_templatetags.py
@@ -5,6 +5,8 @@ from apis_core.utils.helpers import triple_sidebar
 from django.contrib.contenttypes.models import ContentType
 from apis_core.apis_entities.models import AbstractEntity
 
+from apis_core.apis_entities.utils import get_entity_classes
+
 register = template.Library()
 
 
@@ -49,6 +51,20 @@ def entities_content_types():
         )
     )
     return entities
+
+
+@register.simple_tag
+def entities_verbose_name_plural_listview_url():
+    """
+    Return all entities verbose names together with their list uri, sorted in alphabetical order
+    USED BY:
+    * `core/base.html`
+    """
+    ret = {
+        entity._meta.verbose_name_plural: entity.get_listview_url()
+        for entity in get_entity_classes()
+    }
+    return sorted(ret.items())
 
 
 @register.simple_tag(takes_context=True)

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -109,10 +109,9 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
                       {% block entities-menu-items %}
-                        {% entities_content_types as entities %}
-                        {% for content_type in entities %}
-                          <a class="dropdown-item"
-                             href="{% url 'apis:generic:list' content_type %}">{{ content_type|model_meta:"verbose_name_plural"|capfirst }}</a>
+                        {% entities_verbose_name_plural_listview_url as entities %}
+                        {% for verbose_name_plural, list_url in entities %}
+                          <a class="dropdown-item" href="{{ list_url }}">{{ verbose_name_plural|capfirst }}</a>
                         {% endfor %}
                       {% endblock entities-menu-items %}
 


### PR DESCRIPTION
This introduces `entities_verbose_name_plural_listview_url` templatetag,
which returns all entities verbose names together with their list uri,
sorted in alphabetical order.
This is then used in the core template for the main entities menu.

Closes: #860
