### PR TITLE
chore(sample_project): cleanup ./manage.py and settings.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 
-if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apis.settings.settings_test_ci")
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sample_project.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -12,48 +16,8 @@ if __name__ == "__main__":
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-
-    # TODO : Check at some time if the bug in dal_select2 has been fixed, and if so, remove this function here
-    def work_around_dal_select2_bug():
-        """
-        Due to a bug in dal_select2, this workaround function here goes into the offending file and replaces the
-        relevant code segment with a work-around segment.
-
-        This function ensures that this replacement is done each time django is run and also modifies only the file
-        which is loaded via the respective library within the virtual environment of the current python interpreter.
-        """
-
-        import dal_select2
-
-        file_to_fix = dal_select2.__file__.replace(
-            "/__init__.py", "/static/autocomplete_light/select2.js"
-        )
-
-        try:
-            with open(file_to_fix, "r") as f:
-                lines = f.readlines()
-
-            for i, line in enumerate(lines):
-                if (
-                    line == "                processResults: function (data, page) {\n"
-                    and lines[i + 1]
-                    == "                    if (element.attr('data-tags')) {\n"
-                    and lines[i + 2]
-                    == "                        $.each(data.results, function(index, value) {\n"
-                    and lines[i + 3]
-                    == "                            value.id = value.text;\n"
-                ):
-                    lines[i + 3] = "                            value.id = value.id;\n"
-
-            with open(file_to_fix, "w") as f:
-                f.write("".join(lines))
-
-        except FileNotFoundError:
-            raise Exception(
-                "Could not find select2.js file to inject bug workaround into.\n"
-                + "Maybe the dal_select library has changed and this workaround is not necessary anymore?"
-            )
-
-    work_around_dal_select2_bug()
-
     execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -1,4 +1,7 @@
-SECRET_KEY = "a+nkut46lzzg_=ul)zrs29$u_6^*)2by2mjmwn)tqlgw)_at&l"
+import os
+from django.core.management.utils import get_random_secret_key
+
+SECRET_KEY = os.environ.get("SECRET_KEY", get_random_secret_key())
 DEBUG = True
 
 ALLOWED_HOSTS = []
@@ -28,10 +31,9 @@ INSTALLED_APPS = [
     "dal_select2",
     # api
     "rest_framework",
-    "rest_framework.authtoken",
     # for swagger ui generation
     "drf_spectacular",
-    "simple_history",
+    # our ontology
     "sample_project",
 ]
 
@@ -43,8 +45,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "allow_cidr.middleware.AllowCIDRMiddleware",
-    "reversion.middleware.RevisionMiddleware",
 ]
 
 ROOT_URLCONF = "apis_core.urls"
@@ -60,8 +60,6 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                # we need this for accessing `basetemplate`
-                "apis_core.context_processors.custom_context_processors.list_apis_settings",
             ],
         },
     },


### PR DESCRIPTION
The `./manage.py` script still contained a fix that was superseeded by
using `apis-override-select2js` long ago, sow we drop that fix.
Additionaly, we point DJANGO_SETTINGS_MODULE to `sample_project`, which
was still pointing to `apis` which was dropped. And we format the whole
file to look more similar to the default Django generated `manage.py`.

The `sample_project/settings.py` now drops the hardcoded secret key and
regenerates one every execution (or uses one from the environment). We
also removed some unused apps from INSTALLED_APPS and unused entries
from MIDDLEWARE and TEMPLATES.
