### PR TITLE
fix(apis_entities): remove None values before checking model_class

### DIFF
--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -28,7 +28,11 @@ class EntityToContenttypeConverter:
     def to_python(self, value):
         candiates = get_list_or_404(ContentType, model=value)
         candiates = list(
-            filter(lambda ct: issubclass(ct.model_class(), AbstractEntity), candiates)
+            filter(
+                lambda ct: ct.model_class() is not None
+                and issubclass(ct.model_class(), AbstractEntity),
+                candiates,
+            )
         )
         if len(candiates) > 1:
             raise Http404("Multiple entities match the <%s> identifier" % value)


### PR DESCRIPTION
In rare cases (i.e. when you remove a model and don't cleanup the
ContentTypes) we end up having ContentTypes in Djangos DB that have
None as a `model_class`. But we can not check if None is a subclass, so
we have to remove those instance before doing the check.
