### PR TITLE
refactor: remove leftover print statements

### DIFF
--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -10,7 +10,6 @@ from apis_core.apis_entities.forms import EntitiesMergeForm
 
 class EntitiesUpdate(Update):
     def get_context_data(self, *args, **kwargs):
-        print(self.get_object())
         context = super().get_context_data(*args, **kwargs)
         context["mergeform"] = EntitiesMergeForm(instance=self.get_object())
         return context

--- a/apis_core/apis_relations/models.py
+++ b/apis_core/apis_relations/models.py
@@ -20,9 +20,7 @@ from apis_core.history.models import VersionMixin
 def find_if_user_accepted():
     request = get_current_request()
     if request is not None:
-        print("running through request")
         if request.user.is_authenticated:
-            print("authenticated")
             return {}
         else:
             return {"published": True}

--- a/apis_core/utils/utils.py
+++ b/apis_core/utils/utils.py
@@ -14,7 +14,6 @@ def access_for_all(self, viewtype="list"):
 
 def access_for_all_function(user):
     if user.is_anonymous:
-        print(getattr(settings, "APIS_DETAIL_VIEWS_ALLOWED", False))
         return getattr(settings, "APIS_DETAIL_VIEWS_ALLOWED", False)
     else:
         return True


### PR DESCRIPTION
These print statements look like they are leftovers from testing/debugging things during local development and could/should thus be cleaned up.