### PR TITLE
fix(apis_metainfo): fix object duplication

### DIFF
--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -70,9 +70,9 @@ class RootObject(GenericModel, models.Model):
                 values = getattr(self, field.name).all()
                 objfield.set(values)
 
-        duplicate = newobj.save()
-        signals.post_duplicate.send(sender=origin, instance=self, duplicate=duplicate)
-        return duplicate
+        newobj.save()
+        signals.post_duplicate.send(sender=origin, instance=self, duplicate=newobj)
+        return newobj
 
     duplicate.alters_data = True
 


### PR DESCRIPTION
In `duplicate`, return the actual duplicated object and pass it into the `post_duplicate` signal (instead of using the result of the object save(), which returns None).

Closes: #889