### PR TITLE
fix(apis_relations,apis_entities): replace get_object_or_404

### DIFF
--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -6,12 +6,12 @@ from functools import reduce
 
 from dal import autocomplete
 from django import http
-from django.shortcuts import get_object_or_404
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError
 from django.db.models import Q
 
 from apis_core.utils.settings import get_entity_settings_by_modelname
+from apis_core.apis_entities.utils import get_entity_classes
 from apis_core.apis_relations.models import Property
 
 
@@ -72,8 +72,11 @@ class PropertyAutocomplete(autocomplete.Select2ListView):
     SELF_OBJ_OTHER_SUBJ_STR = "self_obj_other_subj"
 
     def get_autocomplete_property_choices(self, self_model, other_model, search_str):
-        self_contenttype = get_object_or_404(ContentType, model=self_model)
-        other_contenttype = get_object_or_404(ContentType, model=other_model)
+        contenttypes = [
+            ContentType.objects.get_for_model(model) for model in get_entity_classes()
+        ]
+        self_contenttype = next(filter(lambda x: x.model == self_model, contenttypes))
+        other_contenttype = next(filter(lambda x: x.model == other_model, contenttypes))
 
         rbc_self_subj_other_obj = Property.objects.filter(
             subj_class=self_contenttype,

--- a/apis_core/apis_relations/forms.py
+++ b/apis_core/apis_relations/forms.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from apis_core.apis_relations.models import TempTriple
 from apis_core.apis_entities.fields import ListSelect2
 from django.contrib.contenttypes.models import ContentType
+from apis_core.apis_entities.utils import get_entity_classes
 
 from apis_core.apis_metainfo.models import Uri
 
@@ -56,7 +57,10 @@ class GenericTripleForm(forms.ModelForm):
         attrs_target = copy.deepcopy(attrs)
         attrs_target["data-tags"] = "1"
 
-        ct = ContentType.objects.get(model=entity_type_other_str.lower())
+        contenttypes = [
+            ContentType.objects.get_for_model(model) for model in get_entity_classes()
+        ]
+        ct = next(filter(lambda x: x.model == entity_type_other_str, contenttypes))
         url = reverse("apis:generic:autocomplete", args=[ct])
 
         self.fields["other_entity"] = autocomplete.Select2ListCreateChoiceField(

--- a/apis_core/apis_relations/views.py
+++ b/apis_core/apis_relations/views.py
@@ -4,10 +4,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.template.loader import render_to_string
-from django.shortcuts import get_object_or_404
 
 from apis_core.apis_relations.forms import GenericTripleForm
 from apis_core.apis_entities.autocomplete3 import PropertyAutocomplete
+from apis_core.apis_entities.utils import get_entity_classes
 
 from apis_core.apis_relations.models import Property, TempTriple, Triple
 
@@ -111,11 +111,14 @@ def save_ajax_form(
     self_other = kind_form.split("triple_form_")[1].split("_to_")
     entity_type_self_str = self_other[0]
     entity_type_other_str = self_other[1]
-    entity_type_self_class = get_object_or_404(
-        ContentType, model=entity_type_self_str
+    contenttypes = [
+        ContentType.objects.get_for_model(model) for model in get_entity_classes()
+    ]
+    entity_type_self_class = next(
+        filter(lambda x: x.model == entity_type_self_str, contenttypes)
     ).model_class()
-    entity_type_other_class = get_object_or_404(
-        ContentType, model=entity_type_other_str
+    entity_type_other_class = next(
+        filter(lambda x: x.model == entity_type_other_str, contenttypes)
     ).model_class()
     entity_instance_self = entity_type_self_class.objects.get(pk=SiteID)
     entity_instance_other = entity_type_other_class.get_or_create_uri(


### PR DESCRIPTION
`get_object_or_404` errors if we are filtering for the modelname only
(before, we filtered for modelname in the `apis_ontology` app). When we
work with models that have the same name as models in Django (like
`Group`) this leads to multiple results, which `get_object_or_404` does
not like. Therefore we are now first making a list of contenttypes that
are entities, then we filter for the model name, then we pick the first
one.
This whole nonsense will be replaced anyway, when we implement new
relations...
