### PR TITLE
feat(generic): list all generic models on overview page

### DIFF
--- a/apis_core/generic/templates/generic/overview.html
+++ b/apis_core/generic/templates/generic/overview.html
@@ -5,18 +5,17 @@
   <div class="card">
     <div class="card-header">Overview</div>
     <div class="card-body text-center">
-      {% contenttypes "apis_ontology" as contenttypes %}
-      {% for contenttype in contenttypes %}
-        <a href="{% url 'apis_core:generic:list' contenttype %}">
-          <button type="button" class="btn btn-outline-dark m-2">{{ contenttype }}</button>
-        </a>
-      {% endfor %}
-      <hr>
-      {% contenttypes "collections" as contenttypes %}
-      {% for contenttype in contenttypes %}
-        <a href="{% url 'apis_core:generic:list' contenttype %}">
-          <button type="button" class="btn btn-outline-dark m-2">{{ contenttype }}</button>
-        </a>
+      {% genericmodel_content_types as contenttypes %}
+      {% regroup contenttypes|dictsort:"app_label" by app_label as contenttypes_by_app %}
+      {% for app in contenttypes_by_app %}
+        <div class="mb-5">
+          <h3>{{ app.grouper }}</h3>
+          {% for contenttype in app.list %}
+            <a href="{% url 'apis_core:generic:list' contenttype %}">
+              <button type="button" class="btn btn-outline-dark m-2">{{ contenttype.name|capfirst }}</button>
+            </a>
+          {% endfor %}
+        </div>
       {% endfor %}
     </div>
   </div>

--- a/apis_core/generic/templatetags/apisgeneric.py
+++ b/apis_core/generic/templatetags/apisgeneric.py
@@ -2,6 +2,7 @@ from itertools import chain
 
 from django import template
 from django.contrib.contenttypes.models import ContentType
+from apis_core.generic.abc import GenericModel
 
 
 register = template.Library()
@@ -39,3 +40,23 @@ def contenttypes(app_labels=None):
         app_labels = app_labels.split(",")
         return ContentType.objects.filter(app_label__in=app_labels)
     return ContentType.objects.all()
+
+
+def is_genericmodel(content_type: ContentType):
+    model_class = content_type.model_class()
+    return model_class is not None and issubclass(model_class, GenericModel)
+
+
+@register.simple_tag
+def genericmodel_content_types():
+    """
+    Retrieve all models which inherit from GenericModel class
+    and return their ContentType.
+    """
+    genericmodels = list(
+        filter(
+            lambda content_type: is_genericmodel(content_type),
+            ContentType.objects.all(),
+        )
+    )
+    return genericmodels


### PR DESCRIPTION
This commit introduces the templatetag `genericmodel_content_types`
which lists all content types of models that inherit from
`apis_core.generic.abc.GenericModel`. This templatetag is then used
in the overview template to create an overview of *all* those
contenttypes and not only `apis_ontology` and `collections` as it was
hardcoded beofre.

Closes: #912 