### PR TITLE
refactor(apis_entities)!: drop GenericNetworkEntitiesAutocomplete

### DIFF
--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -1,69 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import json
-import operator
-from functools import reduce
 
 from dal import autocomplete
 from django import http
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import FieldError
-from django.db.models import Q
 
-from apis_core.utils.settings import get_entity_settings_by_modelname
 from apis_core.apis_entities.utils import get_entity_classes
 from apis_core.apis_relations.models import Property
-
-
-# TODO RDF: Check if this should be removed or adapted
-class GenericNetworkEntitiesAutocomplete(autocomplete.Select2ListView):
-    def get(self, request, *args, **kwargs):
-        entity = self.kwargs["entity"]
-        q = self.q
-        if q.startswith("reg:"):
-            results = []
-            if entity.lower() == "person":
-                filen = "reg_persons.json"
-            elif entity.lower() == "place":
-                filen = "reg_places.json"
-            with open(filen, "r") as reg:
-                r1 = json.load(reg)
-                r_dict = dict()
-                for r2 in r1:
-                    if q[4:].lower() in r2[1].lower():
-                        if r2[1] in r_dict.keys():
-                            r_dict[r2[1]] += "|{}".format(r2[0])
-                        else:
-                            r_dict[r2[1]] = r2[0]
-            for k in r_dict.keys():
-                results.append({"id": "reg:" + r_dict[k], "text": k})
-
-        else:
-            ent_model = ContentType.objects.get(
-                app_label__startswith="apis_", model=entity
-            ).model_class()
-            try:
-                arg_list = [
-                    Q(**{x + "__icontains": q})
-                    for x in get_entity_settings_by_modelname(entity.title()).get(
-                        "search", []
-                    )
-                ]
-            except KeyError:
-                arg_list = [Q(**{x + "__icontains": q}) for x in ["name"]]
-            try:
-                res = ent_model.objects.filter(
-                    reduce(operator.or_, arg_list)
-                ).distinct()
-            except FieldError:
-                arg_list = [Q(**{x + "__icontains": q}) for x in ["text"]]
-                res = ent_model.objects.filter(
-                    reduce(operator.or_, arg_list)
-                ).distinct()
-            results = [{"id": x.pk, "text": str(x)} for x in res]
-        return http.HttpResponse(
-            json.dumps({"results": results}), content_type="application/json"
-        )
 
 
 class PropertyAutocomplete(autocomplete.Select2ListView):

--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -3,10 +3,6 @@ from django.http import Http404
 from django.urls import include, path, register_converter
 from django.shortcuts import get_list_or_404
 
-from .autocomplete3 import (
-    GenericNetworkEntitiesAutocomplete,
-)
-
 # from .views import ReversionCompareView TODO: add again when import is fixed
 from apis_core.apis_entities.models import AbstractEntity
 from apis_core.generic.views import List, Create, Delete, Detail
@@ -88,10 +84,5 @@ urlpatterns = [
     path(
         "entity/<entitytocontenttype:contenttype>/",
         include(entity_patterns),
-    ),
-    path(
-        "autocomplete-network/<slug:entity>/",
-        GenericNetworkEntitiesAutocomplete.as_view(),
-        name="generic_network_entities_autocomplete",
     ),
 ]


### PR DESCRIPTION
The class hardcodes entity types and an applabel prefix. Even if thats
fixed, id does not work (`reduce() of empty iterable`). The class is
not implemented in a readable way. Lets just throw it away and
reimplement it if we need it somewhere in the future...
