### PR TITLE
fix: drop `apis` namespace for all url resolvers

### DIFF
--- a/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity_form.html
@@ -79,7 +79,7 @@ function GetFormAjax(FormName , ObjectID , ButtonText) {
     return $.ajax(
         {
             type: 'POST',
-            url: '{% url 'apis:apis_relations:get_form_ajax' %}',
+            url: '{% url 'apis_core:apis_relations:get_form_ajax' %}',
             beforeSend: function(request) {
                 var csrftoken = getCookie('csrftoken');
                 request.setRequestHeader("X-CSRFToken", csrftoken);

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -24,7 +24,7 @@ class EntitiesDuplicate(GenericModelMixin, PermissionRequiredMixin, View):
 
         return redirect(
             reverse(
-                "apis:apis_entities:generic_entities_edit_view",
+                "apis_core:apis_entities:generic_entities_edit_view",
                 kwargs={
                     "pk": newobj.id,
                     "contenttype": newobj.__class__.__name__.lower(),
@@ -60,6 +60,6 @@ class EntitiesMerge(GenericModelMixin, PermissionRequiredMixin, FormView):
 
     def get_success_url(self):
         return reverse(
-            "apis:apis_entities:generic_entities_edit_view",
+            "apis_core:apis_entities:generic_entities_edit_view",
             args=[self.get_object().__class__.__name__.lower(), self.get_object().id],
         )

--- a/apis_core/apis_metainfo/serializers.py
+++ b/apis_core/apis_metainfo/serializers.py
@@ -7,7 +7,7 @@ from apis_core.generic.serializers import GenericHyperlinkedModelSerializer
 
 class UriSerializer(GenericHyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name="apis:apis_api:uri-detail", lookup_field="pk"
+        view_name="apis_core:apis_api:uri-detail", lookup_field="pk"
     )
 
     class Meta:

--- a/apis_core/apis_metainfo/templates/registration/login.html
+++ b/apis_core/apis_metainfo/templates/registration/login.html
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="container">
     <div class="mt-4">
-      <form method="post" action="{% url 'apis:login' %}">
+      <form method="post" action="{% url 'apis_core:login' %}">
         {% csrf_token %}
         {{ form|crispy }}
         <input type="submit" value="login">

--- a/apis_core/apis_metainfo/viewsets.py
+++ b/apis_core/apis_metainfo/viewsets.py
@@ -4,7 +4,6 @@ from apis_core.apis_metainfo.models import Uri
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseRedirect, QueryDict
-from django.urls import reverse
 
 
 class UriToObjectViewSet(viewsets.ViewSet):
@@ -28,8 +27,7 @@ class UriToObjectViewSet(viewsets.ViewSet):
         uri = params.pop("uri", None)
         if uri:
             u = get_object_or_404(Uri, uri=request.query_params.get("uri"))
-            model = u.root_object.self_contenttype.model
-            r = reverse(f"apis:apis_core:{model}-detail", args=[u.root_object.id])
+            r = u.root_object.get_api_detail_endpoint()
             if params:
                 r += "?" + QueryDict.from_keys(params).urlencode()
             return HttpResponseRedirect(r)

--- a/apis_core/apis_relations/forms.py
+++ b/apis_core/apis_relations/forms.py
@@ -63,7 +63,7 @@ class GenericTripleForm(forms.ModelForm):
         ct = next(
             filter(lambda x: x.model == entity_type_other_str.lower(), contenttypes)
         )
-        url = reverse("apis:generic:autocomplete", args=[ct])
+        url = reverse("apis_core:generic:autocomplete", args=[ct])
 
         self.fields["other_entity"] = autocomplete.Select2ListCreateChoiceField(
             label="entity",
@@ -82,7 +82,7 @@ class GenericTripleForm(forms.ModelForm):
             label="property",
             widget=ListSelect2(
                 url=reverse(
-                    "apis:apis_relations:generic_property_autocomplete",
+                    "apis_core:apis_relations:generic_property_autocomplete",
                     kwargs={
                         "entity_self": entity_type_self_str,
                         "entity_other": entity_type_other_str,

--- a/apis_core/apis_relations/tables.py
+++ b/apis_core/apis_relations/tables.py
@@ -180,7 +180,7 @@ def get_generic_triple_table(other_entity_class_name, entity_pk_self, detail):
 
             def __init__(self, data, *args, **kwargs):
                 self.base_columns["other_entity"] = tables.LinkColumn(
-                    "apis:apis_entities:generic_entities_detail_view",
+                    "apis_core:apis_entities:generic_entities_detail_view",
                     args=[other_entity_class_name, A("other_entity")],
                 )
 
@@ -211,7 +211,7 @@ def get_generic_triple_table(other_entity_class_name, entity_pk_self, detail):
 
             def __init__(self, *args, **kwargs):
                 self.base_columns["other_entity"] = tables.LinkColumn(
-                    "apis:apis_entities:generic_entities_edit_view",
+                    "apis_core:apis_entities:generic_entities_edit_view",
                     args=[other_entity_class_name, A("other_entity")],
                 )
 

--- a/apis_core/apis_relations/templates/apis_relations/_ajax_form.html
+++ b/apis_core/apis_relations/templates/apis_relations/_ajax_form.html
@@ -1,6 +1,6 @@
 <div id="div_{{ type1 }}{{ InstanceID }}">
   <form action=" 
-    {% if ObjectID %}{% url 'apis:apis_relations:save_ajax_form' entity_type type1 SiteID ObjectID %}{% else %}{% url 'apis:apis_relations:save_ajax_form' entity_type type1 SiteID %}{% endif %}
+    {% if ObjectID %}{% url 'apis_core:apis_relations:save_ajax_form' entity_type type1 SiteID ObjectID %}{% else %}{% url 'apis_core:apis_relations:save_ajax_form' entity_type type1 SiteID %}{% endif %}
      " enctype="multipart/form-data" method="post" id="form_{{ type1 }}" class="form ajax_form {{ url2 }}" data-replace="#message-form">
     {% load crispy_forms_tags %}
     {% crispy form form.helper %}

--- a/apis_core/apis_relations/templates/apis_relations/_ajax_form_generic.html
+++ b/apis_core/apis_relations/templates/apis_relations/_ajax_form_generic.html
@@ -1,6 +1,6 @@
 <div id="div_{{ type1 }}{{ InstanceID }}">
   <form action=" 
-    {% if ObjectID %}{% url 'apis:apis_relations:save_ajax_form_generic' type1 SiteID ObjectID %}{% else %}{% url 'apis:apis_relations:save_ajax_form_generic' type1 SiteID %}{% endif %}
+    {% if ObjectID %}{% url 'apis_core:apis_relations:save_ajax_form_generic' type1 SiteID ObjectID %}{% else %}{% url 'apis_core:apis_relations:save_ajax_form_generic' type1 SiteID %}{% endif %}
      " enctype="multipart/form-data" method="post" id="form_{{ type1 }}" class="form ajax_form {{ url2 }}" data-replace="#message-form">
     {% load crispy_forms_tags %}
     {% crispy form form.helper %}

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -127,9 +127,9 @@
 
                       {% block relations-menu-items %}
                         <a class="dropdown-item"
-                           href="{% url 'apis:apis_relations:generic_relations_list' "property" %}">Properties</a>
+                           href="{% url 'apis_core:apis_relations:generic_relations_list' "property" %}">Properties</a>
                         <a class="dropdown-item"
-                           href="{% url 'apis:apis_relations:generic_relations_list' "triple" %}">Triples</a>
+                           href="{% url 'apis_core:apis_relations:generic_relations_list' "triple" %}">Triples</a>
                       {% endblock relations-menu-items %}
 
                     </div>
@@ -155,7 +155,7 @@
                          aria-expanded="false">User: {{ user.get_username }}</a>
                       <div class="dropdown-menu dropdown-menu-right">
                         <div class="dropdown-item">
-                          <a class="nav-link p-0" href="{% url 'apis:logout' %}?next=/">
+                          <a class="nav-link p-0" href="{% url 'apis_core:logout' %}?next=/">
                             <span class="material-symbols-outlined">logout</span>
                             log out
                           </a>
@@ -165,7 +165,7 @@
                   {% else %}
                     <li class="nav-item dropdown ml-auto">
                       <a class="nav-link p-0"
-                         href="{% url 'apis:login' %}?next={{ request.path|urlencode }}">
+                         href="{% url 'apis_core:login' %}?next={{ request.path|urlencode }}">
                         <span class="material-symbols-outlined">login</span>
                       </a>
                     </li>

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -167,7 +167,7 @@ class Delete(GenericModelMixin, PermissionRequiredMixin, DeleteView):
 
     def get_success_url(self):
         return reverse(
-            "apis:generic:list",
+            "apis_core:generic:list",
             args=[self.request.resolver_match.kwargs["contenttype"]],
         )
 
@@ -175,7 +175,7 @@ class Delete(GenericModelMixin, PermissionRequiredMixin, DeleteView):
         if "HX-Request" in self.request.headers:
             return (
                 reverse_lazy(
-                    "apis:generic:list",
+                    "apis_core:generic:list",
                     args=[self.request.resolver_match.kwargs["contenttype"]],
                 ),
             )


### PR DESCRIPTION
Closes: #876
