### PR TITLE
fix(apis_entities): allow to skip default uri creation

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -199,7 +199,9 @@ class AbstractEntity(RootObject):
 
 @receiver(post_save, dispatch_uid="create_default_uri")
 def create_default_uri(sender, instance, created, raw, using, update_fields, **kwargs):
-    if getattr(settings, "CREATE_DEFAULT_URI", True):
+    create_default_uri = getattr(settings, "CREATE_DEFAULT_URI", True)
+    skip_default_uri = getattr(instance, "skip_default_uri", False)
+    if create_default_uri and not skip_default_uri:
         if isinstance(instance, AbstractEntity) and created:
             base = BASE_URI.strip("/")
             try:


### PR DESCRIPTION
This changes the `create_default_uri` signal receiver to check if there
is a `skip_default_uri` attribute of the instance and skips the creation
if that attribute is set to True.

Closes: #436 