### PR TITLE
refactor(apis_relation): use GenericTable as TripleTableBase base

### DIFF
--- a/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity_form.html
@@ -137,30 +137,6 @@ function EntityRelationForm_response(response){
   };
   unbind_compare_forms();
 }
-
-function DeleteTempEntity(pk, kind, app_name=false) {
-    if (app_name){
-        var url = '/apis/api/'+app_name+'/'+kind+'/'+pk.toString()
-    } else {
-    var url = '/apis/api/'+kind+'/'+pk.toString()}
-    $.ajax({
-        type: 'DELETE',
-        url: url,
-        beforeSend: function(request) {
-              var csrftoken = getCookie('csrftoken');
-                request.setRequestHeader("X-CSRFToken", csrftoken);
-              },
-        statusCode : {
-            204: function() {
-                if (kind=='HLAnnotation') {
-                    $('*[data-hl-ann-id="'+pk+'"]').contents().unwrap()
-                } else {
-                $('#tempEntity_'+pk).parents('tr').remove()
-            }
-            }
-        }
-    })
-}
   </script>
   {% object_relations as object_relations %}
   <script type="text/javascript">

--- a/apis_core/apis_relations/templates/apis_relations/delete_button_generic_ajax_form.html
+++ b/apis_core/apis_relations/templates/apis_relations/delete_button_generic_ajax_form.html
@@ -1,6 +1,0 @@
-{% load apis_helpers %}
-{# djlint:off #}
-<a id="tempEntity_{% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}" class="reldelete" aria-label="Left Align" onclick=DeleteTempEntity('{% if record.relation_pk %}{{ record.relation_pk }}{% else %}{{ record.pk }}{% endif %}',"relations/{{ record|content_type|lower }}")>
-{# djlint:on #}
-<span class="material-symbols-outlined">delete</span>
-</a>


### PR DESCRIPTION
This has the advantage of providing the same `delete` button for
relations as we have in other tables (with htmx and html fallback). We
can thus drop the older delete javascript functionality.
