### PR TITLE
fix(apis_relations, apis_entities): use `lower` when comparing modelname

### DIFF
--- a/apis_core/apis_entities/autocomplete3.py
+++ b/apis_core/apis_entities/autocomplete3.py
@@ -19,8 +19,12 @@ class PropertyAutocomplete(autocomplete.Select2ListView):
         contenttypes = [
             ContentType.objects.get_for_model(model) for model in get_entity_classes()
         ]
-        self_contenttype = next(filter(lambda x: x.model == self_model, contenttypes))
-        other_contenttype = next(filter(lambda x: x.model == other_model, contenttypes))
+        self_contenttype = next(
+            filter(lambda x: x.model == self_model.lower(), contenttypes)
+        )
+        other_contenttype = next(
+            filter(lambda x: x.model == other_model.lower(), contenttypes)
+        )
 
         rbc_self_subj_other_obj = Property.objects.filter(
             subj_class=self_contenttype,

--- a/apis_core/apis_relations/forms.py
+++ b/apis_core/apis_relations/forms.py
@@ -60,7 +60,9 @@ class GenericTripleForm(forms.ModelForm):
         contenttypes = [
             ContentType.objects.get_for_model(model) for model in get_entity_classes()
         ]
-        ct = next(filter(lambda x: x.model == entity_type_other_str, contenttypes))
+        ct = next(
+            filter(lambda x: x.model == entity_type_other_str.lower(), contenttypes)
+        )
         url = reverse("apis:generic:autocomplete", args=[ct])
 
         self.fields["other_entity"] = autocomplete.Select2ListCreateChoiceField(

--- a/apis_core/apis_relations/views.py
+++ b/apis_core/apis_relations/views.py
@@ -115,10 +115,10 @@ def save_ajax_form(
         ContentType.objects.get_for_model(model) for model in get_entity_classes()
     ]
     entity_type_self_class = next(
-        filter(lambda x: x.model == entity_type_self_str, contenttypes)
+        filter(lambda x: x.model == entity_type_self_str.lower(), contenttypes)
     ).model_class()
     entity_type_other_class = next(
-        filter(lambda x: x.model == entity_type_other_str, contenttypes)
+        filter(lambda x: x.model == entity_type_other_str.lower(), contenttypes)
     ).model_class()
     entity_instance_self = entity_type_self_class.objects.get(pk=SiteID)
     entity_instance_other = entity_type_other_class.get_or_create_uri(


### PR DESCRIPTION
Modelnames are sometimes with an uppercase first letter, so lets lower
that string before comparing with the `.model` attribute of the
contenttype.
