### PR TITLE
fix: deactivate simple_history plugin for loaddata

### DIFF
--- a/sample_project/entrypoint.sh
+++ b/sample_project/entrypoint.sh
@@ -2,5 +2,5 @@
 
 /app/manage.py migrate
 /app/manage.py setup || true
-/app/manage.py loaddata sample_project
+/app/manage.py loaddata sample_project --settings=sample_project.settings_loaddata
 /app/manage.py runserver 0.0.0.0:5000

--- a/sample_project/settings_loaddata.py
+++ b/sample_project/settings_loaddata.py
@@ -1,0 +1,4 @@
+from .settings import *
+# Disable simple history for loaddata from fixtures
+
+SIMPLE_HISTORY_ENABLED = False


### PR DESCRIPTION
resolves #915
In the fixtures m2m fields are populated directly when the object is created. Given that we activate the tracking of m2m fields by default in simple_history loaddata creates not null constraints errors for objects that have m2m relations. Also the history is anyway in the fixtures, so no need to activate the plugin during import of the data.