### PR TITLE
fix(generic): use request intead of context for checking user

### DIFF
--- a/apis_core/generic/tables.py
+++ b/apis_core/generic/tables.py
@@ -39,9 +39,7 @@ class ActionColumn(CustomTemplateColumn):
 
     def render(self, record, table, *args, **kwargs):
         if permission := getattr(self, "permission", False):
-            if not table.context.request.user.has_perm(
-                permission_fullname(permission, record)
-            ):
+            if not table.request.user.has_perm(permission_fullname(permission, record)):
                 return ""
         return super().render(record, table, *args, **kwargs)
 


### PR DESCRIPTION
The context is only added if we user `render_table` in a template - but
the some tables are rendered directly to html, circumventing the
`render_table` method, which leads to them missing the `context`.
The `request` itself though can be passed to the table directly.
