### PR TITLE
fix(apis_vocabularies): remove collections from migrations

### DIFF
--- a/apis_core/apis_vocabularies/migrations/0001_initial.py
+++ b/apis_core/apis_vocabularies/migrations/0001_initial.py
@@ -180,10 +180,6 @@ class Migration(migrations.Migration):
                         verbose_name="ISO Code",
                     ),
                 ),
-                (
-                    "collections",
-                    models.ManyToManyField(blank=True, to="apis_metainfo.Collection"),
-                ),
             ],
             bases=("apis_vocabularies.vocabsbaseclass",),
         ),

--- a/apis_core/apis_vocabularies/migrations/0002_remove_texttype_collections_and_more.py
+++ b/apis_core/apis_vocabularies/migrations/0002_remove_texttype_collections_and_more.py
@@ -11,10 +11,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RemoveField(
             model_name="texttype",
-            name="collections",
-        ),
-        migrations.RemoveField(
-            model_name="texttype",
             name="vocabsbaseclass_ptr",
         ),
         migrations.RemoveField(


### PR DESCRIPTION
`apis_metainfo.Collection` was removed, so we remove everything pointing
to that model from the migrations.
