### PR TITLE
refactor(apis_relations): move order methods into table

### DIFF
--- a/apis_core/apis_metainfo/tables.py
+++ b/apis_core/apis_metainfo/tables.py
@@ -1,50 +1,8 @@
 import django_tables2 as tables
-from django.db.models import F
 from django.utils.html import format_html
 from apis_core.generic.tables import GenericTable
 
 from .models import Uri
-
-
-# generic order_FOO methods for start_date_written and end_date_written to be used in all kinds of tables where a queryset is loaded
-# whose model has start_date_written and end_date_written. These methods order the *_date_written by their corresponding
-# parsed date objects.
-#
-# In order to use them in a table using django-tables2, the table class must be assigned *_date_written columns
-# (either through fields in Meta inner class or through custom Column() definitions).
-# Important however is that the names between the columns and the order methods are correlated to each other.
-#
-# The django-tables2 plugin searches for each column through the table class for corresponding order_* and render_* methods
-# E.g. to define custom ordering and rendering for a field column 'name' the table class must have
-# 'order_name' and 'render_name' methods. This approach is called order_FOO and render_FOO by django-tables2.
-#
-# So in order to use these functions here, define within the table class
-# 1.) the respective column
-# 2.) a correspondingly named method for each column
-# 3.) assign to this method one of the two functions below
-#
-# In the case of e.g. start_date_written,
-# the table class thus must have a method / class variable 'order_start_date_written = generic_order_start_date_written'
-
-
-def generic_order_start_date_written(self, queryset, is_descending):
-    if is_descending:
-        queryset = queryset.order_by(
-            F("start_date").desc(nulls_last=True)
-        )  # nulls_last=True puts null values behind non-null values
-    else:
-        queryset = queryset.order_by(F("start_date").asc(nulls_last=True))
-
-    return (queryset, True)
-
-
-def generic_order_end_date_written(self, queryset, is_descending):
-    if is_descending:
-        queryset = queryset.order_by(F("end_date").desc(nulls_last=True))
-    else:
-        queryset = queryset.order_by(F("end_date").asc(nulls_last=True))
-
-    return (queryset, True)
 
 
 def helper_render_date(value, var_date, var_start_date, var_end_date):

--- a/apis_core/apis_relations/tables.py
+++ b/apis_core/apis_relations/tables.py
@@ -5,8 +5,6 @@ from django.utils.html import format_html
 from django_tables2.utils import A
 
 from apis_core.apis_metainfo.tables import (
-    generic_order_start_date_written,
-    generic_order_end_date_written,
     generic_render_start_date_written,
     generic_render_end_date_written,
 )
@@ -95,11 +93,6 @@ class TripleTableBase(GenericTable):
     The base table from which detail or edit tables will inherit from in order to avoid redundant definitions
     """
 
-    # reuse the logic for ordering and rendering *_date_written
-    # Important: The names of these class variables must correspond to the column field name,
-    # e.g. for start_date_written, the methods must be named order_start_date_written and render_start_date_written
-    order_start_date_written = generic_order_start_date_written
-    order_end_date_written = generic_order_end_date_written
     render_start_date_written = generic_render_start_date_written
     render_end_date_written = generic_render_end_date_written
 
@@ -120,6 +113,16 @@ class TripleTableBase(GenericTable):
         )
         # reuse the list for ordering
         sequence = tuple(fields)
+
+    def order_start_date_written(self, queryset, is_descending):
+        if is_descending:
+            return (queryset.order_by(F("start_date").desc(nulls_last=True)), True)
+        return (queryset.order_by(F("start_date").asc(nulls_last=True)), True)
+
+    def order_end_date_written(self, queryset, is_descending):
+        if is_descending:
+            return (queryset.order_by(F("end_date").desc(nulls_last=True)), True)
+        return (queryset.order_by(F("end_date").asc(nulls_last=True)), True)
 
     def render_other_entity(self, record, value):
         """


### PR DESCRIPTION
The `order_` methods are only being used by the TripleBase table, so it
make sense to move them into the table. Doing that we also refactor the
method itself.
