### PR TITLE
fix(generic): repair table columns ordering

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -108,10 +108,9 @@ class List(
 
         # we look at the selected columns and exclude
         # all modelfields that are not part of that list
-        selected_columns = (
-            self.request.GET.getlist("columns")
-            if self.request.GET
-            else self.get_filterset(self.get_filterset_class()).form["columns"].initial
+        selected_columns = self.request.GET.getlist(
+            "columns",
+            self.get_filterset(self.get_filterset_class()).form["columns"].initial,
         )
         modelfields = self.model._meta.get_fields()
         kwargs["exclude"] = [


### PR DESCRIPTION
We interpreted a GET request *with* parameters but *without* a columns
parameter as the wish to have a table without any columns. But that
could also be a wish to order the table, which only appends a `sort`
parameter to existing parameters (or creates parameters if there are
none).
Therefore for now we fallback to the default columns if none are
selected, but we gain table ordering.

Closes: #1022
