### PR TITLE
feat(apis_entites): add a generic entites autocomplete endpoint

### DIFF
--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -10,6 +10,7 @@ from apis_core.apis_entities.views import (
     EntitiesDuplicate,
     EntitiesUpdate,
     EntitiesMerge,
+    EntitiesAutocomplete,
 )
 
 
@@ -88,4 +89,5 @@ urlpatterns = [
         "entity/<entitytocontenttype:contenttype>/",
         include(entity_patterns),
     ),
+    path("autocomplete/", EntitiesAutocomplete.as_view(), name="autocomplete"),
 ]


### PR DESCRIPTION
This endpoint allows us to use autocomplete over multiple model types.
It takes a parameter `entities` which is a list of ContentType natural
keys and searches for the query in all instances of those entities
(using `generate_search_filter`, which means it uses a different search
approach for every model).
The return values of the endpoint are then prefixed with the id of the
contenttype of the results, separated by an underscore.
