### PR TITLE
feat(collections): allow add all changes in a session to a collection

### DIFF
--- a/apis_core/collections/apps.py
+++ b/apis_core/collections/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class VocabsConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "apis_core.collections"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/apis_core/collections/signals.py
+++ b/apis_core/collections/signals.py
@@ -1,0 +1,30 @@
+from django.contrib import messages
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from crum import get_current_request
+from apis_core.collections.models import SkosCollection, SkosCollectionContentObject
+from apis_core.history.models import APISHistoryTableBase
+
+
+@receiver(post_save)
+def add_to_session_collection(
+    sender, instance, created, raw, using, update_fields, **kwargs
+):
+    """
+    Add a created apis_core.history model instance to all the SkosCollections
+    that are listed in the `session_collections` session variable.
+    This needs the 'crum.CurrentRequestUserMiddleware' middleware to
+    be enabled.
+    """
+    request = get_current_request()
+    if isinstance(instance, APISHistoryTableBase) and request:
+        for pk in request.session.get("session_collections", []):
+            sc = SkosCollection.objects.get(pk=pk)
+            content_type = ContentType.objects.get_for_model(instance)
+            SkosCollectionContentObject.objects.create(
+                collection=sc,
+                content_type=content_type,
+                object_id=instance.history_id,
+            )
+            messages.info(request, f"Tagged {instance} with tag {sc}")

--- a/apis_core/collections/templates/collections/collection_session_toggle.html
+++ b/apis_core/collections/templates/collections/collection_session_toggle.html
@@ -1,0 +1,8 @@
+{% if user.is_authenticated %}
+  <a href="{% url "apis_core:collections:collectionsessiontoggle" collection.id %}?to={{ request.get_full_path }}"
+     hx-get="{% url "apis_core:collections:collectionsessiontoggle" collection.id %}"
+     hx-swap="outerHTML"
+     class="col-{{ collection.name|slugify }}">
+    <input type="checkbox" {% if enabled %}checked{% endif %}>
+  {{ collection.name }}</a>
+{% endif %}

--- a/apis_core/collections/templatetags/apis_collections.py
+++ b/apis_core/collections/templatetags/apis_collections.py
@@ -93,3 +93,17 @@ def collection_content_objects(context, obj, collectionids=None):
         ids = collectionids.split(",")
         sccos = sccos.filter(collection__id__in=ids)
     return sccos
+
+
+@register.inclusion_tag(
+    "collections/collection_session_toggle.html", takes_context=True
+)
+def collection_session_toggle_by_id(context, collection_id):
+    """
+    Provide a checkbox to toggle if a session collection is active.
+    The checkbox calls the CollectionSessionToggle view.
+    """
+    session_collections = context.request.session.get("session_collections", [])
+    context["collection"] = SkosCollection.objects.get(pk=collection_id)
+    context["enabled"] = collection_id in session_collections
+    return context

--- a/apis_core/collections/urls.py
+++ b/apis_core/collections/urls.py
@@ -15,4 +15,9 @@ urlpatterns = [
         views.CollectionObjectParent.as_view(),
         name="collectionobjectparent",
     ),
+    path(
+        "collectionsessiontoggle/<int:skoscollection>",
+        views.CollectionSessionToggle.as_view(),
+        name="collectionsessiontoggle",
+    ),
 ]

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -112,3 +112,11 @@ implement a workflow (i.e. three collections: `done` as the root one, `in
 process` with `done` as parent and `todo` with `in process` as parent - the
 user can then on the click of a button change an the collection an instance is
 connected to)
+
+* :py:func:`apis_core.collections.templatetags.apis_collections.collection_session_toggle_by_id`
+
+This templatetag provides a checkbox that enables a collection as "session collection" - this
+means that if enabled, all new versions of instances will be added to this collection. This is
+implemented in :py:func:`apis_core.collections.signals.add_to_session_collection`. To use this
+feature, :py:mod:`apis_core.history` has to be enabled and the
+:py:class:`crum.CurrentRequestUserMiddleware` has to be added to the ``MIDDLEWARE``


### PR DESCRIPTION
This commit implements a way to add SkosCollections to the users
session. If there are SkosCollections in the session and an model that
inherits from `apis_core.history.VersionMixin` get saved, the created
version of that object gets tagged with the SkosCollections.

Closes: https://github.com/acdh-oeaw/apis-core-rdf/issues/1066