### PR TITLE
feat(collections): introduce custom collections table

### DIFF
--- a/apis_core/collections/tables.py
+++ b/apis_core/collections/tables.py
@@ -1,0 +1,9 @@
+from django_tables2 import TemplateColumn
+from apis_core.generic.tables import GenericTable
+
+
+class SkosCollectionContentObjectTable(GenericTable):
+    target = TemplateColumn(
+        "<a href='{{ record.content_object.get_absolute_url }}'>{{ record.content_object }}</a>",
+        orderable=False,
+    )


### PR DESCRIPTION
The custom collections table contains a `target` column that lists, with
a link, the instance the collection is pointing to.