### PR TITLE
fix(sample_project): show password only if passwordfile exists

### DIFF
--- a/sample_project/templatetags/sample_project.py
+++ b/sample_project/templatetags/sample_project.py
@@ -7,7 +7,10 @@ register = template.Library()
 
 @register.simple_tag
 def password():
-    return pathlib.Path("/tmp/password.txt").read_text()
+    passwordfile = pathlib.Path("/tmp/password.txt")
+    if passwordfile.exists():
+        return passwordfile.read_text()
+    return None
 
 
 @register.simple_tag


### PR DESCRIPTION
That way the view does not throw an exception if the `setup` management
command was not run before...
