### PR TITLE
fix(history): remove verbose name from APISHistoricalRecord

### DIFF
--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -130,8 +130,6 @@ class VersionMixin(models.Model):
             APISHistoryTableBase,
         ],
         custom_model_name=lambda x: f"Version{x}",
-        verbose_name="Version",
-        verbose_name_plural="Versions",
     )
     __history_date = None
 


### PR DESCRIPTION
fixes #920