### PR TITLE
fix(relations): make `get_relation_targets_from` method more targeted

### DIFF
--- a/apis_core/relations/templates/relations/list_relations_include.html
+++ b/apis_core/relations/templates/relations/list_relations_include.html
@@ -1,7 +1,7 @@
 {% load relations %}
 {% relations_from from_obj=object as relations %}
 {% possible_relation_types_from object as possible_relations %}
-{% get_relation_targets_from possible_relations as possible_targets %}
+{% get_relation_targets_from object as possible_targets %}
 {% for target in possible_targets %}
   <div class="card mb-2">
     <div class="card-header">{{ target.name }}</div>

--- a/apis_core/relations/templatetags/relations.py
+++ b/apis_core/relations/templatetags/relations.py
@@ -15,11 +15,14 @@ def possible_relation_types_from(obj) -> list[ContentType]:
 
 
 @register.simple_tag
-def get_relation_targets_from(relations) -> list[ContentType]:
+def get_relation_targets_from(obj) -> list[ContentType]:
+    relations = relation_content_types(any_model=type(obj))
     types = set()
-    for relation in relations:
-        types.update(relation.model_class().obj_list())
-        types.update(relation.model_class().subj_list())
+    for model in [relation.model_class() for relation in relations]:
+        if type(obj) in model.obj_list():
+            types.update(model.subj_list())
+        if type(obj) in model.subj_list():
+            types.update(model.obj_list())
     return sorted(
         list(map(ContentType.objects.get_for_model, types)), key=lambda x: x.name
     )


### PR DESCRIPTION
The `get_relation_targets_from` method listed all possible targets of
all the relations an object might be related to. But we actually want
only a list of the targets of the relations *other* sides, seen from the
objects point of view. This is why we now also instead pass the object to
`get_relation_targets_from` and use that to check for the right targets.
