### PR TITLE
feat(relations): override default queryset to include subclasses

### DIFF
--- a/apis_core/relations/querysets.py
+++ b/apis_core/relations/querysets.py
@@ -1,0 +1,2 @@
+def RelationListViewQueryset(queryset):
+    return queryset.select_subclasses()


### PR DESCRIPTION
This commit changes the default queryset for the relations listing. It
adds the `select_subclasses()` method, which "casts" the results into
their respective subclasses. This makes the listing show the correct
string representation of the instance.
