### PR TITLE
birger/315 base uri

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -12,7 +12,6 @@ from apis_core.apis_metainfo.models import RootObject, Uri
 from apis_core.apis_relations.models import TempTriple
 from apis_core.apis_entities import signals
 
-BASE_URI = getattr(settings, "APIS_BASE_URI", "http://apis.info/")
 NEXT_PREV = getattr(settings, "APIS_NEXT_PREV", True)
 
 
@@ -204,7 +203,7 @@ def create_default_uri(sender, instance, created, raw, using, update_fields, **k
     skip_default_uri = getattr(instance, "skip_default_uri", False)
     if create_default_uri and not skip_default_uri:
         if isinstance(instance, AbstractEntity) and created:
-            base = BASE_URI.strip("/")
+            base = getattr(settings, "APIS_BASE_URI", "https://example.org").strip("/")
             try:
                 route = reverse("GetEntityGenericRoot", kwargs={"pk": instance.pk})
             except NoReverseMatch:

--- a/apis_core/apis_metainfo/apps.py
+++ b/apis_core/apis_metainfo/apps.py
@@ -1,6 +1,16 @@
 from django.apps import AppConfig
+from django.conf import settings
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MetainfoConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "apis_core.apis_metainfo"
+
+    def ready(self):
+        if getattr(settings, "APIS_BASE_URI", None) is None:
+            logger.warning(
+                "You should set the APIS_BASE_URI setting - we are using https://example.org as a fallback!"
+            )


### PR DESCRIPTION
- **fix(apis_entities): use example.org as fallback and drop global**
- **feat(apis_metainfo): print warning when APIS_BASE_URI is not set**

Closes: #315
