### PR TITLE
feat(apis_relations): use the base template to override relations menu

### DIFF
--- a/apis_core/apis_relations/templates/base.html
+++ b/apis_core/apis_relations/templates/base.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% load relations %}
+
+{% block relations-menu-items %}
+  {{ block.super }}
+  <a class="dropdown-item"
+     href="{% url 'apis_core:apis_relations:generic_relations_list' "property" %}">Properties</a>
+  <a class="dropdown-item"
+     href="{% url 'apis_core:apis_relations:generic_relations_list' "triple" %}">Triples</a>
+{% endblock relations-menu-items %}

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -126,10 +126,6 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
                       {% block relations-menu-items %}
-                        <a class="dropdown-item"
-                           href="{% url 'apis_core:apis_relations:generic_relations_list' "property" %}">Properties</a>
-                        <a class="dropdown-item"
-                           href="{% url 'apis_core:apis_relations:generic_relations_list' "triple" %}">Triples</a>
                       {% endblock relations-menu-items %}
 
                     </div>


### PR DESCRIPTION
Instead of hardcoding the relations menu entries in the base template,
use template inheritance to add to the menu entry if the app is enabled.

Closes: #1144
