### PR TITLE
fix(core): readd login.html template that was accidently dropped

### DIFF
--- a/apis_core/core/templates/registration/login.html
+++ b/apis_core/core/templates/registration/login.html
@@ -1,0 +1,15 @@
+{% extends basetemplate|default:"base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+  <div class="container">
+    <div class="mt-4">
+      <form method="post" action="{% url 'apis_core:login' %}">
+        {% csrf_token %}
+        {{ form|crispy }}
+        <input type="submit" value="login">
+        <input type="hidden" name="next" value="{{ next }}">
+      </form>
+    </div>
+  </div>
+{% endblock content %}


### PR DESCRIPTION
It was originally in `apis_metainfo`, but the `core/templates` folder
makes more sense.
