### PR TITLE
refactor(apis_core): refactor the urls entrypoint

### DIFF
--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -3,6 +3,8 @@ from django.http import Http404
 from django.shortcuts import get_list_or_404
 from django.urls import include, path, register_converter
 
+from apis_core.apis_entities.api_views import GetEntityGeneric, ListEntityGeneric
+
 # from .views import ReversionCompareView TODO: add again when import is fixed
 from apis_core.apis_entities.models import AbstractEntity
 from apis_core.apis_entities.views import (
@@ -10,6 +12,15 @@ from apis_core.apis_entities.views import (
     EntitiesDuplicate,
     EntitiesMerge,
 )
+
+api_routes = [
+    path("entities/", ListEntityGeneric.as_view()),
+    path(
+        "entity/<int:pk>/",
+        GetEntityGeneric.as_view(),
+        name="GetEntityGeneric",
+    ),
+]
 
 
 class EntityToContenttypeConverter:

--- a/apis_core/apis_metainfo/urls.py
+++ b/apis_core/apis_metainfo/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import DefaultRouter
+
+from apis_core.apis_metainfo.viewsets import UriToObjectViewSet
+
+router = DefaultRouter()
+
+router.register(r"metainfo/uritoobject", UriToObjectViewSet, basename="uritoobject")

--- a/apis_core/core/templates/partials/footer-left.html
+++ b/apis_core/core/templates/partials/footer-left.html
@@ -1,6 +1,6 @@
 {% load core %}
 {% load static %}
-{% url "apis_core:apis_api:api-root" as api_root %}
+{% url "apis_core:api-root" as api_root %}
 {% if api_root %}
   <a href="{{ api_root }}" title="API">
     <span class="material-symbols-outlined material-symbols-align">api</span>

--- a/apis_core/core/urls.py
+++ b/apis_core/core/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from django.views.generic import TemplateView
+
+from apis_core.core.views import Dumpdata
+
+urlpatterns = [
+    path("", TemplateView.as_view(template_name="base.html"), name="apis_index"),
+    path("api/dumpdata", Dumpdata.as_view()),
+]

--- a/apis_core/urls.py
+++ b/apis_core/urls.py
@@ -1,79 +1,75 @@
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.auth.decorators import login_required
-from django.urls import include, path, re_path
-from django.views.generic import TemplateView
-from django.views.static import serve
+from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
 
-from apis_core.apis_entities.api_views import GetEntityGeneric, ListEntityGeneric
-from apis_core.apis_metainfo.viewsets import UriToObjectViewSet
-from apis_core.core.views import Dumpdata
 from apis_core.generic.routers import CustomDefaultRouter
 
 app_name = "apis_core"
 
-router = CustomDefaultRouter()
-# inject the manually created UriToObjectViewSet into the api router
-router.register(r"metainfo/uritoobject", UriToObjectViewSet, basename="uritoobject")
-
-
 urlpatterns = [
-    path("", TemplateView.as_view(template_name="base.html"), name="apis_index"),
+    path("", include("apis_core.core.urls")),
+    path("", include("apis_core.generic.urls")),
     path("admin/", admin.site.urls),
-    path("swagger/schema/", SpectacularAPIView.as_view(), name="schema"),
-    # Optional UI:
-    path(
-        "swagger/schema/swagger-ui/",
-        SpectacularSwaggerView.as_view(url_name="apis_core:schema"),
-        name="swagger-ui",
-    ),
-    path(
-        "swagger/schema/redoc/",
-        SpectacularRedocView.as_view(url_name="apis_core:schema"),
-        name="redoc",
-    ),
-    path(
-        "entities/", include("apis_core.apis_entities.urls", namespace="apis_entities")
-    ),
-    path(
-        "relations/",
-        include("apis_core.apis_relations.urls", namespace="apis_relations"),
-    ),
-    path(
-        "api/", include((router.urls, "apis_core"), namespace="apis_api")
-    ),  # routers do not support namespaces out of the box
-    path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
-    re_path(
-        r"^docs/(?P<path>.*)$",
-        login_required(serve),
-        {"document_root": "apis-core/docs/_build/html"},
-        "docs",
-    ),
     path("accounts/", include("django.contrib.auth.urls")),
-    path(
-        "entity/<int:pk>/",
-        GetEntityGeneric.as_view(),
-        name="GetEntityGeneric",
-    ),
-    path("api/entities/", ListEntityGeneric.as_view()),
-    path("api/dumpdata", Dumpdata.as_view()),
-    path("", include("apis_core.generic.urls", namespace="generic")),
 ]
-if "apis_core.history" in settings.INSTALLED_APPS:
-    urlpatterns.append(
-        path("history/", include("apis_core.history.urls", namespace="history"))
-    )
+
+router = CustomDefaultRouter()
+
+
+if "apis_core.apis_metainfo" in settings.INSTALLED_APPS:
+    from apis_core.apis_metainfo.urls import router as apis_metainfo_router
+
+    router.registry.extend(apis_metainfo_router.registry)
+
+
+if "apis_core.apis_entities" in settings.INSTALLED_APPS:
+    urlpatterns.append(path("entities/", include("apis_core.apis_entities.urls")))
+    from apis_core.apis_entities.urls import api_routes
+
+    urlpatterns.append(path("api/", include(api_routes)))
+
+
+if "apis_core.apis_relations" in settings.INSTALLED_APPS:
+    urlpatterns.append(path("relations/", include("apis_core.apis_relations.urls")))
+
 
 if "apis_core.relations" in settings.INSTALLED_APPS:
     urlpatterns.append(path("relations/", include("apis_core.relations.urls")))
 
+
+if "apis_core.history" in settings.INSTALLED_APPS:
+    urlpatterns.append(path("history/", include("apis_core.history.urls")))
+
+
 if "apis_core.collections" in settings.INSTALLED_APPS:
     urlpatterns.append(path("collections/", include("apis_core.collections.urls")))
 
+
 if "apis_core.documentation" in settings.INSTALLED_APPS:
     urlpatterns.append(path("", include("apis_core.documentation.urls")))
+
+
+urlpatterns.append(path("api/", include(router.urls)))
+urlpatterns.append(path("api-auth/", include("rest_framework.urls")))
+
+
+urlpatterns.append(path("swagger/schema/", SpectacularAPIView.as_view(), name="schema"))
+urlpatterns.append(
+    path(
+        "swagger/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="apis_core:schema"),
+        name="swagger-ui",
+    )
+)
+urlpatterns.append(
+    path(
+        "swagger/schema/redoc/",
+        SpectacularRedocView.as_view(url_name="apis_core:schema"),
+        name="redoc",
+    )
+)


### PR DESCRIPTION
This commit refactors the whole `apis_core.urls` module. It splits up
different apps urls in separate blocks that are only included if the app
is actually enabled. It also moves some of the app specific routes to
their apps, instead if cluttering the main urls.py file with the
includes.

Closes: #1170
