### PR TITLE
fix(generic): replace `create` with `add` for required permission

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -317,7 +317,7 @@ class Autocomplete(
 class Import(GenericModelMixin, PermissionRequiredMixin, FormView):
     template_name = "generic/generic_import_form.html"
     template_name_suffix = "_import"
-    permission_action_required = "create"
+    permission_action_required = "add"
 
     def get_form_class(self):
         form_modules = module_paths(self.model, path="forms", suffix="ImportForm")


### PR DESCRIPTION
The `create` permission does not really exist in Django, the correct
permission is called `add`.

Closes: #1173
