### PR TITLE
fix(entities): use field verbose_names in help_text

### DIFF
--- a/apis_core/apis_entities/filtersets.py
+++ b/apis_core/apis_entities/filtersets.py
@@ -109,10 +109,10 @@ class ModelSearchFilter(django_filters.CharFilter):
             if hasattr(model, "_default_search_fields"):
                 fields = model._default_search_fields
             else:
-                modelfields = model._meta.fields
+                model_fields = model._meta.fields
                 fields = [
                     field.name
-                    for field in modelfields
+                    for field in model_fields
                     if isinstance(field, (models.CharField, models.TextField))
                 ]
             fields = ", ".join(fields)


### PR DESCRIPTION
While trying to update the list of `fields` added to the search field's `help_text` in `ModelSearchFilter` to use `verbose_names` names instead of the fields' names, I ran into an error with how the list of fields is put together.

This PR fixes both how the list is constructed and changes the (default) field names to `verbose_name`s.