### PR TITLE
fix(apis_entities,apis_relations): move TempTriple update code to signal

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -10,7 +10,6 @@ from django.urls import NoReverseMatch, reverse
 
 from apis_core.apis_entities import signals
 from apis_core.apis_metainfo.models import RootObject, Uri
-from apis_core.apis_relations.models import TempTriple
 
 NEXT_PREV = getattr(settings, "APIS_NEXT_PREV", True)
 
@@ -129,8 +128,6 @@ class AbstractEntity(RootObject):
                         if s not in sl:
                             getattr(self, f.name).add(s)
             Uri.objects.filter(root_object=ent).update(root_object=self)
-            TempTriple.objects.filter(obj__id=ent.id).update(obj=self)
-            TempTriple.objects.filter(subj__id=ent.id).update(subj=self)
 
         for ent in entities:
             self.merge_fields(ent)

--- a/apis_core/apis_relations/signals.py
+++ b/apis_core/apis_relations/signals.py
@@ -2,6 +2,7 @@ import logging
 
 from django.dispatch import receiver
 
+from apis_core.apis_entities.signals import post_merge_with
 from apis_core.apis_metainfo.models import RootObject
 from apis_core.apis_metainfo.signals import post_duplicate
 from apis_core.apis_relations.models import TempTriple
@@ -21,3 +22,11 @@ def copy_relations(sender, instance, duplicate, **kwargs):
             newrel = rel.duplicate()
             newrel.obj = duplicate
             newrel.save()
+
+
+@receiver(post_merge_with)
+def merge_relations(sender, instance, entities, **kwargs):
+    for ent in entities:
+        logger.info(f"Merging relations from {ent!r} into {instance!r}")
+        TempTriple.objects.filter(obj__id=ent.id).update(obj=instance)
+        TempTriple.objects.filter(subj__id=ent.id).update(subj=instance)


### PR DESCRIPTION
Rather than hardcoding the TempTriple update in the merge method, we use
the `post_merge_with` signal to update the existing TempTriples

Closes: #1228 
