### PR TITLE
refactor (various) to move inline styles

### DIFF
--- a/apis_core/apis_entities/static/css/E53_Place_popover.css
+++ b/apis_core/apis_entities/static/css/E53_Place_popover.css
@@ -1,3 +1,7 @@
+#map {
+    height: 300px;
+}
+
 #popovermap {
     width: 500px;
     height: 500px;

--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -1,0 +1,13 @@
+/* single object view header */
+#single-object-header h2 {
+    text-align: center;
+}
+
+/* navigation between objects (in list) from single object view header */
+.prev-in-list {
+    float: right;
+}
+
+.next-in-list {
+    float: left;
+}

--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -11,3 +11,16 @@
 .next-in-list {
     float: left;
 }
+
+/* additional object actions */
+.object-duplicate {
+    color: blueviolet;
+}
+
+.object-merge {
+    color: dodgerblue;
+}
+
+.object-history {
+    color: #007bff;
+}

--- a/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity.html
@@ -1,4 +1,10 @@
 {% extends "generic/generic_content.html" %}
+{% load static %}
+
+{% block styles %}
+  {{ block.super }}
+  <link href="{% static 'css/apis_entities.css' %}" rel="stylesheet" />
+{% endblock styles %}
 
 {% block content %}
   <div class="container-fluid">
@@ -6,10 +12,10 @@
       <div class="card-header">
 
         {% block card-header-content %}
-          <div class="row">
+          <div id="single-object-header" class="row">
             <div class="col-md-2">{% include "apis_entities/partials/prev_url.html" %}</div>
             <div class="col-md-8">
-              <h2 style="text-align: center;">
+              <h2>
                 {% include "apis_entities/partials/listview_url.html" %}
                 {{ object }}
 

--- a/apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_detail.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_detail.html
@@ -13,7 +13,6 @@
       <table class="table table-hover table-bordered">
         {% if object.latitude and object.longitude %}
           <td id="map"
-              style="height: 300px"
               data-longitude="{{ object.longitude|floatformat:"4u" }}"
               data-latitude="{{ object.latitude|floatformat:"4u" }}">{{ object }}</td>
         {% endif %}

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
@@ -10,14 +10,11 @@
             </a>
           {% endif %}
           {% if object.get_add_permission in perms %}
-            <a class="dropdown-item"
-               style="color: blueviolet"
+            <a class="object-duplicate dropdown-item"
                href="{{ object.get_duplicate_url }}">
               <span class="material-symbols-outlined material-symbols-align">content_copy</span> Duplicate
             </a>
-            <a class="dropdown-item"
-               style="color: dodgerblue"
-               href="{{ object.get_merge_view_url }}">
+            <a class="object-merge dropdown-item" href="{{ object.get_merge_url }}">
               <span class="material-symbols-outlined material-symbols-align">cell_merge</span> Merge
             </a>
           {% endif %}

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
@@ -10,9 +10,8 @@
            href="{{ object.get_edit_url }}"><span class="material-symbols-outlined material-symbols-align">edit</span>Edit</a>
       </li>
       {% if object.history %}
-        <li class="nav-item">
-          <a class="nav-link {% if request.path == object.get_history_url %}active{% endif %} "
-             style="color: #007bff"
+        <li class="object-history nav-item">
+          <a class="nav-link {% if request.path == object.get_history_url %}active{% endif %}"
              href="{{ object.get_history_url }}"><span class="material-symbols-outlined material-symbols-align">history</span>History</a>
         </li>
       {% endif %}

--- a/apis_core/apis_entities/templates/apis_entities/partials/next_url.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/next_url.html
@@ -1,7 +1,7 @@
 {% if object.get_next_id %}
   <h2>
-    <a href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_next_id %}"
-       style="float:left">
+    <a class="next-in-list"
+       href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_next_id %}">
       <span class="material-symbols-outlined">chevron_right</span>
     </a>
   </h2>

--- a/apis_core/apis_entities/templates/apis_entities/partials/prev_url.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/prev_url.html
@@ -1,7 +1,7 @@
 {% if object.get_prev_id %}
   <h2>
-    <a href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_prev_id %}"
-       style="float:right">
+    <a class="prev-in-list"
+       href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_prev_id %}">
       <span class="material-symbols-outlined">chevron_left</span>
     </a>
   </h2>

--- a/apis_core/apis_entities/templates/columns/duplicate.html
+++ b/apis_core/apis_entities/templates/columns/duplicate.html
@@ -1,3 +1,4 @@
 <a title="duplicate"
-   href="{{ record.get_duplicate_url }}"
-   style="color: blueviolet"><span class="material-symbols-outlined">content_copy</span></a>
+   class="object-duplicate"
+   href="{{ record.get_duplicate_url }}">
+  <span class="material-symbols-outlined">content_copy</span></a>

--- a/apis_core/apis_relations/static/css/apis_relations.css
+++ b/apis_core/apis_relations/static/css/apis_relations.css
@@ -1,0 +1,11 @@
+/* single object view header */
+/* TODO relates to potentially redundant relations_detail_generic.html template */
+#single-object-header h2:nth-of-type(2) {
+    text-align: center;
+}
+
+/* navigation between objects (in list) from single object view */
+/* TODO relates to potentially redundant relations_detail_generic.html template */
+.next-in-list {
+    float: right;
+}

--- a/apis_core/apis_relations/templates/apis_relations/relations_detail_generic.html
+++ b/apis_core/apis_relations/templates/apis_relations/relations_detail_generic.html
@@ -3,6 +3,11 @@
 
 {% block title %}{{ object }}{% endblock %}
 
+{% block styles %}
+  {{ block.super }}
+  <link href="{% static 'css/apis_relations.css' %}" rel="stylesheet" />
+{% endblock styles %}
+
 {% block scriptHeader %}
   {{ block.super }}
 {% endblock scriptHeader %}
@@ -11,7 +16,7 @@
   <div class="container-fluid">
     <div class="card">
       <div class="card-header">
-        <div class="row">
+        <div id="single-object-header" class="row">
           <div class="col-md-2">
             {% if object.get_prev %}
               <h2>
@@ -22,7 +27,7 @@
             {% endif %}
           </div>
           <div class="col-md-8">
-            <h2 style="text-align: center;">
+            <h2>
               {% if object.get_listview_url %}
                 <a href="{{ object.get_listview_url }}">
                   <small>{{ entity_type }}s</small>
@@ -53,7 +58,7 @@
           <div class="col-md-2">
             <h2>
               {% if object.get_next %}
-                <a href="{{ object.get_next }}" style="float:right">
+                <a class="next-in-list" href="{{ object.get_next }}">
                   <i class="fas fa-chevron-right" title="next"></i>
                 </a>
               </h2>

--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -11,3 +11,8 @@ footer a:has(> img):hover,
 footer a:has(> span[class*="material-symbols"]):hover {
     text-decoration: none;
 }
+
+/* main modal in modal block */
+#modal .modal-dialog {
+    max-width: 800px;
+}

--- a/apis_core/core/static/css/override_bootstrap.min.css
+++ b/apis_core/core/static/css/override_bootstrap.min.css
@@ -1,0 +1,6 @@
+/* override of Bootstrap 4.6.2 generated (min) version to partially
+fix an issue with select2
+TODO remove after move to Boostrap 5 */
+.select2-container--default .select2-selection span.select2-selection__rendered {
+    line-height: initial;
+}

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -52,6 +52,7 @@
       <link rel="stylesheet"
             href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.min.css" />
       {% include "partials/bootstrap4_css.html" %}
+      <link href="{% static 'css/override_bootstrap.min.css' %}" rel="stylesheet" />
       <link href="{% static 'css/material-symbols.css' %}" rel="stylesheet" />
       <link href="{% static 'css/core.css' %}" rel="stylesheet" />
       <link href="{% static 'css/E53_Place_popover.css' %}" rel="stylesheet" />

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -260,7 +260,7 @@
            tabindex="-1"
            aria-labelledby="modalLabel"
            aria-hidden="true">
-        <div class="modal-dialog" style="max-width: 800px;">
+        <div class="modal-dialog">
           <div id="modal-here" class="modal-content"></div>
         </div>
       </div>

--- a/apis_core/core/templates/partials/bootstrap4_css.html
+++ b/apis_core/core/templates/partials/bootstrap4_css.html
@@ -3,9 +3,3 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
       integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N"
       crossorigin="anonymous">
-{# this is an override to partially fix an css issue with select2, shoule be removed when move to boostrap5 #}
-<style>
-     .select2-container--default .select2-selection span.select2-selection__rendered {
-        line-height: initial;
-      }
-</style>


### PR DESCRIPTION
Move leftover inline styles from HTML templates to static CSS files.

Closes #1258

---

Not included are the scroll button styles already covered by #1234 and styling applied in Python code as that's harder to untangle. Ex. https://github.com/acdh-oeaw/apis-core-rdf/blob/cda343687afb839f8147dbe89a70c8f8038759c0/apis_core/apis_relations/forms.py#L49-L54

The styles in `apis_relations.css` may be redundant as they belong to `relations_detail_generic.html`, see #1259, but I didn't want to leave strays. I've added TODO comments in the file to make note of that.