### PR TITLE
feat(generic): more/less text column template

### DIFF
--- a/apis_core/generic/static/css/more-less-column.css
+++ b/apis_core/generic/static/css/more-less-column.css
@@ -1,0 +1,42 @@
+summary.more-less-column {
+  list-style: none;
+  appearance: none;
+  -webkit-appearance: none; /* for WebKit browsers */
+}
+
+/* optional: remove ::marker for older browsers */
+summary.more-less-column ::marker {
+  content: none;
+}
+
+summary.more-less-column {
+  cursor: pointer;
+}
+
+/* add "Show more" text when collapsed */
+summary.more-less-column::after {
+  content: " Show more";
+  font-weight: normal;
+  font-size: smaller;
+  color: grey;
+}
+
+/* hide the summary text when expanded, show only "Show less" */
+details[open] summary.more-less-column::before {
+  content: "Show less";
+  color: grey;
+}
+
+/* hide the original summary text when expanded */
+details[open] summary.more-less-column::after {
+  content: "";
+}
+
+details[open] summary.more-less-column {
+  visibility: hidden;
+}
+
+/* make sure the generated "Show less" text is visible */
+details[open] summary.more-less-column::before {
+  visibility: visible;
+}

--- a/apis_core/generic/tables.py
+++ b/apis_core/generic/tables.py
@@ -95,3 +95,23 @@ class GenericTable(tables.Table):
     class Meta:
         fields = ["id", "desc"]
         sequence = ("...", "view", "edit", "delete")
+
+
+class MoreLessColumn(tables.TemplateColumn):
+    """
+    Useful for displaying long fields.
+    A preview is shown initially with a "Show more" link
+    which is replaced with a "Show less" link when expanded.
+    """
+
+    template_name = "columns/more-less.html"
+
+    def __init__(self, preview, fulltext, *args, **kwargs):
+        self.preview = preview
+        self.fulltext = fulltext
+        super().__init__(template_name=self.template_name, *args, **kwargs)
+
+    def render(self, record, **kwargs):
+        self.extra_context["preview"] = self.preview(record)
+        self.extra_context["fulltext"] = self.fulltext(record)
+        return super().render(record, **kwargs)

--- a/apis_core/generic/templates/columns/more-less.html
+++ b/apis_core/generic/templates/columns/more-less.html
@@ -1,0 +1,10 @@
+{% load static %}
+<link rel="stylesheet" href="{% static 'css/more-less-column.css' %}">
+{% if preview != "" and fulltext != preview %}
+  <details class="more-less-column">
+    <summary class="more-less-column">{{ preview }}</summary>
+    {{ fulltext }}
+  </details>
+{% else %}
+  {{ fulltext }}
+{% endif %}

--- a/sample_project/tables.py
+++ b/sample_project/tables.py
@@ -1,0 +1,14 @@
+from apis_core.apis_entities.tables import AbstractEntityTable
+from apis_core.generic.tables import MoreLessColumn
+
+
+class PersonTable(AbstractEntityTable):
+    class Meta(AbstractEntityTable.Meta):
+        sequence = ["desc", "bio"]
+
+    # example column to show preview and detail
+    bio = MoreLessColumn(
+        orderable=False,
+        preview=lambda x: f"This is {x.surname}",
+        fulltext=lambda x: f"This is {x.surname}, {x.forename} {x.surname}.",
+    )


### PR DESCRIPTION
This pull request introduces a new `MoreLessColumn` feature to handle long text fields in tables, providing a preview with a "Show more" link that expands to reveal the full text. The changes span across CSS, template, and Python files to implement this functionality.

### New `MoreLessColumn`:

* **CSS for MoreLessColumn**:
  * Added styles in `apis_core/generic/static/css/more-less-column.css` to handle the appearance and behavior of the "Show more" and "Show less" links.

* **Template for MoreLessColumn**:
  * Created a new template `apis_core/generic/templates/columns/more-less.html` to render the preview and full text within a `<details>` element.

* **Python class for MoreLessColumn**:
  * Added `MoreLessColumn` class in `apis_core/generic/tables.py` to use the new template and CSS for rendering long text fields with expandable previews.

* **Usage example**:
  * Updated `sample_project/tables.py` to include an example of how to use the `MoreLessColumn` in a `PersonTable`.
 
Closes #944 