### PR TITLE
chore(deps): bump Django min version to 5.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1606,4 +1606,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4165a33f1d41f3c2e32990f21c4627f7afd1a2fb641b33da54dd6efa5e98603c"
+content-hash = "67c4fe69fb9b1a05f6a89c35dc3bdf4da0a0bf04c7a1b726168617a77bd40d36"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = ["manage.py", "__pycache__"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-Django = ">=4.1,<6.0"
+Django = ">5"
 djangorestframework = "^3.14.0"
 django-filter = ">=24.1"
 django-autocomplete-light = ">=3.9.4,<3.12.0"


### PR DESCRIPTION
The `apis_core.collections` app now uses the `nulls_distinct` argument
for a UniqueConstraint, which was only introduced in Django 5, so we
bump the minimal Django dependency.

Closes: #1271
