### PR TITLE
fix(relations): use form instead of hardcoding the id

### DIFF
--- a/apis_core/relations/static/js/relation_dialog.js
+++ b/apis_core/relations/static/js/relation_dialog.js
@@ -5,7 +5,7 @@ document.body.addEventListener("reinit_select2", function(evt) {
             ajax: {
                 url: $(element).data("autocomplete-light-url"),
             },
-            dropdownParent: $("#relationdialog"),
+            dropdownParent: $(form),
         });
     });
     $('.select2-selection').addClass("form-control");


### PR DESCRIPTION
The dropdownParent setting defines where the autocomplete api call
results should be put in the DOM. Using the form as container we are
more flexible and can reuse the reinit_select2 event also for other
forms.
