### PR TITLE
Refactor JavaScript inclusion

### DIFF
--- a/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html
@@ -11,125 +11,129 @@
 {% block scripts %}
   {{ block.super }}
   <script type="text/javascript">
-{% with object|opts as opts %}
-{% with opts.object_name|lower as modelname %}
-function GetFormAjax(FormName , ObjectID , ButtonText) {
-    function add_form(data) {
-        // update our tooltip content with our returned data and cache it
-        $('#tab_'+data.tab).find('div:eq(1)').remove();
-        $('#tab_'+data.tab).append(data.form);
-            $('#form_PersonInstitutionForm div:first div:first select').focus();
-        $('#tab_'+data.tab+" select.listselect2").each(function( index, element ){
-            console.log($(this).data("autocompleteLightUrl"))
-        $(this).select2({
-            escapeMarkup: function(markup) {
-            return markup;
-        },
-        templateResult: function(data) {
-            return data.text;
-        },
-        templateSelection: function(data) {
-            return data.text;
-        },
-            ajax: {
-            url: $(this).data("autocompleteLightUrl"),
-            dataType: 'json'
-            // Additional AJAX parameters go here; see the end of this chapter for the full code of this example
-            },
-        })
+    {% with object|opts as opts %}
+      {% with opts.object_name|lower as modelname %}
 
+        function GetFormAjax(FormName, ObjectID, ButtonText) {
+          function add_form(data) {
+            {#update our tooltip content with our returned data and cache it#}
+            $("#tab_" + data.tab).find("div:eq(1)").remove();
+            $("#tab_" + data.tab).append(data.form);
+            $("#form_PersonInstitutionForm div:first div:first select").focus();
+            $("#tab_" + data.tab + " select.listselect2").each(function(index, element) {
+              console.log($(this).data("autocompleteLightUrl"))
+              $(this).select2({
+                escapeMarkup: function(markup) {
+                return markup;
+                },
+                templateResult: function(data) {
+                  return data.text;
+                },
+                templateSelection: function(data) {
+                  return data.text;
+                },
+                ajax: {
+                  url: $(this).data("autocompleteLightUrl"),
+                  dataType: "json"
+                  {#Additional AJAX parameters go here; see the end of this chapter for the full code of this example#}
+                },
+              })
+            })
+            {#$(".form.ajax_form").unbind()#}
+            console.log($("#tab_" + data.tab + " select.listselect2"))
 
-        })            //$(".form.ajax_form").unbind()
-        console.log($('#tab_'+data.tab+" select.listselect2"))
-        {% if apis_bibsonomy %}
-        reinitialize_bibsonomy_tooltips()
-        {% endif %}
-	$('#tab_'+data.tab).each(function() {
-	        htmx.process(this);
-	});
-    };
-    if (!$.ApisForms) {
-        $.ApisForms = {}
-    };
-    if (ObjectID === undefined) {
-        if ($.ApisForms[FormName+'_'+'{{object}}']) {
-            var new_data = $.ApisForms[FormName+'_'+'{{modelname}}']
-            new_data.form = new_data.form.replace('##ENT_PK##', {{object.pk}});
-            add_form(new_data);
-            return;
-        };
-    };
-    if (ButtonText === undefined) {
-        ButtonText = 'create/modify';
-    };
-    return $.ajax(
-        {
-            type: 'POST',
-            url: '{% url 'apis_core:apis_relations:get_form_ajax' %}',
+            {% if apis_bibsonomy %}
+              reinitialize_bibsonomy_tooltips()
+            {% endif %}
+
+            $("#tab_" + data.tab).each(function() {
+              htmx.process(this);
+            });
+          }
+
+          if (!$.ApisForms) {
+            $.ApisForms = {}
+          }
+          if (ObjectID === undefined) {
+            if ($.ApisForms[FormName + "_" + "{{object}}"]) {
+              var new_data = $.ApisForms[FormName + "_" + "{{modelname}}"]
+              new_data.form = new_data.form.replace("##ENT_PK##", {{object.pk}});
+              add_form(new_data);
+              return;
+            }
+          }
+          if (ButtonText === undefined) {
+            ButtonText = "create/modify";
+          }
+
+          return $.ajax({
+            type: "POST",
+            url: "{% url 'apis_core:apis_relations:get_form_ajax' %}",
             beforeSend: function(request) {
-                var csrftoken = getCookie('csrftoken');
-                request.setRequestHeader("X-CSRFToken", csrftoken);
+              var csrftoken = getCookie("csrftoken");
+              request.setRequestHeader("X-CSRFToken", csrftoken);
             },
             data: {
-                'FormName':FormName,
-                'SiteID':{{object.pk}},
-                'ObjectID':ObjectID,
-                'ButtonText':ButtonText,
-                'entity_type': '{{modelname}}',
+              "FormName": FormName,
+              "SiteID": {{object.pk}},
+              "ObjectID": ObjectID,
+              "ButtonText": ButtonText,
+              "entity_type": "{{modelname}}",
             },
             success: function(data) {
-		console.log(data);
-                add_form(data);
-                if (!ObjectID) {
-                    $.ApisForms[FormName+'_'+'{{modelname}}'] = data;
-                    $.ApisForms[FormName+'_'+'{{modelname}}'].form = $.ApisForms[FormName+'_'+'{{modelname}}'].form
-                    .replace('/{{object.pk}}/', '/##ENT_PK##/');
-                };
+              console.log(data);
+              add_form(data);
+              if (!ObjectID) {
+                $.ApisForms[FormName + "_" + "{{modelname}}"] = data;
+                $.ApisForms[FormName + "_" + "{{modelname}}"].form = $.ApisForms[FormName + "_" + "{{modelname}}"].form.replace("/{{object.pk}}/", "/##ENT_PK##/");
+              }
             },
             error: function(error) {
-                console.log(error)
+              console.log(error)
             }
-        }
-    );
-}
-{% endwith %}
-{% endwith %}
-
-function EntityRelationForm_response(response){
-  if (response.test == false) {
-      $('#'+response.DivID).replaceWith(response.form);
-      //$(".form.ajax_form").unbind();
-      if ($.ApisHigh.tt_instance_detail) {
-      if ($.ApisHigh.tt_instance_detail["__state"] == 'stable') {
-          $.ApisHigh.tt_instance_detail.content(response.form);
-      } }
-  } else {
-      console.log('test did not fail');
-       $('#tab_'+response.tab).find('div').remove();
-       $('#tab_'+response.tab).append(response.table_html);
-       {% if object %}
-       if (response.right_card) {
-         GetFormAjax(response.tab);
-       };
-       if ($.ApisHigh){
-         if ($.ApisHigh.tt_instance_detail["__state"] == 'stable') {
-            $.ApisHigh.tt_instance_detail.close()
-         } else {
-            $('.reldelete').addClass('disabled')
+          });
          }
-       }
-       {% endif %}
-  };
-}
+
+      {% endwith %}
+    {% endwith %}
+
+    function EntityRelationForm_response(response) {
+      if (response.test == false) {
+        $("#" + response.DivID).replaceWith(response.form);
+        {#$(".form.ajax_form").unbind();#}
+        if ($.ApisHigh.tt_instance_detail) {
+          if ($.ApisHigh.tt_instance_detail["__state"] == "stable") {
+            $.ApisHigh.tt_instance_detail.content(response.form);
+          }
+        }
+      } else {
+        console.log("test did not fail");
+        $("#tab_" + response.tab).find("div").remove();
+        $("#tab_" + response.tab).append(response.table_html);
+
+        {% if object %}
+          if (response.right_card) {
+            GetFormAjax(response.tab);
+          }
+          if ($.ApisHigh) {
+           if ($.ApisHigh.tt_instance_detail["__state"] == "stable") {
+             $.ApisHigh.tt_instance_detail.close()
+           } else {
+             $(".reldelete").addClass("disabled")
+           }
+          }
+        {% endif %}
+      }
+    }
   </script>
   {% object_relations as object_relations %}
   <script type="text/javascript">
-function activate_editing(){
-       {% for obj in object_relations %}
+    function activate_editing() {
+     {% for obj in object_relations %}
        GetFormAjax("{{obj.2}}");
-       //unbind_ajax_forms();
-       {% endfor %}
-};
-activate_editing();
+       {#unbind_ajax_forms();#}
+     {% endfor %}
+    }
+    activate_editing();
   </script>
 {% endblock scripts %}

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -5,3 +5,12 @@ $(document).ready(function() {
         enableFiltering: true
     });
 })
+
+document.addEventListener("readystatechange", (event) => {
+  if (event.target.readyState === "interactive") {
+    // equivalent to DOMContentLoaded; document has loaded, defered scripts
+    // have downloaded and executed, sub-resources may not be ready yet
+  } else if (event.target.readyState === "complete") {
+    // fired when fully loaded, incl. sub-resources and async scripts
+  }
+});

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -24,14 +24,14 @@ function configHtmx() {
 /* scroll-to-top button */
 function scrollButton() {
 
-  //Get the button
+  // get the button
   let mybutton = document.getElementById("btn-back-to-top");
 
-  // When the user scrolls down 20px from the top of the document, show the button
   window.onscroll = function () {
     scrollFunction();
   };
 
+  // show button when user has scrolled down 20px from top of document
   function scrollFunction() {
     if (
       document.body.scrollTop > 20 ||
@@ -42,7 +42,8 @@ function scrollButton() {
       mybutton.style.display = "none";
     }
   }
-  // When the user clicks on the button, scroll to the top of the document
+
+  // scroll back up on click on button
   mybutton.addEventListener("click", backToTop);
 
   function backToTop() {

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -12,9 +12,10 @@ function configMultiSelect() {
 * see also https://htmx.org/events/
 */
 function configHtmx() {
+  // DOM content swapping behaviour
   document.body.addEventListener('htmx:beforeSwap', function(event) {
     if (event.detail.xhr.status === 204) {
-      // Swap content even when the response is empty.
+      // swap even when the response is empty
       event.detail.shouldSwap = true;
     }
   });

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -8,6 +8,18 @@ function configMultiSelect() {
   });
 }
 
+/* config HTMX events,
+* see also https://htmx.org/events/
+*/
+function configHtmx() {
+  document.body.addEventListener('htmx:beforeSwap', function(event) {
+    if (event.detail.xhr.status === 204) {
+      // Swap content even when the response is empty.
+      event.detail.shouldSwap = true;
+    }
+  });
+}
+
 document.addEventListener("readystatechange", (event) => {
   if (event.target.readyState === "interactive") {
     // equivalent to DOMContentLoaded; document has loaded, defered scripts
@@ -16,5 +28,6 @@ document.addEventListener("readystatechange", (event) => {
     // fired when fully loaded, incl. sub-resources and async scripts
 
     configMultiSelect();
+    configHtmx();
   }
 });

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -1,10 +1,12 @@
-//script that converts the multi select element
-$(document).ready(function() {
-    $('select.selectmultiple').multiselect({
-        includeSelectAllOption: true,
-        enableFiltering: true
-    });
-})
+/* config for bootstrap-multiselect widget,
+see also https://davidstutz.github.io/bootstrap-multiselect/#configuration-options
+*/
+function configMultiSelect() {
+  $('select.selectmultiple').multiselect({
+    includeSelectAllOption: true,
+    enableFiltering: true
+  });
+}
 
 document.addEventListener("readystatechange", (event) => {
   if (event.target.readyState === "interactive") {
@@ -12,5 +14,7 @@ document.addEventListener("readystatechange", (event) => {
     // have downloaded and executed, sub-resources may not be ready yet
   } else if (event.target.readyState === "complete") {
     // fired when fully loaded, incl. sub-resources and async scripts
+
+    configMultiSelect();
   }
 });

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -21,6 +21,36 @@ function configHtmx() {
   });
 }
 
+/* scroll-to-top button */
+function scrollButton() {
+
+  //Get the button
+  let mybutton = document.getElementById("btn-back-to-top");
+
+  // When the user scrolls down 20px from the top of the document, show the button
+  window.onscroll = function () {
+    scrollFunction();
+  };
+
+  function scrollFunction() {
+    if (
+      document.body.scrollTop > 20 ||
+      document.documentElement.scrollTop > 20
+    ) {
+      mybutton.style.display = "block";
+    } else {
+      mybutton.style.display = "none";
+    }
+  }
+  // When the user clicks on the button, scroll to the top of the document
+  mybutton.addEventListener("click", backToTop);
+
+  function backToTop() {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  }
+}
+
 document.addEventListener("readystatechange", (event) => {
   if (event.target.readyState === "interactive") {
     // equivalent to DOMContentLoaded; document has loaded, defered scripts
@@ -30,5 +60,6 @@ document.addEventListener("readystatechange", (event) => {
 
     configMultiSelect();
     configHtmx();
+    scrollButton();
   }
 });

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -67,6 +67,9 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.15/js/bootstrap-multiselect.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.full.min.js"></script>
+      <script src="https://unpkg.com/htmx.org@1.9.10"
+              integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC"
+              crossorigin="anonymous"></script>
       <script src="{% static "js/core.js" %}"></script>
       <script src="{% static 'js/E53_Place_popover.js' %}"></script>
     {% endblock %}
@@ -245,7 +248,6 @@
     {% endblock footer %}
 
     {% block scripts %}
-      <script src="https://unpkg.com/htmx.org@1.9.10"></script>
       <script>
         document.body.addEventListener('htmx:beforeSwap', function(event) {
           if (event.detail.xhr.status === 204) {

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -59,6 +59,11 @@
 
     {% block scriptHeader %}
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+      {# Bootstrap 4.6.2 bundle (without jQuery) #}
+      {# see https://getbootstrap.com/docs/4.6/getting-started/introduction/ #}
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
+              integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
+              crossorigin="anonymous"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.15/js/bootstrap-multiselect.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.full.min.js"></script>
@@ -240,7 +245,6 @@
     {% endblock footer %}
 
     {% block scripts %}
-      {% include "partials/bootstrap4_js.html" %}
       <script src="https://unpkg.com/htmx.org@1.9.10"></script>
       <script>
         document.body.addEventListener('htmx:beforeSwap', function(event) {

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -58,20 +58,26 @@
     {% endblock styles %}
 
     {% block scriptHeader %}
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"
+              defer></script>
       {# Bootstrap 4.6.2 bundle (without jQuery) #}
       {# see https://getbootstrap.com/docs/4.6/getting-started/introduction/ #}
       <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
               integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
-              crossorigin="anonymous"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.15/js/bootstrap-multiselect.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.full.min.js"></script>
+              crossorigin="anonymous"
+              defer></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.15/js/bootstrap-multiselect.min.js"
+              defer></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js"
+              defer></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.full.min.js"
+              defer></script>
       <script src="https://unpkg.com/htmx.org@1.9.10"
               integrity="sha384-D1Kt99CQMDuVetoL1lrYwg5t+9QdHe7NLX/SoJYkXDFfX37iInKRy5xLSi8nO7UC"
-              crossorigin="anonymous"></script>
-      <script src="{% static "js/core.js" %}"></script>
-      <script src="{% static 'js/E53_Place_popover.js' %}"></script>
+              crossorigin="anonymous"
+              defer></script>
+      <script src="{% static "js/core.js" %}" defer></script>
+      <script src="{% static 'js/E53_Place_popover.js' %}" defer></script>
     {% endblock %}
 
   </head>

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -247,16 +247,7 @@
       </footer>
     {% endblock footer %}
 
-    {% block scripts %}
-      <script>
-        document.body.addEventListener('htmx:beforeSwap', function(event) {
-          if (event.detail.xhr.status === 204) {
-            // Swap content even when the response is empty.
-            event.detail.shouldSwap = true;
-          }
-        });
-      </script>
-    {% endblock %}
+    {% block scripts %}{% endblock %}
 
     {% block modal %}
       <!-- Modal -->

--- a/apis_core/core/templates/partials/backtotopbtn.html
+++ b/apis_core/core/templates/partials/backtotopbtn.html
@@ -12,30 +12,3 @@
         id="btn-back-to-top">
   <span>&uarr;</span>
 </button>
-<script>
-//Get the button
-let mybutton = document.getElementById("btn-back-to-top");
-
-// When the user scrolls down 20px from the top of the document, show the button
-window.onscroll = function () {
-  scrollFunction();
-};
-
-function scrollFunction() {
-  if (
-    document.body.scrollTop > 20 ||
-    document.documentElement.scrollTop > 20
-  ) {
-    mybutton.style.display = "block";
-  } else {
-    mybutton.style.display = "none";
-  }
-}
-// When the user clicks on the button, scroll to the top of the document
-mybutton.addEventListener("click", backToTop);
-
-function backToTop() {
-  document.body.scrollTop = 0;
-  document.documentElement.scrollTop = 0;
-}
-</script>

--- a/apis_core/core/templates/partials/bootstrap4_js.html
+++ b/apis_core/core/templates/partials/bootstrap4_js.html
@@ -1,4 +1,0 @@
-{# the bootstrap 4.6.2 javascript, as suggested on https://getbootstrap.com/docs/4.6/getting-started/introduction/ #}
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
-        crossorigin="anonymous"></script>


### PR DESCRIPTION
Moves (most of) the existing internal JS to external files in an attempt to solve #1166.

Event listening for loading of static content is implemented via `readystatechange` rather than `DOMContentLoaded` _or_ `load` to allow for greater flexibility, also with regard to integrating jQuery (which does its own thing).

The remaining internal JS is in `apis_relations`. The last commit reformats [abstractentity_form.html](https://github.com/acdh-oeaw/apis-core-rdf/blob/08abebadf6d949b018463c09589a02af5ff51315/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html) for readability.

Tangentially related: the internal JS was recently moved from `apis_entities` to `apis_relations`. It interacts with functions in [apis_entities.js](https://github.com/acdh-oeaw/apis-core-rdf/blob/08abebadf6d949b018463c09589a02af5ff51315/apis_core/apis_entities/static/js/apis_entities.js), which should probably be moved to `apis_relations.js` in `apis_relations` (?!).