### PR TITLE
fix(apis_relations): call block.super in the col-one block

### DIFF
--- a/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html
@@ -3,6 +3,7 @@
 {% load apis_entities %}
 
 {% block col-one %}
+  {{ block.super }}
   <div class="card">
     <div class="card-body">{% include "apis_relations/entity_relations_multiple_cards.html" %}</div>
   </div>


### PR DESCRIPTION
The col-one block is use by multiple apps, so it is crucial that all the
blocks call block.super, to also allow other apps to insert content.
This was forgotten when the template was introduced in
cda343687afb839f8147dbe89a70c8f8038759c0
