### PR TITLE
fix(apis_entities): correct merge link

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -84,6 +84,13 @@ class AbstractEntity(RootObject):
             kwargs={"contenttype": entity, "pk": self.id},
         )
 
+    def get_merge_view_url(self):
+        entity = self.__class__.__name__.lower()
+        return reverse(
+            "apis_core:apis_entities:generic_entities_merge_view",
+            kwargs={"contenttype": entity, "pk": self.id},
+        )
+
     def merge_start_date_written(self, other):
         self.start_date_written = self.start_date_written or other.start_date_written
 

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
@@ -17,7 +17,7 @@
             </a>
             <a class="dropdown-item"
                style="color: dodgerblue"
-               href="{{ object.get_merge_url }}">
+               href="{{ object.get_merge_view_url }}">
               <span class="material-symbols-outlined material-symbols-align">cell_merge</span> Merge
             </a>
           {% endif %}


### PR DESCRIPTION
The merge link was incorrectly pointing the merge action view that merges two objects; it has been corrected to point to the merge view that allows the user to select another object for merging.

closes #1278