### PR TITLE
fix(generic): redirect to detail page after merge

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -389,6 +389,9 @@ class MergeWith(GenericModelMixin, PermissionRequiredMixin, FormView):
         messages.info(self.request, f"Merged values of {self.other} into {self.object}")
         return super().form_valid(form)
 
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
 
 class Enrich(GenericModelMixin, PermissionRequiredMixin, FormView):
     """


### PR DESCRIPTION
get_successful_url of MergeWith view got acccidentally removed from MergeWith in commit 9e8fe5c. This is now reinstated.

Closes #1282