### PR TITLE
ms/allow to configure serializer and queryset from renderer

### DIFF
--- a/apis_core/generic/api_views.py
+++ b/apis_core/generic/api_views.py
@@ -21,6 +21,10 @@ class ModelViewSet(viewsets.ModelViewSet):
         return super().dispatch(*args, **kwargs)
 
     def get_queryset(self):
+        renderer = getattr(getattr(self, "request", {}), "accepted_renderer", None)
+        if renderer is not None:
+            if hasattr(renderer, "get_queryset"):
+                return renderer.get_queryset()
         queryset_methods = module_paths(
             self.model, path="querysets", suffix="ViewSetQueryset"
         )
@@ -33,6 +37,8 @@ class ModelViewSet(viewsets.ModelViewSet):
             self.model, path="serializers", suffix="Serializer"
         )
         if renderer is not None:
+            if hasattr(renderer, "get_serializer_class"):
+                return renderer.get_serializer_class()
             prefix = makeclassprefix(renderer.format)
             serializer_class_modules = (
                 module_paths(

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -210,3 +210,47 @@ To use this logic in forms, there is
 based on `django.forms.ModelChoiceField <https://docs.djangoproject.com/en/5.0/ref/forms/fields/#modelchoicefield>`_. It checks if the passed value starts
 with ``http`` and if so, it uses the importer that fits the model and uses it to
 create the model instance.
+
+API specific customizations
+---------------------------
+
+The API can be configured in a similar way as the website itself. However, 
+there are some special cases.
+
+Renderers
+^^^^^^^^^
+
+Users can request data via the API in various shapes. The selection of 
+the shape that is returned is done via `content negotiation <https://www.django-rest-framework.org/api-guide/content-negotiation/>`_.
+Based on the configured renderers and the accept header of the clients 
+request a renderer is selected. In APIS in addition to the default 
+functionalities of renderers a `get_serializer_class` and a `get_queryset`
+function can be defined to overwrite default behaviour:
+
+.. code-block:: python
+
+        class Renderer(renderers.BaseRenderer):
+            media_type = "ACCEPT HEADER" # set here the accept header in the clients request
+            format = "FILE EXTENSION"
+
+            def get_serializer_class(self):
+                pass # return a serializer class used to serialize data passed to the renderer
+
+            def get_queryset(self):
+                pass # return the queryset used in the serializer. Allows to filter objects and/or use annotations
+
+            def render(self, data, accepted_media_type=None, renderer_context=None):
+                pass # function called to before returning the data. Gets the serialized data rather than the queryset objects.
+
+
+When the renderer is defined it still needs to be configured. This can 
+either be done globally by setting it in the settings.py:
+
+.. code-block:: python
+   REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += [
+    "YOUR_MODULE.Renderer",
+   ]
+
+or by overwriting API views and setting the renderer on a per view basis.
+
+


### PR DESCRIPTION
some renderers (eg RDF) need their own serialization
of the objects. This allows to set serializers (and
querysets, to optimize performance via annotations)
directly in the renderer.