### PR TITLE
refactor(apis_relations): move external methods into module

### DIFF
--- a/apis_core/apis_entities/templatetags/apis_entities.py
+++ b/apis_core/apis_entities/templatetags/apis_entities.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes.models import ContentType
 from apis_core.apis_entities.forms import EntitiesMergeForm
 from apis_core.apis_entities.models import AbstractEntity
 from apis_core.apis_entities.utils import get_entity_classes
-from apis_core.utils.helpers import triple_sidebar
 
 register = template.Library()
 
@@ -49,12 +48,6 @@ def entities_verbose_name_plural_listview_url():
         for entity in get_entity_classes()
     }
     return sorted(ret.items())
-
-
-@register.simple_tag(takes_context=True)
-def object_relations(context, detail=True):
-    obj = context["object"]
-    return triple_sidebar(obj, context["request"], detail)
 
 
 @register.simple_tag(takes_context=True)

--- a/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_detail.html
+++ b/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_detail.html
@@ -1,6 +1,6 @@
 {% extends "apis_core/apis_entities/abstractentity_detail.html" %}
 {% load django_tables2 %}
-{% load apis_entities %}
+{% load apis_relations %}
 
 {% block col-one %}
   <div class="card">

--- a/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_core/apis_relations/templates/apis_core/apis_entities/abstractentity_form.html
@@ -1,6 +1,6 @@
 {% extends "apis_core/apis_entities/abstractentity_form.html" %}
 {% load core %}
-{% load apis_entities %}
+{% load apis_relations %}
 
 {% block col-one %}
   {{ block.super }}

--- a/apis_core/apis_relations/templates/apis_relations/entity_relations_multiple_cards.html
+++ b/apis_core/apis_relations/templates/apis_relations/entity_relations_multiple_cards.html
@@ -1,5 +1,5 @@
 {% load django_tables2 %}
-{% load apis_entities %}
+{% load apis_relations %}
 {% object_relations detail=False as object_relations %}
 {% for obj in object_relations %}
   <div class="card card-default mb-2">

--- a/apis_core/apis_relations/templatetags/apis_relations.py
+++ b/apis_core/apis_relations/templatetags/apis_relations.py
@@ -1,0 +1,11 @@
+from django import template
+
+from apis_core.apis_relations.utils import triple_sidebar
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def object_relations(context, detail=True):
+    obj = context["object"]
+    return triple_sidebar(obj, context["request"], detail)

--- a/apis_core/apis_relations/utils.py
+++ b/apis_core/apis_relations/utils.py
@@ -1,0 +1,80 @@
+import itertools
+
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from django_tables2 import RequestConfig
+
+from apis_core.apis_relations.models import Property, TempTriple
+from apis_core.apis_relations.tables import get_generic_triple_table
+from apis_core.utils.settings import get_entity_settings_by_modelname
+
+
+def get_content_types_with_allowed_relation_from(
+    content_type: ContentType,
+) -> list[ContentType]:
+    """Returns a list of ContentTypes to which the given ContentTypes may be related by a Property"""
+
+    # Find all the properties where the entity is either subject or object
+    properties_with_entity_as_subject = Property.objects.filter(
+        subj_class=content_type
+    ).prefetch_related("obj_class")
+    properties_with_entity_as_object = Property.objects.filter(
+        obj_class=content_type
+    ).prefetch_related("subj_class")
+
+    content_type_querysets = []
+
+    # Where entity is subject, get all the object content_types
+    for p in properties_with_entity_as_subject:
+        objs = p.obj_class.all()
+        content_type_querysets.append(objs)
+    # Where entity is object, get all the subject content_types
+    for p in properties_with_entity_as_object:
+        subjs = p.subj_class.all()
+        content_type_querysets.append(subjs)
+
+    # Join querysets with itertools.chain, call set to make unique, and extract the model class
+    return set(itertools.chain(*content_type_querysets))
+
+
+def triple_sidebar(obj: object, request, detail=True):
+    content_type = ContentType.objects.get_for_model(obj)
+    side_bar = []
+
+    triples_related_all = (
+        TempTriple.objects_inheritance.filter(Q(subj__pk=obj.pk) | Q(obj__pk=obj.pk))
+        .all()
+        .select_subclasses()
+    )
+
+    for other_content_type in get_content_types_with_allowed_relation_from(
+        content_type
+    ):
+        triples_related_by_entity = triples_related_all.filter(
+            (Q(subj__self_contenttype=other_content_type) & Q(obj__pk=obj.pk))
+            | (Q(obj__self_contenttype=other_content_type) & Q(subj__pk=obj.pk))
+        )
+
+        table_class = get_generic_triple_table(
+            other_entity_class_name=other_content_type.model,
+            entity_pk_self=obj.pk,
+            detail=detail,
+        )
+
+        prefix = f"{other_content_type.model}"
+        title_card = other_content_type.name
+        tb_object = table_class(data=triples_related_by_entity, prefix=prefix)
+        tb_object_open = request.GET.get(prefix + "page", None)
+        entity_settings = get_entity_settings_by_modelname(content_type.model)
+        per_page = entity_settings.get("relations_per_page", 10)
+        RequestConfig(request, paginate={"per_page": per_page}).configure(tb_object)
+        tab_id = f"triple_form_{content_type.model}_to_{other_content_type.model}"
+        side_bar.append(
+            (
+                title_card,
+                tb_object,
+                tab_id,
+                tb_object_open,
+            )
+        )
+    return side_bar

--- a/apis_core/history/utils.py
+++ b/apis_core/history/utils.py
@@ -1,9 +1,9 @@
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django_tables2 import RequestConfig
 
 from apis_core.apis_relations.tables import get_generic_triple_table
-from apis_core.utils.helpers import get_content_types_with_allowed_relation_from
 from apis_core.utils.settings import get_entity_settings_by_modelname
 
 
@@ -17,37 +17,45 @@ def triple_sidebar_history(obj: object, request, detail=True):
             | Q(version_tag__contains=f"{obj.version_tag},")
         )
     content_type = ContentType.objects.get_for_model(obj.instance_type)
-    for other_content_type in get_content_types_with_allowed_relation_from(
-        content_type
-    ):
-        triples_related_by_entity = triples_related_all.filter(
-            (Q(subj__self_contenttype=other_content_type) & Q(obj__pk=obj.instance.pk))
-            | (
-                Q(obj__self_contenttype=other_content_type)
-                & Q(subj__pk=obj.instance.pk)
-            )
+    if "apis_core.apis_relations" in settings.INSTALLED_APPS:
+        from apis_core.apis_relations.utils import (
+            get_content_types_with_allowed_relation_from,
         )
 
-        table_class = get_generic_triple_table(
-            other_entity_class_name=other_content_type.model,
-            entity_pk_self=obj.instance.pk,
-            detail=detail,
-        )
-
-        prefix = f"{other_content_type.model}"
-        title_card = other_content_type.name
-        tb_object = table_class(data=triples_related_by_entity, prefix=prefix)
-        tb_object_open = request.GET.get(prefix + "page", None)
-        entity_settings = get_entity_settings_by_modelname(content_type.model)
-        per_page = entity_settings.get("relations_per_page", 10)
-        RequestConfig(request, paginate={"per_page": per_page}).configure(tb_object)
-        tab_id = f"triple_form_{content_type.model}_to_{other_content_type.model}"
-        side_bar.append(
-            (
-                title_card,
-                tb_object,
-                tab_id,
-                tb_object_open,
+        for other_content_type in get_content_types_with_allowed_relation_from(
+            content_type
+        ):
+            triples_related_by_entity = triples_related_all.filter(
+                (
+                    Q(subj__self_contenttype=other_content_type)
+                    & Q(obj__pk=obj.instance.pk)
+                )
+                | (
+                    Q(obj__self_contenttype=other_content_type)
+                    & Q(subj__pk=obj.instance.pk)
+                )
             )
-        )
+
+            table_class = get_generic_triple_table(
+                other_entity_class_name=other_content_type.model,
+                entity_pk_self=obj.instance.pk,
+                detail=detail,
+            )
+
+            prefix = f"{other_content_type.model}"
+            title_card = other_content_type.name
+            tb_object = table_class(data=triples_related_by_entity, prefix=prefix)
+            tb_object_open = request.GET.get(prefix + "page", None)
+            entity_settings = get_entity_settings_by_modelname(content_type.model)
+            per_page = entity_settings.get("relations_per_page", 10)
+            RequestConfig(request, paginate={"per_page": per_page}).configure(tb_object)
+            tab_id = f"triple_form_{content_type.model}_to_{other_content_type.model}"
+            side_bar.append(
+                (
+                    title_card,
+                    tb_object,
+                    tab_id,
+                    tb_object_open,
+                )
+            )
     return side_bar

--- a/apis_core/utils/helpers.py
+++ b/apis_core/utils/helpers.py
@@ -1,47 +1,12 @@
 import difflib
-import itertools
 
 from django.apps import apps
-from django.contrib.contenttypes.models import ContentType
 from django.core import serializers
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS, router
-from django.db.models import Q
-from django_tables2 import RequestConfig
 
 from apis_core.apis_metainfo.models import Uri
-from apis_core.apis_relations.models import Property, TempTriple
-from apis_core.apis_relations.tables import get_generic_triple_table
 from apis_core.generic.helpers import first_member_match, module_paths
-from apis_core.utils.settings import get_entity_settings_by_modelname
-
-
-def get_content_types_with_allowed_relation_from(
-    content_type: ContentType,
-) -> list[ContentType]:
-    """Returns a list of ContentTypes to which the given ContentTypes may be related by a Property"""
-
-    # Find all the properties where the entity is either subject or object
-    properties_with_entity_as_subject = Property.objects.filter(
-        subj_class=content_type
-    ).prefetch_related("obj_class")
-    properties_with_entity_as_object = Property.objects.filter(
-        obj_class=content_type
-    ).prefetch_related("subj_class")
-
-    content_type_querysets = []
-
-    # Where entity is subject, get all the object content_types
-    for p in properties_with_entity_as_subject:
-        objs = p.obj_class.all()
-        content_type_querysets.append(objs)
-    # Where entity is object, get all the subject content_types
-    for p in properties_with_entity_as_object:
-        subjs = p.subj_class.all()
-        content_type_querysets.append(subjs)
-
-    # Join querysets with itertools.chain, call set to make unique, and extract the model class
-    return set(itertools.chain(*content_type_querysets))
 
 
 def datadump_get_objects(models: list = [], *args, **kwargs):
@@ -96,49 +61,6 @@ def datadump_serializer(additional_app_labels: list = [], serialier_format="json
         datadump_get_queryset(additional_app_labels),
         use_natural_foreign_keys=True,
     )
-
-
-def triple_sidebar(obj: object, request, detail=True):
-    content_type = ContentType.objects.get_for_model(obj)
-    side_bar = []
-
-    triples_related_all = (
-        TempTriple.objects_inheritance.filter(Q(subj__pk=obj.pk) | Q(obj__pk=obj.pk))
-        .all()
-        .select_subclasses()
-    )
-
-    for other_content_type in get_content_types_with_allowed_relation_from(
-        content_type
-    ):
-        triples_related_by_entity = triples_related_all.filter(
-            (Q(subj__self_contenttype=other_content_type) & Q(obj__pk=obj.pk))
-            | (Q(obj__self_contenttype=other_content_type) & Q(subj__pk=obj.pk))
-        )
-
-        table_class = get_generic_triple_table(
-            other_entity_class_name=other_content_type.model,
-            entity_pk_self=obj.pk,
-            detail=detail,
-        )
-
-        prefix = f"{other_content_type.model}"
-        title_card = other_content_type.name
-        tb_object = table_class(data=triples_related_by_entity, prefix=prefix)
-        tb_object_open = request.GET.get(prefix + "page", None)
-        entity_settings = get_entity_settings_by_modelname(content_type.model)
-        per_page = entity_settings.get("relations_per_page", 10)
-        RequestConfig(request, paginate={"per_page": per_page}).configure(tb_object)
-        tab_id = f"triple_form_{content_type.model}_to_{other_content_type.model}"
-        side_bar.append(
-            (
-                title_card,
-                tb_object,
-                tab_id,
-                tb_object_open,
-            )
-        )
-    return side_bar
 
 
 def get_importer_for_model(model: object):


### PR DESCRIPTION
This commit moves a couple of methos and templatetags into the
`apis_relations` module, that were previously spread over the `utils`
and the `apis_entities` module. Having them contained in the
`apis_relations` module moves us one step further in being able to allow
disabling the `apis_relations` module.
