### PR TITLE
refactor(utils): drop unused functions

### DIFF
--- a/apis_core/utils/settings.py
+++ b/apis_core/utils/settings.py
@@ -2,18 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from pathlib import Path
 
 import tomllib
 from django.conf import settings
 from django.template.utils import get_app_template_dirs
 
 logger = logging.getLogger(__name__)
-
-
-def default_settings() -> Path:
-    curpath = Path(__file__).parent
-    return curpath.parent / "default_settings"
 
 
 def get_entity_settings_by_modelname(entity: str = None) -> dict:
@@ -26,10 +20,6 @@ def get_entity_settings_by_modelname(entity: str = None) -> dict:
         # lookup entity settings by name and by capitalized name
         return apis_entities.get(entity, apis_entities.get(entity.capitalize(), {}))
     return apis_entities
-
-
-def list_links_to_edit() -> bool:
-    return getattr(settings, "APIS_LIST_LINKS_TO_EDIT", False)
 
 
 def dict_from_toml_directory(directory: str) -> dict:


### PR DESCRIPTION
The default_settings and the list_links_to_edit functions are not used
anywhere in the apis-core-rdf codebase.
