### PR TITLE
fix(relations): when target is None list_relations shouldn't fail

### DIFF
--- a/apis_core/relations/templates/relations/list_relations.html
+++ b/apis_core/relations/templates/relations/list_relations.html
@@ -1,6 +1,7 @@
 {% load relations %}
 {% load django_tables2 %}
-<div id="rel_{{ object.id }}_{{ target.name }}" hx-swap-oob="true">
+<div id="rel_{{ object.id }}_{% if target is None %}all{% else %}{{ target.name }}{% endif %}"
+     hx-swap-oob="true">
 
   {% block relations_list %}
     {% relations_list_table relations target as table %}


### PR DESCRIPTION
This pull request includes a change to the `apis_core/relations/templates/relations/list_relations.html` file to handle cases where the `target` variable is `None`. The change ensures that the `id` attribute of the `div` element is suffixed with "all" when `target` is `None`.

Template Update:

* [`apis_core/relations/templates/relations/list_relations.html`](diffhunk://#diff-3f3cf83aeabce3021058f7372b6a6702a5dd9457c8bf15343d6204decc350465L3-R4): Modified the `id` attribute of the `div` element to use "all" when the `target` variable is `None`.