### PR TITLE
Solve issues with footer links/icons

### DIFF
--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -11,3 +11,8 @@ footer a:has(> img),
 footer a:has(> span[class*="material-symbols"]) {
     display: inline-block;
 }
+
+footer a:has(> img):hover,
+footer a:has(> span[class*="material-symbols"]):hover {
+    text-decoration: none;
+}

--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -6,3 +6,8 @@
 a #logo:hover {
     opacity: 0.5;
 }
+
+footer a:has(> img),
+footer a:has(> span[class*="material-symbols"]) {
+    display: inline-block;
+}

--- a/apis_core/core/templates/partials/footer-left.html
+++ b/apis_core/core/templates/partials/footer-left.html
@@ -2,19 +2,19 @@
 {% load static %}
 {% url "apis_core:apis_api:api-root" as api_root %}
 {% if api_root %}
-  <a href="{{ api_root }}" title="API">
+  <a href="{{ api_root }}">
     <span class="material-symbols-outlined material-symbols-align">api</span>
   </a>
 {% endif %}
 {% url "apis_core:swagger-ui" as swagger_ui %}
 {% if swagger_ui %}
-  <a href="{{ swagger_ui }}" title="Swagger UI">
-    <img src="{% static "/img/Swagger-logo.png" %}" height="24px">
+  <a href="{{ swagger_ui }}">
+    <img src="{% static "/img/Swagger-logo.png" %}" alt="Swagger UI" height="24px">
   </a>
 {% endif %}
 {% git_repository_url as repository_url %}
 {% if repository_url %}
-  <a href="{{ repository_url }}" title="Git repository">
-    <img src="{% static "/img/Git-Icon-1788C.png" %}" height="24px">
+  <a href="{{ repository_url }}">
+    <img src="{% static "/img/Git-Icon-1788C.png" %}" alt="Git repository" height="24px">
   </a>
 {% endif %}


### PR DESCRIPTION
This solves the `<a>` size issue and whitespace getting underlined as described in #1343 and replaces `title` attributes on links with `alt` attributes on images.

In FF, the place where the link destinations are displayed still switches randomly (apparently) between bottom left and right corner for me, but they now display fine in Chrome. I'm wondering if the reason for the flip-flopping in FF may be too little space left (interpreted by the browser) below the individual links. (Will need further investigation.)