### PR TITLE
fix(core): fix footer link dimensions

### DIFF
--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -7,6 +7,11 @@ a #logo:hover {
     opacity: 0.5;
 }
 
+footer a:has(> img),
+footer a:has(> span[class*="material-symbols"]) {
+    display: inline-block;
+}
+
 footer a:has(> img):hover,
 footer a:has(> span[class*="material-symbols"]):hover {
     text-decoration: none;


### PR DESCRIPTION
Set display property of links in site footer
which are visualised by icons – which contain
images or <span> tags for Material Symbols –
to inline-block to make them fit the icons'
dimensions. Prevents links that are smaller
in size than their visual content, which can
cause unexpected behaviour when hovering.

Solves one of the issues described in #1343. 