### PR TITLE
fix(core): don't underline hovered footer icon links

### DIFF
--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -6,3 +6,8 @@
 a #logo:hover {
     opacity: 0.5;
 }
+
+footer a:has(> img):hover,
+footer a:has(> span[class*="material-symbols"]):hover {
+    text-decoration: none;
+}


### PR DESCRIPTION
Set text-decoration property to none for
hovered footer links which contain icons to
prevent whitespace between links/icons from
getting underlined (default effect when text
links are hovered).

Solves one of the issues described in https://github.com/acdh-oeaw/apis-core-rdf/issues/1343.