### PR TITLE
fix(generic): use copy instead of working with the original field

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from copy import copy
 from typing import Optional
 
 from dal import autocomplete
@@ -133,7 +134,8 @@ class List(
         # are part of the selected columns to the extra_columns
         annotationfields = list()
         for key, value in self.object_list.query.annotations.items():
-            fake_field = getattr(value, "field", value.output_field)
+            # we have to use copy, so we don't edit the original field
+            fake_field = copy(getattr(value, "field", value.output_field))
             setattr(fake_field, "name", key)
             annotationfields.append(fake_field)
         extra_fields = list(


### PR DESCRIPTION
If we create `fake_field` by simply using `getattr` on the
`annotations.items()` we actually get the original field and then change
its name in the next line. But thats not what we want, because that
changes the field for the model it belongs to. We only want a temporary
field, so we can add it to the `extra_columns`.

Closes: #1346
