### PR TITLE
fix(relations): order fields before initializing FormHelper

### DIFF
--- a/apis_core/relations/forms.py
+++ b/apis_core/relations/forms.py
@@ -169,6 +169,7 @@ class RelationForm(GenericModelForm):
                         (select_identifier, self.obj_instance)
                     ]
 
+        self.order_fields(self.field_order)
         self.helper = FormHelper(self)
         model_ct = ContentType.objects.get_for_model(self.Meta.model)
         self.helper.form_id = f"relation_{model_ct.model}_form"


### PR DESCRIPTION
Since RelationForm creates new form fields in its init method, `order_fields` must be called after these fields are created and before `FormHelper` is initialized to ensure the desired `field_order` is rendered correctly.

fixes #1355