### PR TITLE
fix(relations): fix modal overflow to access dropdown

### DIFF
--- a/apis_core/relations/static/css/relations.css
+++ b/apis_core/relations/static/css/relations.css
@@ -6,8 +6,7 @@
 #relationdialog {
     border: 1px solid black;
     border-radius: .3rem;
-    overflow-x: visible;
-    overflow-y: scroll;
+    overflow: visible;
     padding: 0;
     opacity: 1;
     transform: scale(1);
@@ -21,4 +20,6 @@
 
 #relation-dialog-content {
     padding: 1rem;
+    overflow-y: auto;
+    max-height: 80vh;
 }


### PR DESCRIPTION
reverted modal dialog overflow to `visible` in the new relations form so that when the dialog height is shorter than the dropdown, the dropdown remains accessible without having to scroll the dialog.

introduced max-height and auto scroll option for `#relation-dialog-content` so that when the contents of the dialog overflows the dialog height, the dialog is scrollable (maintains the behaviour of fix #1351)

closes #1359