### PR TITLE
fix(apis_entities): remove merge form from the entities edit view

### DIFF
--- a/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity_form.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity_form.html
@@ -1,6 +1,5 @@
 {% extends "apis_core/apis_entities/abstractentity.html" %}
 {% load crispy_forms_tags %}
-{% load apis_entities %}
 {% load static %}
 
 {% block col-zero %}
@@ -9,18 +8,6 @@
     <div class="card-footer">{% include "apis_entities/partials/linked_open_data.html" %}</div>
   </div>
 {% endblock col-zero %}
-
-{% block col-one %}
-  {{ block.super }}
-  <div class="card mt-2">
-    <div class="card-body">
-      {% mergeform as mergeform %}
-      {% if mergeform %}
-        {% crispy mergeform mergeform.helper %}
-      {% endif %}
-    </div>
-  </div>
-{% endblock col-one %}
 
 {% block scripts %}
   {{ block.super }}

--- a/apis_core/apis_entities/templatetags/apis_entities.py
+++ b/apis_core/apis_entities/templatetags/apis_entities.py
@@ -1,7 +1,6 @@
 from django import template
 from django.contrib.contenttypes.models import ContentType
 
-from apis_core.apis_entities.forms import EntitiesMergeForm
 from apis_core.apis_entities.models import AbstractEntity
 from apis_core.apis_entities.utils import get_entity_classes
 
@@ -48,9 +47,3 @@ def entities_verbose_name_plural_listview_url():
         for entity in get_entity_classes()
     }
     return sorted(ret.items())
-
-
-@register.simple_tag(takes_context=True)
-def mergeform(context):
-    obj = context["object"]
-    return EntitiesMergeForm(instance=obj)


### PR DESCRIPTION
Remove the merge form from the default entities edit view, given that
there is a more powerful merge view that should be used instead.

Closes: #1285
