### PR TITLE
fix(core): remove leading slash from static files

### DIFF
--- a/apis_core/core/templates/partials/footer-left.html
+++ b/apis_core/core/templates/partials/footer-left.html
@@ -9,12 +9,12 @@
 {% url "apis_core:swagger-ui" as swagger_ui %}
 {% if swagger_ui %}
   <a href="{{ swagger_ui }}" title="Swagger UI">
-    <img src="{% static "/img/Swagger-logo.png" %}" alt="Swagger UI" height="24px">
+    <img src="{% static "img/Swagger-logo.png" %}" alt="Swagger UI" height="24px">
   </a>
 {% endif %}
 {% git_repository_url as repository_url %}
 {% if repository_url %}
   <a href="{{ repository_url }}" title="Git repository">
-    <img src="{% static "/img/Git-Icon-1788C.png" %}" alt="Git repository" height="24px">
+    <img src="{% static "img/Git-Icon-1788C.png" %}" alt="Git repository" height="24px">
   </a>
 {% endif %}


### PR DESCRIPTION
The leading slashes seem to lead to confusing errors from the django
debug toolbar and the `url` method of the configured storages remove it
anyway:
https://github.com/django/django/blob/d71c588d83e58e83bdd9ea8bf03724d10f02a8bd/django/core/files/storage/filesystem.py#L225

Closes: #1339
