### PR TITLE
feat(relations): graph visualisation of relations

### DIFF
--- a/apis_core/relations/templates/relations/graph_relations.html
+++ b/apis_core/relations/templates/relations/graph_relations.html
@@ -1,0 +1,10 @@
+{% load relations %}
+{% relations_graph relations target as graph %}
+{% if graph.error %}<div class="alert alert-warning" role="alert">{{ graph.error }}</div>{% endif %}
+{% if graph.svg %}
+  <div class="d-flex justify-content-center"
+       style="overflow: auto;
+              max-width: 100%">
+    <div id="svg-container">{{ graph.svg|safe }}</div>
+  </div>
+{% endif %}

--- a/apis_core/relations/templates/relations/list_relations_include_tabs.html
+++ b/apis_core/relations/templates/relations/list_relations_include_tabs.html
@@ -17,6 +17,9 @@
              href="#reltab_{{ object.id }}_{{ target.name }}">{{ target.name | title }}</a>
         </li>
       {% endfor %}
+      <li class="nav-item">
+        <a class="nav-link" data-toggle="tab" href="#reltab_graph">Graph</a>
+      </li>
     </ul>
   </div>
   <div class="card-body">
@@ -25,6 +28,7 @@
       {% for target in possible_targets %}
         <div class="tab-pane" id="reltab_{{ object.id }}_{{ target.name }}">{% include "relations/list_relations.html" %}</div>
       {% endfor %}
+      <div class="tab-pane" id="reltab_graph">{% include "relations/graph_relations.html" %}</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a Graph tab to the tabbed relations template. Graph tab shows a graphical representation of the all relations that include the current object.
Nodes represent objects, each entity type deterministically gets a unique colour.
All edges are directed from the object to the related objects.