### PR TITLE
feat(core): introduce a MaintenanceMiddleware

### DIFF
--- a/apis_core/core/middleware.py
+++ b/apis_core/core/middleware.py
@@ -1,0 +1,24 @@
+import logging
+from pathlib import Path
+
+from django.conf import settings
+from django.shortcuts import render
+
+logger = logging.getLogger(__name__)
+
+
+class MaintenanceMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        maintenance_file = getattr(
+            settings, "APIS_MAINTENANCE_FILE", "apis_maintenance"
+        )
+        if Path(maintenance_file).exists():
+            logger.warning("Site is running in maintenance mode")
+            if hasattr(request, "user"):
+                if request.user.is_superuser:
+                    return self.get_response(request)
+            return render(request, "maintenance.html")
+        return self.get_response(request)

--- a/apis_core/core/static/css/maintenance.css
+++ b/apis_core/core/static/css/maintenance.css
@@ -1,0 +1,20 @@
+body {
+    text-align: center;
+    padding: 150px;
+}
+
+h1 {
+    font-size: 50px;
+}
+
+body {
+    font: 20px Helvetica, sans-serif;
+    color: #333;
+}
+
+article {
+    display: block;
+    text-align: left;
+    width: 650px;
+    margin: 0 auto;
+}

--- a/apis_core/core/templates/maintenance.html
+++ b/apis_core/core/templates/maintenance.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en">
+  <link href="{% static 'css/maintenance.css' %}" rel="stylesheet" />
+  <head>
+    <meta charset="UTF-8">
+    <title>Site Maintenance</title>
+  </head>
+  <body>
+    <article>
+      <h1>We&rsquo;ll be back soon!</h1>
+      <div>
+        <p>
+          Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. We&rsquo;ll be back online shortly!
+        </p>
+        <p>&mdash; The Team</p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -134,3 +134,20 @@ Allows to define a function that receives the view - including e.g. the
 `request` object - and a queryset and can do custom filtering on that queryset.
 This can be used to set the listviews to public using the
 `APIS_LIST_VIEWS_ALLOWED` setting, but still only list specific entities.
+
+
+Maintenance Middleware
+^^^^^^^^^^^^^^^^^^^^^^
+
+APIS ships a maintenance middlware that you can use and activate to enable a maintenance mode in your project.
+Maintenance mode means that only superuser accounts can access the webinterfaces, all other requests are being
+answered with a simple maintenance mode page (the ``maintenance.html`` template).
+To use the middleware, add
+
+.. code-block:: python
+
+   "apis_core.core.middleware.MaintenanceMiddleware"
+
+to your ``settings.MIDDLEWARE`` list. To activate the maintenance mode once the middlware is enabled, simply
+create a file ``apis_maintenance`` in the directory the main Django process runs in.
+The path of the maintenance file can be changed in the settings: ``APIS_MAINTENANCE_FILE = "path of the file"``


### PR DESCRIPTION
Add a MaintenanceMiddleware that allows to set APIS in maintenance mode.
Maintenance mode allows superusers to access the site, but all other
requests get a simple maintenance page as a response.
This can be enabled by adding
`apis_core.core.middleware.MaintenanceMiddleware` to
`settings.MIDDLEWARE`. To active the maintenance mode simply create a
`/tmp/apis_maintenance` file. To deactivate maintenance mode, remove
that file.

Closes: #1296
