### PR TITLE
refactor(relations): put display logic of relations in a block

### DIFF
--- a/apis_core/relations/templates/relations/list_relations_include.html
+++ b/apis_core/relations/templates/relations/list_relations_include.html
@@ -2,9 +2,12 @@
 {% relations_from from_obj=object as relations %}
 {% possible_relation_types_from object as possible_relations %}
 {% get_relation_targets_from object as possible_targets %}
-{% for target in possible_targets %}
-  <div class="card mb-2">
-    <div class="card-header">{{ target.name }}</div>
-    <div class="card-body">{% include "relations/list_relations.html" %}</div>
-  </div>
-{% endfor %}
+
+{% block display-relations %}
+  {% for target in possible_targets %}
+    <div class="card mb-2">
+      <div class="card-header">{{ target.name }}</div>
+      <div class="card-body">{% include "relations/list_relations.html" %}</div>
+    </div>
+  {% endfor %}
+{% endblock display-relations %}

--- a/apis_core/relations/templates/relations/list_relations_include_tabs.html
+++ b/apis_core/relations/templates/relations/list_relations_include_tabs.html
@@ -1,30 +1,30 @@
-{% load relations %}
-{% relations_from from_obj=object as relations %}
-{% possible_relation_types_from object as possible_relations %}
-{% get_relation_targets_from object as possible_targets %}
-<div class="card mb-2">
-  <div class="card-header pb-0 border-bottom-0">
-    <ul class="nav nav-tabs">
-      <li class="nav-item">
-        <a class="nav-link active"
-           data-toggle="tab"
-           href="#reltab_{{ object.id }}_ALL">All</a>
-      </li>
-      {% for target in possible_targets %}
+{% extends "relations/list_relations_include.html" %}
+
+{% block display-relations %}
+  <div class="card mb-2">
+    <div class="card-header pb-0 border-bottom-0">
+      <ul class="nav nav-tabs">
         <li class="nav-item">
-          <a class="nav-link"
+          <a class="nav-link active"
              data-toggle="tab"
-             href="#reltab_{{ object.id }}_{{ target.name }}">{{ target.name | title }}</a>
+             href="#reltab_{{ object.id }}_ALL">All</a>
         </li>
-      {% endfor %}
-    </ul>
-  </div>
-  <div class="card-body">
-    <div class="tab-content">
-      <div class="tab-pane active" id="reltab_{{ object.id }}_ALL">{% include "relations/list_relations.html" %}</div>
-      {% for target in possible_targets %}
-        <div class="tab-pane" id="reltab_{{ object.id }}_{{ target.name }}">{% include "relations/list_relations.html" %}</div>
-      {% endfor %}
+        {% for target in possible_targets %}
+          <li class="nav-item">
+            <a class="nav-link"
+               data-toggle="tab"
+               href="#reltab_{{ object.id }}_{{ target.name }}">{{ target.name | title }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="card-body">
+      <div class="tab-content">
+        <div class="tab-pane active" id="reltab_{{ object.id }}_ALL">{% include "relations/list_relations.html" %}</div>
+        {% for target in possible_targets %}
+          <div class="tab-pane" id="reltab_{{ object.id }}_{{ target.name }}">{% include "relations/list_relations.html" %}</div>
+        {% endfor %}
+      </div>
     </div>
   </div>
-</div>
+{% endblock display-relations %}


### PR DESCRIPTION
this way `list_relations_include_tabs` can inherit from the `list_relations_include` template and not contain redundant code to fetch the relations data

@b1rger the large diff is not my fault, it's djlint, my change is only 3 lines :-0 

![image](https://github.com/user-attachments/assets/58e8978d-e23a-4d29-95fd-ca056b5a1297)
