### PR TITLE
fix(relations): support modelselect2multiple fields

### DIFF
--- a/apis_core/relations/static/js/relation_dialog.js
+++ b/apis_core/relations/static/js/relation_dialog.js
@@ -5,7 +5,7 @@ function tohtml(item) {
 }
 document.body.addEventListener("reinit_select2", function(evt) {
     form = document.getElementById(evt.detail.value);
-    form.querySelectorAll(".listselect2").forEach(element => {
+    form.querySelectorAll(".listselect2, .modelselect2multiple, .modelselect2").forEach(element => {
         $(element).select2({
             ajax: {
                 url: $(element).data("autocomplete-light-url"),


### PR DESCRIPTION
This pull request includes a change to the `tohtml` function in the `relation_dialog.js` file to enhance the functionality of the `select2` initialization.

Enhancements to `select2` initialization:

* [`apis_core/relations/static/js/relation_dialog.js`](diffhunk://#diff-348bcae18586c8a83583596ccf46a4858b42bb5886c6b65f736d894456d9fcd4L8-R8): Modified the `form.querySelectorAll` method to include additional selectors `.modelselect2multiple` and `.modelselect2` for initializing `select2`.