### PR TITLE
fix(utils): add a `raise_on_fail` argument to the object create function

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -328,7 +328,7 @@ class Autocomplete(
         return results
 
     def create_object(self, value):
-        return create_object_from_uri(value, self.queryset.model)
+        return create_object_from_uri(value, self.queryset.model, raise_on_fail=True)
 
     def post(self, request, *args, **kwargs):
         try:

--- a/apis_core/utils/helpers.py
+++ b/apis_core/utils/helpers.py
@@ -71,7 +71,7 @@ def get_importer_for_model(model: object):
     raise ImproperlyConfigured(f"No suitable importer found for {model}")
 
 
-def create_object_from_uri(uri: str, model: object) -> object:
+def create_object_from_uri(uri: str, model: object, raise_on_fail=False) -> object:
     if uri.startswith("http"):
         try:
             uri = Uri.objects.get(uri=uri)
@@ -82,10 +82,12 @@ def create_object_from_uri(uri: str, model: object) -> object:
             instance = importer.create_instance()
             uri = Uri.objects.create(uri=importer.get_uri, root_object=instance)
             return instance
-    content_type = ContentType.objects.get_for_model(model)
-    raise ImproperlyConfigured(
-        f'Could not create {content_type.name} from string "{uri}"'
-    )
+    if raise_on_fail:
+        content_type = ContentType.objects.get_for_model(model)
+        raise ImproperlyConfigured(
+            f'Could not create {content_type.name} from string "{uri}"'
+        )
+    return False
 
 
 def get_html_diff(a, b, show_a=True, show_b=True, shorten=0):


### PR DESCRIPTION
This allows the calling function to define how it wants the
`create_object_from_uri` function to communicate errors. This is not
pretty and we might want to rethink that function in the future, but for
now it allows the two places that call that function to both keep
working.

Closes: #1405
