### PR TITLE
fix(history): drop TempTripleHistoryLogs api view

### DIFF
--- a/apis_core/history/api_views.py
+++ b/apis_core/history/api_views.py
@@ -1,7 +1,5 @@
-from django.db.models import Q
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
-from apis_core.apis_relations.models import TempTriple
 from apis_core.history.serializers import (
     HistoryLogSerializer,
     HistoryObjectSerializer,
@@ -17,14 +15,6 @@ class EntityHistoryLogs(ListAPIView):
             .model_class()
             .history.filter(id=self.kwargs.get("pk"))
         )
-
-
-class TempTripleHistoryLogs(ListAPIView):
-    serializer_class = HistoryLogSerializer
-
-    def get_queryset(self):
-        id = self.kwargs.get("pk")
-        return TempTriple.history.filter(Q(subj_id=id) | Q(obj_id=id))
 
 
 class GenericHistoryLog(RetrieveAPIView):

--- a/apis_core/history/urls.py
+++ b/apis_core/history/urls.py
@@ -4,7 +4,6 @@ from apis_core.history import views
 from apis_core.history.api_views import (
     EntityHistoryLogs,
     GenericHistoryLog,
-    TempTripleHistoryLogs,
 )
 
 app_name = "history"
@@ -25,11 +24,6 @@ urlpatterns = [
         "api/version_log/<contenttype:contenttype>/<int:pk>/",
         EntityHistoryLogs.as_view(),
         name="entityhistorylog",
-    ),
-    path(
-        "api/version_log/temp_triple/<int:pk>/",
-        TempTripleHistoryLogs.as_view(),
-        name="temptriplehistorylog",
     ),
     path(
         "api/entity_combined/<contenttype:contenttype>/<int:pk>/",


### PR DESCRIPTION
Remove the TempTripleHistoryLogs API view, because it has a hardcoded
dependency on the TempTriple model and therefore *needs* the
`apis_core.apis_relations` app in the INSTALLED_APPS.
Together with the API view we are also dropping the url pointing to the
API view.
