### PR TITLE
ci(djlint): change the name of the workflow to reflect what it does

### DIFF
--- a/.github/workflows/djlint.yml
+++ b/.github/workflows/djlint.yml
@@ -1,6 +1,6 @@
 #SPDX-FileCopyrightText: 2023 Birger Schacht
 #SPDX-License-Identifier: MIT
-name: Run djLint Linter
+name: Run djLint Formatter
 
 on: [push, pull_request]
 


### PR DESCRIPTION
The workflow we are including does call djlint with `--check` option,
which checks the formatting of the the template, but does not lint the
template. Therefore using `Formatter` instead of `Linter` in the
template is more correct.

Closes: #1371
