### PR TITLE
fix(core): harmonize footer icon dimension specification

### DIFF
--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -1,8 +1,3 @@
-/* project/site logo in footer */
-#logo {
-    height: 1.5em;
-}
-
 a #logo:hover {
     opacity: 0.5;
 }
@@ -29,4 +24,9 @@ footer a:has(> span[class*="material-symbols"]):hover {
     right: 20px;
     display: none;
     opacity: 0.5;
+}
+
+footer .icon {
+    height: 1em;
+    font-size: 1.5em;
 }

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -224,6 +224,7 @@
             {% block footer-center %}
               <a href="https://www.oeaw.ac.at/acdh/">
                 <img id="logo"
+                     class="icon"
                      alt="ACDH Logo"
                      title="Austrian Centre for Digital Humanities (ACDH) of the Austrian Academy of Sciences"
                      src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg" />

--- a/apis_core/core/templates/partials/footer-left.html
+++ b/apis_core/core/templates/partials/footer-left.html
@@ -3,18 +3,18 @@
 {% url "apis_core:api-root" as api_root %}
 {% if api_root %}
   <a href="{{ api_root }}" title="API">
-    <span class="material-symbols-outlined material-symbols-align">api</span>
+    <span class="material-symbols-outlined material-symbols-align icon">api</span>
   </a>
 {% endif %}
 {% url "apis_core:swagger-ui" as swagger_ui %}
 {% if swagger_ui %}
   <a href="{{ swagger_ui }}" title="Swagger UI">
-    <img src="{% static "img/Swagger-logo.png" %}" alt="Swagger UI" height="24px">
+    <img class="icon" src="{% static "img/Swagger-logo.png" %}" alt="Swagger UI">
   </a>
 {% endif %}
 {% git_repository_url as repository_url %}
 {% if repository_url %}
   <a href="{{ repository_url }}" title="Git repository">
-    <img src="{% static "img/Git-Icon-1788C.png" %}" alt="Git repository" height="24px">
+    <img class="icon" src="{% static "img/Git-Icon-1788C.png" %}" alt="Git repository">
   </a>
 {% endif %}


### PR DESCRIPTION
Introduce *one* place to specify dimensions for footer icons in the CSS
file by adding an `icon` class to the elements. This replaces the inline
`height` settings, the CSS `#logo` definition and overwrites the
`height` and `font-size` settings for the material symbol if used in the
footer with the icon class.

Closes: #1340
