### PR TITLE
fix: allow for sameAs links

### DIFF
--- a/apis_core/utils/rdf.py
+++ b/apis_core/utils/rdf.py
@@ -68,6 +68,20 @@ def get_definition_and_attributes_from_uri(
             break
     model_attributes = dict()
     if matching_definition:
+        sameas = matching_definition.get(
+            "sameas",
+            """
+            PREFIX owl: <http://www.w3.org/2002/7/owl#>
+            SELECT ?sameas WHERE {
+                ?subject owl:sameAs ?sameas .
+            }
+        """,
+        )
+        model_attributes["sameas"] = []
+        result = graph.query(sameas)
+        for binding in result.bindings:
+            for value in binding.values():
+                model_attributes["sameas"].append(str(value))
         attributes = matching_definition.get("attributes", [])
         sparql_attributes = list(filter(lambda d: d.get("sparql"), attributes))
         for attribute in sparql_attributes:


### PR DESCRIPTION
To resolve the sameAs problem described in #819 we need to get the sameAs URIs defined in the RDF files. Other than originally thought not all of them are using `owl:sameAs`. This PR proposes another attribute in the toml definition that allows to set a sparql query that retrieves sameAs uris. Eg for Persons in Wikidata the definition could look like:
```toml
superclass = "apis_ontology.models.Person"
regex = "http://www.wikidata.org.*"
sameas = """
PREFIX wdtn: <http://www.wikidata.org/prop/direct-normalized/> 
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
SELECT ?sameas ?parl_url
WHERE {
?subject wdtn:P227 ?sameas
OPTIONAL {
?subject wdt:P2280 ?parl_nr .
BIND(concat("https://www.parlament.gv.at/WWER/PAD_", str(?parl_nr)) AS ?parl_url)
}
}
"""
[[attributes]]
# name
sparql = """
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
SELECT ?forename
WHERE {
  ?person wdt:P735/rdfs:label ?first_name .
  BIND(?first_name AS ?forename)
}
"""
```
This fetches the GND link and uses the Parlament Nr to create a link and returns that. As a fallback a query for owl:sameAs is used.
The PR also changes the `RootObject` to accept the sameas attribute retrieved via the sparql queries (or actually any list of uris) directly via putting them in the sameas attribute.

resolves #819