### PR TITLE
fix(generic): check for attribute `id` before using it

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -7,7 +7,9 @@ from apis_core.generic.helpers import permission_fullname
 
 class GenericModel:
     def __repr__(self):
-        return super().__repr__() + f" (ID: {self.id})"
+        if id := getattr(self, "id", None):
+            return super().__repr__() + f" (ID: {id})"
+        return super().__repr__()
 
     @classmethod
     def get_listview_url(cls):


### PR DESCRIPTION
Some models do not have an `id` attribute, therefore it makes sense to
check for its existence before using it in the __repr__ string.

Closes: #1450
