### PR TITLE
fix(apis_entities): replace the update link icon with text

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html
@@ -5,7 +5,7 @@
       <li>
         {{ uri.uri | urlize }}
         {% if object.get_change_permission in perms %}
-          <a href="{{ object.get_enrich_url }}?uri={{ uri.uri }}"><span class="material-symbols-outlined">network_intelligence_update</span></a>
+          | <a href="{{ object.get_enrich_url }}?uri={{ uri.uri }}" class="small">... merge data</a>
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
We want to provide a link to allow updating/enriching the entity with
data from external sources, but there is not really an icon that
reflects that action. So we use a simple link instead of an icon.
