### PR TITLE
feat(generic): allow to disable pagination in table class

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from copy import copy
-from typing import Optional
 
 from dal import autocomplete
 from django import forms, http
@@ -204,12 +203,14 @@ class List(
         queryset = first_member_match(queryset_methods) or (lambda x: x)
         return self.filter_queryset(queryset(self.model.objects.all()))
 
-    def get_paginate_by(self, table_data) -> Optional[int]:
+    def get_table_pagination(self, table):
         """
-        Override `get_paginate_by` from the tables2 TableMixinBase,
-        so we can set the paginate_by value as attribute of the table.
+        Override `get_table_pagination` from the tables2 TableMixinBase,
+        so we can set the paginate_by and the table_pagination value as attribute of the table.
         """
-        return getattr(self.get_table_class(), "paginate_by", None)
+        self.paginate_by = getattr(table, "paginate_by", None)
+        self.table_pagination = getattr(table, "table_pagination", None)
+        return super().get_table_pagination(table)
 
 
 class Detail(GenericModelMixin, PermissionRequiredMixin, DetailView):

--- a/docs/source/customization.rst
+++ b/docs/source/customization.rst
@@ -58,8 +58,9 @@ useful `django table columns
 that you might want to use.
 
 Your table can also contain a ``paginate_by`` attribute, which is then used
-by the list view to determines the number of items per page, or ``None`` for no
-pagination (which is the default).
+by the list view to determines the number of items per page. When this is not
+set, the page size defaults to ``25``. To disable pagination altogether, use
+``table_pagination = False``.
 
 The base queryset that is used in the listview, which is then filtered using
 the django-filters filter, is ``model.objects.all()`` - but you can override


### PR DESCRIPTION
Instead of overriding the `get_paginate_by` method of the
TableMixinBase, we now override the `get_table_pagination` method. This
allows to also set the `table_pagination` setting in the table
itself, therefore providing the means to disable the pagination
alltogether.

Closes: #1444
