### PR TITLE
refactor(generic): rename GenericMergeForm to GenericMergeWithForm

### DIFF
--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -88,7 +88,7 @@ class GenericModelForm(forms.ModelForm):
                     self.fields[field].widget.choices = self.fields[field].choices
 
 
-class GenericMergeForm(forms.Form):
+class GenericMergeWithForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -30,7 +30,7 @@ from .filtersets import GenericFilterSet
 from .forms import (
     GenericEnrichForm,
     GenericImportForm,
-    GenericMergeForm,
+    GenericMergeWithForm,
     GenericModelForm,
 )
 from .helpers import (
@@ -372,7 +372,7 @@ class MergeWith(GenericModelMixin, PermissionRequiredMixin, FormView):
     """
 
     permission_action_required = "change"
-    form_class = GenericMergeForm
+    form_class = GenericMergeWithForm
     template_name = "generic/generic_merge.html"
 
     def setup(self, *args, **kwargs):


### PR DESCRIPTION
The form is used in the `MergeWith` view, so it should be called
accordingly.
