### PR TITLE
fix(generic): exclude subclasses from columns selector

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -172,6 +172,7 @@ class List(
         choices = [
             (field.name, pretty_name(getattr(field, "verbose_name", field.name)))
             for field in self.model._meta.get_fields()
+            if field.name not in getattr(self.get_queryset(), "subclasses", [])
         ]
         # we add any annotated fields to that
         choices += [(key, key) for key in self.get_queryset().query.annotations.keys()]


### PR DESCRIPTION
We don't want to list subclasses as model attribute in the column
selector in the list view, but they are part of the fields list. If the
model uses the InheritanceManager we can check in the `subclasses`
attribute if the field refers to a subclass and exclude those.

Closes: #1297
