### PR TITLE
chore(sample_project): drop `apis_relation` from INSTALLED_APPS

### DIFF
--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  DJANGO_SETTINGS_MODULE: sample_project.settings
+  DJANGO_SETTINGS_MODULE: sample_project.settings_tests
 
 jobs:
   setup:

--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -44,7 +44,6 @@ INSTALLED_APPS = [
     # The APIS apps
     "apis_core.relations",
     "apis_core.apis_metainfo",
-    "apis_core.apis_relations",
     "apis_core.apis_entities",
     # apis_vocabularies is deprecated, but there are
     # still migrations depending on it - it will be dropped

--- a/sample_project/settings_tests.py
+++ b/sample_project/settings_tests.py
@@ -1,0 +1,3 @@
+from .settings import *
+
+INSTALLED_APPS += ["apis_core.apis_relations"]  # noqa: F405


### PR DESCRIPTION
We only use the new style relations in the sample project, so we can
drop the old ones.
