### PR TITLE
refactor(apis_entities): reorder E3_Place coordinate fields

### DIFF
--- a/apis_core/apis_entities/abc.py
+++ b/apis_core/apis_entities/abc.py
@@ -26,8 +26,8 @@ class E21_Person(models.Model):
 
 class E53_Place(models.Model):
     label = models.CharField(blank=True, default="", max_length=4096)
-    longitude = models.FloatField(blank=True, null=True)
     latitude = models.FloatField(blank=True, null=True)
+    longitude = models.FloatField(blank=True, null=True)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Swap `E3_Place` `latitude` and `longitude` fields
so that the fields appear in the order in which
geographic coordinates are given.
Relevant for views/tools which base the default
order of model fields on how they are originally
defined.

Closes: #1475