### PR TITLE
fix(generic,apis_entities): move action classes to generic app

### DIFF
--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -11,16 +11,3 @@
 .next-in-list {
     float: left;
 }
-
-/* additional object actions */
-.object-duplicate {
-    color: blueviolet;
-}
-
-.object-merge {
-    color: dodgerblue;
-}
-
-.object-history {
-    color: #007bff;
-}

--- a/apis_core/generic/static/css/generic.css
+++ b/apis_core/generic/static/css/generic.css
@@ -1,0 +1,12 @@
+/* additional object actions */
+.object-duplicate {
+    color: blueviolet;
+}
+
+.object-merge {
+    color: dodgerblue;
+}
+
+.object-history {
+    color: #007bff;
+}

--- a/apis_core/generic/templates/generic/generic_content.html
+++ b/apis_core/generic/templates/generic/generic_content.html
@@ -1,4 +1,10 @@
 {% extends basetemplate|default:"base.html" %}
+{% load static %}
+
+{% block styles %}
+  {{ block.super }}
+  <link href="{% static 'css/generic.css' %}" rel="stylesheet" />
+{% endblock styles %}
 
 {% block content %}
   <div class="container-fluid">


### PR DESCRIPTION
The object action classes are used in the generic templates, therefore
they should be moved to a `generic.css` stylesheet which is included in
the `generic_content.html` base template.

Closes: #1469
