### PR TITLE
feat (documentation): declutter and enrich the datamodel graph

### DIFF
--- a/apis_core/documentation/utils.py
+++ b/apis_core/documentation/utils.py
@@ -36,12 +36,29 @@ class Datamodel:
 
         for rel in self.relations:
             for subj_class in rel.model_class().subj_list():
+                subj_name = ContentType.objects.get_for_model(subj_class).name
                 for obj_class in rel.model_class().obj_list():
-                    key = (
-                        ContentType.objects.get_for_model(subj_class).name,
-                        ContentType.objects.get_for_model(obj_class).name,
-                    )
-                    edges[key].append(force_str(rel.model_class().name()))
+                    obj_name = ContentType.objects.get_for_model(obj_class).name
+
+                    original_pair = (subj_name, obj_name)
+                    key = tuple(sorted(original_pair))
+
+                    rel_model = rel.model_class()
+                    rel_label = ""
+                    if key == original_pair:
+                        rel_label = (
+                            f"{force_str(rel_model.name())}/{force_str(rel_model.reverse_name())}"
+                            if rel_model.name() != rel_model.reverse_name()
+                            else rel_model.name()
+                        )
+                    else:
+                        rel_label = (
+                            f"{force_str(rel_model.reverse_name())}/{force_str(rel_model.name())}"
+                            if rel_model.name() != rel_model.reverse_name()
+                            else rel_model.name()
+                        )
+
+                    edges[key].append(rel_label)
         return edges
 
     def make_graph(self):
@@ -61,7 +78,7 @@ class Datamodel:
                 node.set_style("filled")
                 graph.add_node(node)
             for (subj, obj), names in self.edges().items():
-                e = Edge(subj, obj, label="\n".join(names))
+                e = Edge(subj, obj, label="\n".join(names), fontsize="11")
                 graph.add_edge(e)
             self.graph = {"svg": graph.create_svg().decode(), "dot": graph.to_string()}
         except ImportError as e:


### PR DESCRIPTION
1. show only one edge between a subject model and an object model
2. show reverse name of the relations in the edge label if it is different from the name
3. slightly reduce the size of the label on the edge


![image](https://github.com/user-attachments/assets/08de0fae-857c-49a7-8a45-974af0ff4d19)

TBD:

- [ ]  1 & 2 above  only implemented for new relations, can we drop support for apis_relations?
- [ ]  Since we are showing both forrward and reverse relations, should the edges be bidirectional?