### PR TITLE
docs(configuration): add APIS_FORMER_BASE_URIS setting

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -14,6 +14,8 @@ comes from the ``APIS_BASE_URI`` setting. The second part comes from the reverse
 route of ``GetEntityGenericRoot`` if that exists. If not, it uses the
 the reverse route of ``apis_core:GetEntityGeneric``, which is defined in
 :py:mod:`apis_core.urls` and defaults to ``/entity/{pk}``.
+If the value of ``APIS_BASE_URL`` changes and urls containing the former ``APIS_BASE_URL`` remain in the database, then the old ``APIS_BASE_URL`` value must added to the setting ``APIS_FORMER_BASE_URIS``.
+``APIS_FORMER_BASE_URIS`` is a list that contains base urls that were once used.
 
 Django Settings
 ---------------


### PR DESCRIPTION
This pull request includes an update to the documentation in the `docs/source/configuration.rst` file. The change provides additional information on handling changes to the `APIS_BASE_URL` setting.

Documentation update:

* [`docs/source/configuration.rst`](diffhunk://#diff-e662b6389537d2a309e93ca2065f311d3f00156764a4835671300f6c4e95ec1dR17-R18): Added instructions to use the `APIS_FORMER_BASE_URIS` setting to list former base URLs if the `APIS_BASE_URL` changes and old URLs remain in the database.