### PR TITLE
fix(generic): remove .html from template_name_suffix

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -366,7 +366,7 @@ class SelectMergeOrEnrich(GenericModelMixin, PermissionRequiredMixin, FormView):
     external sources, if set up) and on form submit redirects to the Enrich view.
     """
 
-    template_name_suffix = "_selectmergeorenrich.html"
+    template_name_suffix = "_selectmergeorenrich"
     permission_action_required = "create"
     form_class = GenericSelectMergeOrEnrichForm
 


### PR DESCRIPTION
In SelectMergeOrEnrich view, ".html" extension is removed from the `template_name_suffix`, to avoid `TemplateDoesNotExist` error as it tries to find templates ending with `_selectmergeorenrich.html.html`