### PR TITLE
fix(apis_metainfo): check for numeric id before listing related Uris

### DIFF
--- a/apis_core/apis_metainfo/signals.py
+++ b/apis_core/apis_metainfo/signals.py
@@ -12,9 +12,10 @@ logger = logging.getLogger(__name__)
 @receiver(post_delete)
 def remove_stale_uris(sender, instance, *args, **kwargs):
     content_type = ContentType.objects.get_for_model(instance)
-    uris = Uri.objects.filter(content_type=content_type, object_id=instance.id)
-    for uri in uris:
-        logger.info(
-            "Deleting uri %s as a result of deleting %s", repr(uri), repr(instance)
-        )
-        uri.delete()
+    if isinstance(instance.pk, int):
+        uris = Uri.objects.filter(content_type=content_type, object_id=instance.pk)
+        for uri in uris:
+            logger.info(
+                "Deleting uri %s as a result of deleting %s", repr(uri), repr(instance)
+            )
+            uri.delete()


### PR DESCRIPTION
Some model instance don't have a primary key thats called `id` or don't
have a numeric primary key. Use the `pk` attribute and check if its an
integer before using it to filter Uris.
