### PR TITLE
chore(apis_metainfo): drop unused field classes

### DIFF
--- a/apis_core/apis_metainfo/migrations/0001_initial.py
+++ b/apis_core/apis_metainfo/migrations/0001_initial.py
@@ -3,8 +3,6 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
-import apis_core.apis_metainfo.models
-
 
 class Migration(migrations.Migration):
     initial = True
@@ -126,7 +124,7 @@ class Migration(migrations.Migration):
                 ("loaded_time", models.DateTimeField(blank=True, null=True)),
                 (
                     "root_object",
-                    apis_core.apis_metainfo.models.InheritanceForeignKey(
+                    models.ForeignKey(
                         blank=True,
                         null=True,
                         on_delete=django.db.models.deletion.CASCADE,

--- a/apis_core/apis_metainfo/models.py
+++ b/apis_core/apis_metainfo/models.py
@@ -4,7 +4,6 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
-from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
 from model_utils.managers import InheritanceManager
 
 from apis_core.generic.abc import GenericModel
@@ -35,17 +34,6 @@ class RootObject(GenericModel, models.Model):
     def save(self, *args, **kwargs):
         self.self_contenttype = ContentType.objects.get_for_model(self)
         super().save(*args, **kwargs)
-
-
-class InheritanceForwardManyToOneDescriptor(ForwardManyToOneDescriptor):
-    def get_queryset(self, **hints):
-        return self.field.remote_field.model.objects_inheritance.db_manager(
-            hints=hints
-        ).select_subclasses()
-
-
-class InheritanceForeignKey(models.ForeignKey):
-    forward_related_accessor_class = InheritanceForwardManyToOneDescriptor
 
 
 # Uri model


### PR DESCRIPTION
The InheritanceForeignKey was previously used by the Uri model instead
of a foreign key. After refactoring the Uri to use a generic foreign
key, this can be dropped.
