### PR TITLE
fix(relations): hide empty relations tables

### DIFF
--- a/apis_core/relations/templates/relations/list_relations.html
+++ b/apis_core/relations/templates/relations/list_relations.html
@@ -4,7 +4,9 @@
 
   {% block relations_list %}
     {% relations_list_table relations target as table %}
-    {% render_table table %}
+    {% if table.data %}
+      {% render_table table %}
+    {% endif %}
   {% endblock relations_list %}
 
   {% block relations_create %}


### PR DESCRIPTION
If the table contains no data, it's better to now show it at all instead
of showing empty tables.

Closes: #1543
