### PR TITLE
fix(generic): move split up again and put it inside try/except

### DIFF
--- a/apis_core/generic/filtersets.py
+++ b/apis_core/generic/filtersets.py
@@ -23,8 +23,11 @@ class CollectionsFilter(django_filters.filters.ModelMultipleChoiceFilter):
         return IncludeExcludeField(super().field, required=self.extra["required"])
 
     def filter(self, queryset, value):
-        if value:
+        try:
             value, include_exclude = value
+        except ValueError:
+            pass
+        if value:
             content_type = ContentType.objects.get_for_model(queryset.model)
             try:
                 skoscollectioncontentobject = apps.get_model(


### PR DESCRIPTION
The fix in 997975c64387fe825e8893f6b22ecc7d9c869239 did help, but
sometimes the value *is* a tuple, but it contains an empty queryset.
Therefore we now try to split it in an try/except block and then test
the emptyness of `value`
