### PR TITLE
feat(generic): introduce generic menu entry

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -89,6 +89,10 @@ class GenericModel:
     def get_delete_permission(self):
         return permission_fullname("delete", self)
 
+    @classmethod
+    def get_view_permission(self):
+        return permission_fullname("view", self)
+
     def get_merge_charfield_value(self, other: CharField, field: CharField):
         res = getattr(self, field.name)
         if not field.choices:

--- a/apis_core/generic/templates/base.html
+++ b/apis_core/generic/templates/base.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% load generic %}
+
+{% block main-menu %}
+  {{ block.super }}
+  {% pure_genericmodel_content_types as content_types %}
+  {% any_view_permission content_types as anyperm %}
+  {% if anyperm %}
+    <li class="nav-item dropdown">
+      <a href="#"
+         class="nav-link dropdown-toggle"
+         data-bs-toggle="dropdown"
+         role="button"
+         aria-haspopup="true"
+         aria-expanded="false">
+        Other models
+        <span class="caret" />
+      </a>
+      <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        {% for content_type in content_types %}
+          {% if content_type.model_class.get_view_permission in perms %}
+            <a class="dropdown-item"
+               href="{{ content_type.model_class.get_listview_url }}">{{ content_type.name }}</a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </li>
+  {% endif %}
+{% endblock main-menu %}

--- a/apis_core/generic/templatetags/generic.py
+++ b/apis_core/generic/templatetags/generic.py
@@ -1,4 +1,5 @@
 from django import template
+from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 
 from apis_core.core.templatetags.core import get_model_fields
@@ -58,6 +59,34 @@ def genericmodel_content_types():
             ContentType.objects.all(),
         )
     )
+    return genericmodels
+
+
+@register.simple_tag
+def pure_genericmodel_content_types():
+    """
+    Retrieve all models which inherit from GenericModel class
+    but are not Collections, Entities, Relations or History models
+    """
+    parents = []
+    if apps.is_installed("apis_core.collections"):
+        collections = apps.get_app_config("collections")
+        parents.append(collections.models_module.SkosCollection)
+        parents.append(collections.models_module.SkosCollectionContentObject)
+    if apps.is_installed("apis_core.relations"):
+        relations = apps.get_app_config("relations")
+        parents.append(relations.models_module.Relation)
+    if apps.is_installed("apis_core.history"):
+        history = apps.get_app_config("history")
+        parents.append(history.models_module.APISHistoryTableBase)
+    if apps.is_installed("apis_core.apis_entities"):
+        entities = apps.get_app_config("apis_entities")
+        parents.append(entities.models_module.AbstractEntity)
+    genericmodels = [
+        ct
+        for ct in set(genericmodel_content_types())
+        if not issubclass(ct.model_class(), tuple(parents))
+    ]
     return genericmodels
 
 

--- a/apis_core/generic/templatetags/generic.py
+++ b/apis_core/generic/templatetags/generic.py
@@ -77,3 +77,11 @@ def content_type_count(content_type):
 @register.simple_tag
 def template_list(obj, suffix):
     return template_names_via_mro(type(obj), suffix)
+
+
+@register.simple_tag(takes_context=True)
+def any_view_permission(context, content_types):
+    user = context.request.user
+    return any(
+        [user.has_perm(ct.model_class().get_view_permission()) for ct in content_types]
+    )


### PR DESCRIPTION
This commit introduces a template tag in the generic module that lists
all content types that inherit from the Generic Model but are not
Collections, Entities, Relations or History models.
This templatetag is then used to create a menu entry to manage those
types.

Closes: #1582
