### PR TITLE
ci(docs): use default sample_project settings for building documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  DJANGO_SETTINGS_MODULE: sample_project.settings_tests
+  DJANGO_SETTINGS_MODULE: sample_project.settings
 
 permissions:
   contents: write


### PR DESCRIPTION
Because the `settings_test` file was dropped
