### PR TITLE
feat(relations): use more generic template tag to list relations

### DIFF
--- a/apis_core/relations/templates/base.html
+++ b/apis_core/relations/templates/base.html
@@ -24,9 +24,10 @@
                placeholder="Filter relations...">
       </form>
       <div id="relationList">
-        {% relations_verbose_name_listview_url as relations %}
-        {% for verbose_name, list_url in relations %}
-          <a class="dropdown-item relation-item" href="{{ list_url }}">{{ verbose_name|capfirst }}</a>
+        {% get_relation_content_types as content_types %}
+        {% for content_type in content_types %}
+          <a class="dropdown-item relation-item"
+             href="{{ content_type.model_class.get_listview_url }}">{{ content_type.model_class.name }}</a>
         {% endfor %}
       </div>
     </div>

--- a/apis_core/relations/templatetags/relations.py
+++ b/apis_core/relations/templatetags/relations.py
@@ -79,15 +79,5 @@ def relations_list_table(context, relations, target=None):
 
 
 @register.simple_tag
-def relations_verbose_name_listview_url():
-    """
-    Return all relations verbose names together with their list uri, sorted in alphabetical order
-    USED BY:
-    * `apis_core/relations/templates/base.html` (to extend the default `base.html`)
-    """
-    relation_classes = [relation.model_class() for relation in relation_content_types()]
-    ret = {
-        relation._meta.verbose_name: relation.get_listview_url()
-        for relation in relation_classes
-    }
-    return sorted(ret.items())
+def get_relation_content_types():
+    return relation_content_types()


### PR DESCRIPTION
This introduces the `get_relation_content_types` template tag, which
simply lists the relation content types. This is then used instead of
the `relations_verbose_name_listview_url` templatetag to get a list
of relations and their list view urls. This approach allows to only
show the relations, the accessing user has permission to view.
The `relations_verbose_name_listview_url` templatetag is being dropped.

Closes: #1577
