### PR TITLE
feat(apis_entities): replace entity list templatetag with generic one

### DIFF
--- a/apis_core/apis_entities/templates/base.html
+++ b/apis_core/apis_entities/templates/base.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load apis_entities %}
+{% load core %}
 
 {% block main-menu %}
   {{ block.super }}
@@ -14,14 +15,13 @@
       <span class="caret" />
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-
-      {% block entities-menu-items %}
-        {% entities_verbose_name_plural_listview_url as entities %}
-        {% for verbose_name_plural, list_url in entities %}
-          <a class="dropdown-item" href="{{ list_url }}">{{ verbose_name_plural|capfirst }}</a>
-        {% endfor %}
-      {% endblock entities-menu-items %}
-
+      {% entities_content_types as content_types %}
+      {% for content_type in content_types %}
+        {% with content_type.model_class|opts as meta %}
+          <a class="dropdown-item"
+             href="{{ content_type.model_class.get_listview_url }}">{{ meta.verbose_name_plural|capfirst }}</a>
+        {% endwith %}
+      {% endfor %}
     </div>
   </li>
 {% endblock main-menu %}

--- a/apis_core/apis_entities/templatetags/apis_entities.py
+++ b/apis_core/apis_entities/templatetags/apis_entities.py
@@ -2,7 +2,6 @@ from django import template
 from django.contrib.contenttypes.models import ContentType
 
 from apis_core.apis_entities.models import AbstractEntity
-from apis_core.apis_entities.utils import get_entity_classes
 
 register = template.Library()
 
@@ -33,17 +32,3 @@ def entities_content_types():
         )
     )
     return entities
-
-
-@register.simple_tag
-def entities_verbose_name_plural_listview_url():
-    """
-    Return all entities verbose names together with their list uri, sorted in alphabetical order
-    USED BY:
-    * `core/base.html`
-    """
-    ret = {
-        entity._meta.verbose_name_plural: entity.get_listview_url()
-        for entity in get_entity_classes()
-    }
-    return sorted(ret.items())


### PR DESCRIPTION
This replaces the `entities_verbose_name_plural_listview_url`
templatetag with a more generic one that simply lists the entity content
types. This is more similar to how it is done in the generic menu entry.

Closes: #1576
