### PR TITLE
feat(relations): remove relation_ptr from columns selector

### DIFF
--- a/apis_core/relations/filtersets.py
+++ b/apis_core/relations/filtersets.py
@@ -5,6 +5,7 @@ from django_filters import CharFilter, MultipleChoiceFilter
 from apis_core.apis_metainfo.models import RootObject
 from apis_core.generic.filtersets import GenericFilterSet
 from apis_core.generic.helpers import generate_search_filter
+from apis_core.relations.forms import RelationFilterSetForm
 from apis_core.relations.utils import get_all_relation_subj_and_obj
 
 
@@ -85,7 +86,7 @@ class RelationFilterSet(GenericFilterSet):
             "obj_object_id",
             "obj_content_type",
         ]
-        form = GenericFilterSet.Meta.form
+        form = RelationFilterSetForm
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/apis_core/relations/forms.py
+++ b/apis_core/relations/forms.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 
 from apis_core.core.fields import ApisListSelect2
-from apis_core.generic.forms import GenericModelForm
+from apis_core.generic.forms import GenericFilterSetForm, GenericModelForm
 from apis_core.generic.forms.fields import ModelImportChoiceField
 
 
@@ -230,3 +230,12 @@ class RelationForm(GenericModelForm):
         if self.is_reverse:
             return self._meta.model.reverse_name
         return self._meta.model.name
+
+
+class RelationFilterSetForm(GenericFilterSetForm):
+    """
+    FilterSet form for relations based on GenericFilterSetForm.
+    Excludes `relation_ptr` from the columns selector
+    """
+
+    columns_exclude = ["relation_ptr"]


### PR DESCRIPTION
closes #1612

This pull request includes changes to the `apis_core` module to introduce a new `RelationFilterSetForm` and update the filter set forms accordingly. The most important changes are:

### Introduction of `RelationFilterSetForm`:

* [`apis_core/relations/forms.py`](diffhunk://#diff-58db7770b3002c6fe2e368b7d0f9375a2588291e815aee3bdc6144620c463d05R233-R241): Added a new class `RelationFilterSetForm` that inherits from `GenericFilterSetForm` and excludes `relation_ptr` from the columns selector.

### Updates to filter set forms:

* [`apis_core/relations/filtersets.py`](diffhunk://#diff-219ab10ae1c1caa879aa84cbbcae306ff15cc6db0e083945c388ff06edd853e6R8): Imported `RelationFilterSetForm` and updated the form in the `Meta` class to use `RelationFilterSetForm` instead of `GenericFilterSetForm`. [[1]](diffhunk://#diff-219ab10ae1c1caa879aa84cbbcae306ff15cc6db0e083945c388ff06edd853e6R8) [[2]](diffhunk://#diff-219ab10ae1c1caa879aa84cbbcae306ff15cc6db0e083945c388ff06edd853e6L88-R89)
* [`apis_core/relations/forms.py`](diffhunk://#diff-58db7770b3002c6fe2e368b7d0f9375a2588291e815aee3bdc6144620c463d05L12-R12): Imported `GenericFilterSetForm` to support the new `RelationFilterSetForm` class.