### PR TITLE
feat(sample_project): move generic app up in INSTALLED_APPS list

### DIFF
--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     # swagger ui generation
     "drf_spectacular",
     # The APIS apps
+    "apis_core.generic",
     # APIS collections provide a collection model similar to
     # SKOS collections and allow tagging of content
     "apis_core.collections",
@@ -53,7 +54,6 @@ INSTALLED_APPS = [
     "apis_core.history",
     # The core APIS apps come last, so other apps can override
     # and extend their templates
-    "apis_core.generic",
     "apis_core.core",
     "apis_core.documentation",
 ]


### PR DESCRIPTION
The sequence in the INSTALLED_APPS list defines where in the main menu
the apps menu item will be. We want the generic menu item to be the one
on the right.
