### PR TITLE
feat(collections): implement toggling collection without the parent

### DIFF
--- a/apis_core/collections/models.py
+++ b/apis_core/collections/models.py
@@ -111,6 +111,18 @@ class SkosCollection(GenericModel, models.Model):
             collection=self, content_type=content_type, object_id=instance.id
         ).delete()
 
+    @property
+    def parent_collection(self):
+        content_type = ContentType.objects.get_for_model(self)
+        sccos = SkosCollectionContentObject.objects.filter(
+            content_type=content_type, object_id=self.id
+        )
+        if len(sccos) == 1:
+            return sccos.first().collection
+        raise SkosCollection.MultipleObjectsReturned(
+            f'"{self}" is part of multiple collections'
+        )
+
 
 class SkosCollectionContentObject(GenericModel, models.Model):
     """

--- a/apis_core/collections/templates/collections/collection_object_collection.html
+++ b/apis_core/collections/templates/collections/collection_object_collection.html
@@ -1,0 +1,10 @@
+{% if error %}
+  <a class="btn btn-sm btn-outline-dark disabled">Could not create toggle button: {{ error }}</a>
+{% else %}
+  <a href="{% url "apis_core:collections:collectionobjectparent" content_type.id object.id collectionobject.id %}?to={{ request.get_full_path }}"
+     hx-get="{% url "apis_core:collections:collectionobjectparent" content_type.id object.id collectionobject.id %}"
+     hx-swap="outerHTML"
+     class="btn btn-sm btn-outline-dark col-{{ collectionobject.collection.name|slugify }} col-{{ collectionobject.collection.pk }}"
+     title="Click to change to {{ collectionobject.collection.parent.name }}"
+     hx-confirm="Change {{ object }} from {{ collectionobject.collection.name }} to {{ collectionobject.collection.parent.name }}?">{{ collectionobject.collection }}</a>
+{% endif %}

--- a/apis_core/collections/templatetags/collections.py
+++ b/apis_core/collections/templatetags/collections.py
@@ -82,6 +82,36 @@ def collection_object_parent_by_id(context, obj, collectionobject_id):
     return collection_object_parent(context, obj, collectionobject)
 
 
+@register.inclusion_tag(
+    "collections/collection_object_collection.html", takes_context=True
+)
+def collection_object_collection(context, obj, collectionobject):
+    """
+    Provide a button to change the connection between an object and
+    a collection to point to the collection the collection is in.
+    """
+    try:
+        context["parent"] = collectionobject.collection.parent
+        context["collectionobject"] = collectionobject
+        context["content_type"] = ContentType.objects.get_for_model(obj)
+        context["object"] = obj
+    except collectionobject.collection.MultipleObjectsReturned as e:
+        context["error"] = e
+    return context
+
+
+@register.inclusion_tag(
+    "collections/collection_object_collection.html", takes_context=True
+)
+def collection_object_collection_by_id(context, obj, collectionobject_id):
+    """
+    Wrapper templatetag to allow using `collection_object_parent` with
+    just the `id` of the collectionobject.
+    """
+    collectionobject = SkosCollectionContentObject.objects.get(pk=collectionobject_id)
+    return collection_object_parent(context, obj, collectionobject)
+
+
 @register.simple_tag(takes_context=True)
 def collection_content_objects(context, obj, collectionids=None):
     content_type = ContentType.objects.get_for_model(obj)

--- a/apis_core/collections/urls.py
+++ b/apis_core/collections/urls.py
@@ -16,6 +16,11 @@ urlpatterns = [
         name="collectionobjectparent",
     ),
     path(
+        "collectionobjectcollection/<int:content_type_id>/<int:object_id>/<int:collectionobject>",
+        views.CollectionObjectCollection.as_view(),
+        name="collectionobjectparent",
+    ),
+    path(
         "collectionsessiontoggle/<int:skoscollection>",
         views.CollectionSessionToggle.as_view(),
         name="collectionsessiontoggle",

--- a/apis_core/collections/views.py
+++ b/apis_core/collections/views.py
@@ -77,6 +77,26 @@ class CollectionObjectParent(LoginRequiredMixin, ContentObjectMixin, TemplateVie
         return context
 
 
+class CollectionObjectCollection(LoginRequiredMixin, ContentObjectMixin, TemplateView):
+    """
+    Change the requested CollectionObjects collection to point to the collection the
+    current collection is in.
+    """
+
+    template_name = "collections/collection_object_collection.html"
+
+    def get_context_data(self, *args, **kwargs):
+        collectionobject = get_object_or_404(
+            SkosCollectionContentObject, pk=kwargs["collectionobject"]
+        )
+        parent = collectionobject.collection.parent_collection
+        collectionobject.collection = parent
+        collectionobject.save()
+        context = super().get_context_data(*args, **kwargs)
+        context["collectionobject"] = collectionobject
+        return context
+
+
 class CollectionSessionToggle(LoginRequiredMixin, TemplateView):
     """
     Toggle the existence of an SkosCollection in the `session_collections`


### PR DESCRIPTION
We provide a way of toggling collections by simply allowing them to
reside in each other (two collections A and B, A is in collection B and
B is in collection A).
