### PR TITLE
fix(apis_metainfo): drop references to `apis_metainfo.collection`

### DIFF
--- a/apis_core/apis_entities/migrations/0001_initial.py
+++ b/apis_core/apis_entities/migrations/0001_initial.py
@@ -55,7 +55,6 @@ class Migration(migrations.Migration):
                 ("references", models.TextField(blank=True, null=True)),
                 ("notes", models.TextField(blank=True, null=True)),
                 ("published", models.BooleanField(default=False)),
-                ("collection", models.ManyToManyField(to="apis_metainfo.Collection")),
                 (
                     "source",
                     models.ForeignKey(

--- a/apis_core/apis_metainfo/migrations/0002_auto_20220201_1241.py
+++ b/apis_core/apis_metainfo/migrations/0002_auto_20220201_1241.py
@@ -39,14 +39,4 @@ class Migration(migrations.Migration):
             name="groups_allowed",
             field=models.ManyToManyField(to="auth.Group"),
         ),
-        migrations.AddField(
-            model_name="collection",
-            name="parent_class",
-            field=models.ForeignKey(
-                blank=True,
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                to="apis_metainfo.collection",
-            ),
-        ),
     ]


### PR DESCRIPTION
Closes: #1377
