### PR TITLE
fix(generic): use different attribute for excluding column choices

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -185,7 +185,7 @@ class List(
         choices = [
             (field.name, pretty_name(getattr(field, "verbose_name", field.name)))
             for field in self.model._meta.get_fields()
-            if not getattr(field, "parent_link", False)
+            if not getattr(field, "auto_created", False)
             and not isinstance(field, ManyToManyRel)
         ]
         # we add any annotated fields to that


### PR DESCRIPTION
The `parent_link` attribute is apparently only set when the model
inherits from a concrete model, which is not the case for all the models
inheriting from AbstractEntity ("When True and used in a model which
inherits from another concrete model, indicates that this field should
be used as the link back to the parent class", from
https://docs.djangoproject.com/en/5.1/ref/models/fields/#django.db.models.OneToOneField.parent_link

Lets use the `auto_created` field instead, which "indicates if the field
was automatically created, such as the OneToOneField used by model
inheritance" - this might have side effect, but "auto_created" looks
like it should not be part of a column choice selector.
