### PR TITLE
fix(apis_entities): reorder entity menu items

### DIFF
--- a/apis_core/apis_entities/templates/base.html
+++ b/apis_core/apis_entities/templates/base.html
@@ -16,7 +16,7 @@
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       {% entities_content_types as content_types %}
-      {% for content_type in content_types %}
+      {% for content_type in content_types|dictsort:"name" %}
         {% with content_type.model_class|opts as meta %}
           <a class="dropdown-item"
              href="{{ content_type.model_class.get_listview_url }}">{{ meta.verbose_name_plural|capfirst }}</a>


### PR DESCRIPTION
Changes the current sort order of entity model
classes in the entities menu in `base.html` from
(presumably) by `ContentType` `id` to alphabetical by `ContentType` `name`, which is based on the
model's `verbose_name`.

Resolves: #1657