### PR TITLE
fix(collections): repair the new collection toggle templatetags

### DIFF
--- a/apis_core/collections/templates/collections/collection_object_collection.html
+++ b/apis_core/collections/templates/collections/collection_object_collection.html
@@ -1,6 +1,7 @@
 {% if error %}
   <a class="btn btn-sm btn-outline-dark disabled">Could not create toggle button: {{ error }}</a>
-{% else %}
+{% endif %}
+{% if content_type and object and collectionobject %}
   <a href="{% url "apis_core:collections:collectionobjectparent" content_type.id object.id collectionobject.id %}?to={{ request.get_full_path }}"
      hx-get="{% url "apis_core:collections:collectionobjectparent" content_type.id object.id collectionobject.id %}"
      hx-swap="outerHTML"


### PR DESCRIPTION
The toggle templatetags were written to work with the ids of
SkosCollectionContentObjects, but SkosCollectionContentObjects are 1:1
relations to any object, so listing their IDs in a template tag does not
make sense.
This commit fixes those templatetags and also makes them more resistent
against errors (and it also shows the errors, if there are any).
