### PR TITLE
feat(generic): refactor the collections filter

### DIFF
--- a/apis_core/collections/filters.py
+++ b/apis_core/collections/filters.py
@@ -1,0 +1,51 @@
+import logging
+
+import django_filters
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+
+from apis_core.generic.forms.fields import RowColumnMultiValueField
+
+logger = logging.getLogger(__name__)
+
+
+class CollectionsIncludeExcludeFilter(django_filters.filters.ModelMultipleChoiceFilter):
+    """
+    The CollectionsIncludeExcludeFilter provides to ModelMultipleChoiceFilters that allow
+    to filter model instances that are either **in** a collection OR (or AND) are **not in**
+    a collection.
+    """
+
+    @property
+    def field(self):
+        return RowColumnMultiValueField(
+            fields=[super().field, super().field],
+            labels=["include", "exclude"],
+            required=self.extra["required"],
+        )
+
+    def filter(self, queryset, value):
+        if not value:
+            return queryset
+        include = exclude = []
+        q = Q()
+        try:
+            content_type = ContentType.objects.get_for_model(queryset.model)
+            skoscollectioncontentobject = apps.get_model(
+                "collections.SkosCollectionContentObject"
+            )
+            include, exclude = value
+            include_ids = skoscollectioncontentobject.objects.filter(
+                content_type=content_type, collection__in=include
+            ).values("object_id")
+            if include:
+                q &= Q(id__in=include_ids)
+            exclude_ids = skoscollectioncontentobject.objects.filter(
+                content_type=content_type, collection__in=exclude
+            ).values("object_id")
+            if exclude:
+                q &= ~Q(id__in=exclude_ids)
+        except LookupError as e:
+            logger.debug("Not filtering for collections: %s", e)
+        return queryset.filter(q)

--- a/apis_core/generic/filtersets.py
+++ b/apis_core/generic/filtersets.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django_filters.filterset import FilterSet
 
 from apis_core.generic.forms.fields import IncludeExcludeField
+from apis_core.collections.filters import CollectionsIncludeExcludeFilter
 
 from .forms import GenericFilterSetForm
 
@@ -64,7 +65,7 @@ class GenericFilterSet(FilterSet):
         try:
             skoscollection = apps.get_model("collections.SkosCollection")
             if skoscollection.objects.exists():
-                self.filters["collections"] = CollectionsFilter(
+                self.filters["collections"] = CollectionsIncludeExcludeFilter(
                     queryset=skoscollection.objects.all(),
                 )
         except LookupError as e:

--- a/apis_core/generic/filtersets.py
+++ b/apis_core/generic/filtersets.py
@@ -2,49 +2,13 @@ import logging
 
 import django_filters
 from django.apps import apps
-from django.contrib.contenttypes.models import ContentType
 from django_filters.filterset import FilterSet
 
-from apis_core.generic.forms.fields import IncludeExcludeField
 from apis_core.collections.filters import CollectionsIncludeExcludeFilter
 
 from .forms import GenericFilterSetForm
 
 logger = logging.getLogger(__name__)
-
-
-class CollectionsFilter(django_filters.filters.ModelMultipleChoiceFilter):
-    """
-    A simple filter for connections to collections. It provides an `include`/`exclude`
-    selector, which allows to define what the filter should do.
-    """
-
-    @property
-    def field(self):
-        return IncludeExcludeField(super().field, required=self.extra["required"])
-
-    def filter(self, queryset, value):
-        try:
-            value, include_exclude = value
-        except ValueError:
-            pass
-        if value:
-            content_type = ContentType.objects.get_for_model(queryset.model)
-            try:
-                skoscollectioncontentobject = apps.get_model(
-                    "collections.SkosCollectionContentObject"
-                )
-                scco = skoscollectioncontentobject.objects.filter(
-                    content_type=content_type, collection__in=value
-                ).values("object_id")
-                match include_exclude:
-                    case "include":
-                        return queryset.filter(id__in=scco)
-                    case "exclude":
-                        return queryset.exclude(id__in=scco)
-            except LookupError as e:
-                logger.debug("Not filtering for collections: %s", e)
-        return queryset
 
 
 class GenericFilterSet(FilterSet):

--- a/apis_core/generic/forms/fields.py
+++ b/apis_core/generic/forms/fields.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.forms import ChoiceField, ModelChoiceField, MultiValueField, MultiWidget
+from django.forms import ModelChoiceField, MultiValueField, MultiWidget
 from django.utils.translation import gettext as _
 
 from apis_core.utils.helpers import create_object_from_uri
@@ -16,33 +16,6 @@ class ModelImportChoiceField(ModelChoiceField):
                 params={"value": value, "exception": e},
             )
         return result or super().to_python(value)
-
-
-class IncludeExcludeMultiWidget(MultiWidget):
-    template_name = "widgets/includeexclude_multiwidget.html"
-    use_fieldset = False
-
-    def decompress(self, value):
-        return [value, value]
-
-
-class IncludeExcludeField(MultiValueField):
-    """
-    This is a custom MultiValueField that adds a ChoiceField that only provides two
-    choices, namely `exclude` and `include`. It can be used for django-filter filters
-    to specify which action should be done with the filter.
-    """
-
-    def __init__(self, field, *args, **kwargs):
-        fields = (
-            field,
-            ChoiceField(choices=[("include", "include"), ("exclude", "exclude")]),
-        )
-        kwargs["widget"] = IncludeExcludeMultiWidget(widgets=[f.widget for f in fields])
-        super().__init__(fields=fields, *args, **kwargs)
-
-    def compress(self, data_list):
-        return data_list
 
 
 class RowColumnMultiWidget(MultiWidget):

--- a/apis_core/generic/forms/fields.py
+++ b/apis_core/generic/forms/fields.py
@@ -43,3 +43,53 @@ class IncludeExcludeField(MultiValueField):
 
     def compress(self, data_list):
         return data_list
+
+
+class RowColumnMultiWidget(MultiWidget):
+    """
+    A custom MultiWidget that is meant to be used with the
+    RowColumnMultiValueField. The widget takes a list of widgets
+    as a parameter and displays those widgets in columns in one row.
+    The `labels` parameter is used to add a separate label to the
+    individual widgets.
+    """
+
+    template_name = "widgets/row_column_multiwidget.html"
+    use_fieldset = False
+
+    def __init__(self, widgets, labels=[], attrs=None):
+        self.labels = labels
+        super().__init__(widgets, attrs)
+
+    def get_context(self, name, value, attrs):
+        ctx = super().get_context(name, value, attrs)
+        for widget in ctx["widget"]["subwidgets"]:
+            if self.labels:
+                widget["label"] = self.labels.pop(0)
+        return ctx
+
+    def decompress(self, value):
+        if value:
+            return value
+        return []
+
+
+class RowColumnMultiValueField(MultiValueField):
+    """
+    This is a custom MultiValueField that simply shows multiple form
+    fields in a row. The form fields are passed to the constructor and
+    the corresponding RowColumnMultiWidget simply iterates through all
+    the fields and shows them in rows.
+    Additionaly it is possible to pass a list of `labels` that are then
+    also passed on to the widget, which uses those to add a separate
+    label to the individual widgets.
+    """
+
+    def __init__(self, fields, labels=[], *args, **kwargs):
+        kwargs["widget"] = RowColumnMultiWidget(
+            widgets=[f.widget for f in fields], labels=labels
+        )
+        super().__init__(fields, *args, **kwargs)
+
+    def compress(self, data_list):
+        return data_list

--- a/apis_core/generic/templates/widgets/row_column_multiwidget.html
+++ b/apis_core/generic/templates/widgets/row_column_multiwidget.html
@@ -1,0 +1,10 @@
+<div class="row">
+  {% spaceless %}
+    {% for widget in widget.subwidgets %}
+      <div class="col">
+        <label class="form-label me-2">{{ widget.label|title }}</label>
+        {% include widget.template_name %}
+      </div>
+    {% endfor %}
+  {% endspaceless %}
+</div>


### PR DESCRIPTION
Instead of providing one dropdown for selecting the collections and one
dropdown for selecting include or exclude, we now provide one dropdown
for selecting collections to exclude and one dropdown for selections to
include.
This introduces a RowColumnMultiValueField (+ widget) and uses this one
instead of the IncludeExcludeField (+ widget), so we drop the
IncludeExcludeField (+ widget).
