### PR TITLE
Move remaining duplicate logic to generic and drop legacy converter

### DIFF
--- a/apis_core/apis_entities/models.py
+++ b/apis_core/apis_entities/models.py
@@ -72,13 +72,6 @@ class AbstractEntity(RootObject):
                 return next_instance.id
         return False
 
-    def get_duplicate_url(self):
-        entity = self.__class__.__name__.lower()
-        return reverse(
-            "apis_core:apis_entities:generic_entities_duplicate_view",
-            kwargs={"contenttype": entity, "pk": self.id},
-        )
-
 
 @receiver(post_save, dispatch_uid="create_default_uri")
 def create_default_uri(sender, instance, created, raw, using, update_fields, **kwargs):

--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -1,12 +1,8 @@
-from django.contrib.contenttypes.models import ContentType
-from django.http import Http404
-from django.shortcuts import get_list_or_404
-from django.urls import path, register_converter
+from django.urls import path
 
 from apis_core.apis_entities.api_views import GetEntityGeneric, ListEntityGeneric
 
 # from .views import ReversionCompareView TODO: add again when import is fixed
-from apis_core.apis_entities.models import AbstractEntity
 from apis_core.apis_entities.views import EntitiesAutocomplete
 
 api_routes = [
@@ -18,36 +14,6 @@ api_routes = [
     ),
 ]
 
-
-class EntityToContenttypeConverter:
-    """
-    A converter that converts from a the name of an entity class
-    (i.e. `person`) to the actual Django model class.
-    """
-
-    regex = r"\w+"
-
-    def to_python(self, value):
-        candiates = get_list_or_404(ContentType, model=value)
-        candiates = list(
-            filter(
-                lambda ct: ct.model_class() is not None
-                and issubclass(ct.model_class(), AbstractEntity),
-                candiates,
-            )
-        )
-        if len(candiates) > 1:
-            raise Http404("Multiple entities match the <%s> identifier" % value)
-        return candiates[0]
-
-    def to_url(self, value):
-        if isinstance(value, ContentType):
-            return value.model
-        if isinstance(value, str):
-            return value
-
-
-register_converter(EntityToContenttypeConverter, "entitytocontenttype")
 
 app_name = "apis_entities"
 

--- a/apis_core/apis_entities/urls.py
+++ b/apis_core/apis_entities/urls.py
@@ -1,16 +1,13 @@
 from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
 from django.shortcuts import get_list_or_404
-from django.urls import include, path, register_converter
+from django.urls import path, register_converter
 
 from apis_core.apis_entities.api_views import GetEntityGeneric, ListEntityGeneric
 
 # from .views import ReversionCompareView TODO: add again when import is fixed
 from apis_core.apis_entities.models import AbstractEntity
-from apis_core.apis_entities.views import (
-    EntitiesAutocomplete,
-    EntitiesDuplicate,
-)
+from apis_core.apis_entities.views import EntitiesAutocomplete
 
 api_routes = [
     path("entities/", ListEntityGeneric.as_view()),
@@ -54,18 +51,6 @@ register_converter(EntityToContenttypeConverter, "entitytocontenttype")
 
 app_name = "apis_entities"
 
-entity_patterns = [
-    path(
-        "<int:pk>/duplicate/",
-        EntitiesDuplicate.as_view(),
-        name="generic_entities_duplicate_view",
-    ),
-]
-
 urlpatterns = [
-    path(
-        "entity/<entitytocontenttype:contenttype>/",
-        include(entity_patterns),
-    ),
     path("autocomplete/", EntitiesAutocomplete.as_view(), name="autocomplete"),
 ]

--- a/apis_core/apis_entities/views.py
+++ b/apis_core/apis_entities/views.py
@@ -1,34 +1,11 @@
 from dal import autocomplete
-from django.contrib import messages
-from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
-from django.shortcuts import get_object_or_404, redirect
-from django.utils.html import format_html
-from django.views import View
+from django.shortcuts import get_object_or_404
 
 from apis_core.apis_entities.utils import get_entity_content_types
 from apis_core.apis_metainfo.models import RootObject
 from apis_core.generic.helpers import generate_search_filter
-from apis_core.generic.views import GenericModelMixin
-
-
-class EntitiesDuplicate(GenericModelMixin, PermissionRequiredMixin, View):
-    permission_action_required = "create"
-
-    def get(self, request, *args, **kwargs):
-        source_obj = get_object_or_404(self.model, pk=kwargs["pk"])
-        newobj = source_obj.duplicate()
-
-        messages.success(
-            request,
-            format_html(
-                "<a href={}>{}</a> was successfully duplicated to the current object:",
-                source_obj.get_absolute_url(),
-                source_obj,
-            ),
-        )
-        return redirect(newobj.get_edit_url())
 
 
 class EntitiesAutocomplete(autocomplete.Select2QuerySetView):

--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -51,6 +51,10 @@ class GenericModel:
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:generic:update", args=[ct, self.id])
 
+    def get_duplicate_url(self):
+        ct = ContentType.objects.get_for_model(self)
+        return reverse("apis_core:generic:duplicate", args=[ct, self.id])
+
     def get_enrich_url(self):
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:generic:enrich", args=[ct, self.id])

--- a/apis_core/generic/urls.py
+++ b/apis_core/generic/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
                 path("create", views.Create.as_view(), name="create"),
                 path("delete/<int:pk>", views.Delete.as_view(), name="delete"),
                 path("update/<int:pk>", views.Update.as_view(), name="update"),
+                path("duplicate/<int:pk>", views.Duplicate.as_view(), name="duplicate"),
                 path(
                     "selectmergeorenrich/<int:pk>",
                     views.SelectMergeOrEnrich.as_view(),

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -16,6 +16,8 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import select_template
 from django.urls import reverse, reverse_lazy
+from django.utils.html import format_html
+from django.views import View
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import CreateView, DeleteView, FormView, UpdateView
@@ -300,6 +302,24 @@ class Update(GenericModelMixin, PermissionRequiredMixin, UpdateView):
 
     def get_success_url(self):
         return self.object.get_update_success_url()
+
+
+class Duplicate(GenericModelMixin, PermissionRequiredMixin, View):
+    permission_action_required = "create"
+
+    def get(self, request, *args, **kwargs):
+        source_obj = get_object_or_404(self.model, pk=kwargs["pk"])
+        newobj = source_obj.duplicate()
+
+        messages.success(
+            request,
+            format_html(
+                "<a href={}>{}</a> was successfully duplicated to the current object:",
+                source_obj.get_absolute_url(),
+                source_obj,
+            ),
+        )
+        return redirect(newobj.get_edit_url())
 
 
 class Autocomplete(


### PR DESCRIPTION
- **refactor(generic,apis_entities): move duplicate logic to GenericModel**
- **refactor(apis_entities): drop legacy EntityToContenttypeConverter**
