### PR TITLE
fix(generic): don't coerce values to string in modeldict

### DIFF
--- a/apis_core/generic/templatetags/generic.py
+++ b/apis_core/generic/templatetags/generic.py
@@ -26,7 +26,9 @@ def modeldict(instance, fields=None, exclude=None):
         if exclude and f.name in exclude:
             continue
         field = instance._meta.get_field(f.name)
-        data[field] = instance._get_FIELD_display(field)
+        data[field] = getattr(instance, field.name)
+        if fn := getattr(instance, f"get_{field.name}_display", False):
+            data[field] = fn()
         if getattr(field, "remote_field", False):
             data[field] = getattr(instance, field.name)
         if getattr(field, "m2m_field_name", False):


### PR DESCRIPTION
The `_get_FIELD_display()` method coerces values to string, which is not
ideal if we for example want to format a value differently in the
templates. We now use the `get_{field.name}_display()` method instead if
it exists (which is basically the same as the `_get_FIELD_display()` if
the value has choices defined) and we default directly to the value of
the field.
This way we still have lists as lists in the template.
