### PR TITLE
fix(relations): repair the relation target autocomplete

### DIFF
--- a/apis_core/relations/forms/__init__.py
+++ b/apis_core/relations/forms/__init__.py
@@ -84,6 +84,23 @@ class RelationForm(GenericModelForm):
         """
 
         self.params = kwargs.pop("params", {})
+        # workaround: if there is only one possible subj or obj type
+        # we use that as subj_content_type or obj_content_type, which
+        # lets us use another endpoint for autocomplete
+        # this can be removed when we stop allowing multiple types
+        # for relation subjects or objects
+        initial = kwargs["initial"]
+        if (
+            initial["subj_content_type"] is None
+            and len(self.Meta.model.subj_list()) == 1
+        ):
+            kwargs["initial"]["subj_content_type"] = ContentType.objects.get_for_model(
+                self.Meta.model.subj_list()[0]
+            ).id
+        if initial["obj_content_type"] is None and len(self.Meta.model.obj_list()) == 1:
+            kwargs["initial"]["obj_content_type"] = ContentType.objects.get_for_model(
+                self.Meta.model.obj_list()[0]
+            ).id
         super().__init__(*args, **kwargs)
         subj_content_type = kwargs["initial"].get("subj_content_type", None)
         subj_object_id = kwargs["initial"].get("subj_object_id", None)


### PR DESCRIPTION
With the refactoring done in 29d39dab2644980f51c7d09a6a24695e4b8cdde5 we
don't know anymore which target type the relation create form refers to.
This leads to the creation form using a different autocomplete endpoint,
one where we don't have external autocomplete results.
This commit fixes this partially for Relations that allow only **one**
specific type of relation target.

Closes: #1676
