### PR TITLE
fix(apis_entities): readd queryset to view

### DIFF
--- a/apis_core/apis_entities/api_views.py
+++ b/apis_core/apis_entities/api_views.py
@@ -11,6 +11,8 @@ from apis_core.utils.filters import CustomSearchFilter
 
 
 class GetEntityGeneric(APIView):
+    queryset = RootObject.objects.all()
+
     def get(self, request, pk):
         try:
             obj = RootObject.objects_inheritance.get_subclass(id=pk)


### PR DESCRIPTION
`queryset` was dropped from `GetEntityGeneric` when it was rewritten in f825739, which results in an
AssertionError when trying to access objects via
their /entity/ uris.
This adds the `queryset` back (like it was before).

Closes: #1678