### PR TITLE
fix(apis_entities): add permission class to GetEntityGeneric view

### DIFF
--- a/apis_core/apis_entities/api_views.py
+++ b/apis_core/apis_entities/api_views.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from django.shortcuts import redirect
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import ListAPIView
+from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 
 from apis_core.apis_entities.serializers import MinimalEntitySerializer
@@ -11,6 +12,8 @@ from apis_core.utils.filters import CustomSearchFilter
 
 
 class GetEntityGeneric(APIView):
+    permission_classes = [AllowAny]
+
     def get(self, request, pk):
         try:
             obj = RootObject.objects_inheritance.get_subclass(id=pk)


### PR DESCRIPTION
Without the permission class, DRF falls back to the default permission
class, which might sometimes be the DjangoModelPermissions class. This
class, however, uses the queryset to assess the permission of the user.
Given that this view does not use a queryset and it only forwards a
request, it makes sense to simply set the permission class to allow any
request.

Closes: #1678
