### PR TITLE
feat(generic): readd the `get_queryset` method to the List view

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -221,6 +221,13 @@ class List(
 
         return filterset
 
+    def get_queryset(self):
+        queryset_methods = module_paths(
+            self.model, path="querysets", suffix="ListViewQueryset"
+        )
+        queryset = first_member_match(queryset_methods) or (lambda x: x)
+        return queryset(self.model.objects.all())
+
     def get_table_pagination(self, table):
         """
         Override `get_table_pagination` from the tables2 TableMixinBase,


### PR DESCRIPTION
This method was lost in f2e0b2f9ac5f43154049284529e9ec9e1af393c7 but is
actually useful, if we want to override the queryset for the list view.
In the long run we might replace that logic with a custom Generic
Manager, but for now we still use this override.
