### PR TITLE
fix(core): include the main autocomplete_light js in the header

### DIFF
--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -65,6 +65,7 @@
       <script src="{% static "js/core.js" %}"></script>
       <script src="{% static 'js/E53_Place_popover.js' %}"></script>
       <script src="{% static 'js/apis_select2.js' %}"></script>
+      <script src="{% static 'autocomplete_light/autocomplete_light.js' %}"></script>
     {% endblock %}
 
   </head>


### PR DESCRIPTION
Include the `autocomplete_light.js` script in the page header.

Usually this is automatically done during form rendering, because the
file is included in the media assets of forms using autocomplete light.
And the main setup method of autocomplete light is then triggered by the
`load` event. But this event is not fired when we include dialogs via
htmx. Therefore it does not help much to include the script in the
relation forms media assets and we have to include it in the pages
header as a global javascript file.

Closes: #1696
