### PR TITLE
feat(generic): print exception message if module not found

### DIFF
--- a/apis_core/generic/helpers.py
+++ b/apis_core/generic/helpers.py
@@ -110,7 +110,8 @@ def makeclassprefix(string: str) -> str:
 def import_string(dotted_path):
     try:
         return module_loading.import_string(dotted_path)
-    except (ModuleNotFoundError, ImportError):
+    except (ModuleNotFoundError, ImportError) as e:
+        logger.debug("Could not load %s: %s", dotted_path, e)
         return False
 
 


### PR DESCRIPTION
This is useful for the automatic module lookup, because it tells you
that it could not import a module and might even tell you why it could
not import a module.
