### PR TITLE
build(gitignore): ignore `*.mo` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ apis_core.egg-info
 .coverage
 .env
 *.lock
+*.mo


### PR DESCRIPTION
The `.mo` files should not be part of the source repository, but be
generated on installation
