### PR TITLE
fix(collections): use blocktranslate with `with` statement

### DIFF
--- a/apis_core/collections/templates/collections/collection_object_collection.html
+++ b/apis_core/collections/templates/collections/collection_object_collection.html
@@ -7,6 +7,6 @@
      hx-get="{% url "apis_core:collections:collectionobjectparent" content_type.id object.id collectionobject.id %}"
      hx-swap="outerHTML"
      class="btn btn-sm btn-outline-dark col-{{ collectionobject.collection.name|slugify }} col-{{ collectionobject.collection.pk }}"
-     title="{% blocktranslate %}Click to change to {{ collectionobject.collection.parent.name }}{% endblocktranslate %}"
-     hx-confirm="{% blocktranslate %}Change {{ object }} from {{ collectionobject.collection.name }} to {{ collectionobject.collection.parent.name }}?{% endblocktranslate %}">{{ collectionobject.collection }}</a>
+     title="{% blocktranslate with parent_name=collectionobject.collection.parent.name %}Click to change to {{ parent_name }}{% endblocktranslate %}"
+     hx-confirm="{% blocktranslate with name=collectionobject.collection.name parent_name=collectionobject.collection.parent.name %}Change {{ object }} from {{ name }} to {{ parent_name }}?{% endblocktranslate %}">{{ collectionobject.collection }}</a>
 {% endif %}


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#std-templatetag-blocktranslate:
"To translate a template expression – say, accessing object attributes
or using template filters – you need to bind the expression to a local
variable for use within the translation block."
