### PR TITLE
fix(templates): repeat the default settings for htmx.responseHandling

### DIFF
--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -25,7 +25,7 @@
       <meta name="generator"
             content="APIS Core{% if debug %} {% apis_version %}{% endif %}">
       <meta name="htmx-config"
-            content='{"responseHandling":[{"code":"204", "swap": true}]}' />
+            content='{"responseHandling":[ {"code":"204", "swap": true}, {"code":"[23]..", "swap": true}, {"code":"[45]..", "swap": false, "error":true}, {"code":"...", "swap": false}]}' />
     {% endblock meta %}
 
     {% block favicons %}


### PR DESCRIPTION
If we only set the responseHandling object with the setting for the 204
response code, we replace all the other defaults. Lets instead set the
204 together with the defaults.
