### PR TITLE
docs: add Sphinx autosectionlabel extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ pyproject = tomllib.loads(pathlib.Path("../../pyproject.toml").read_text())
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",


### PR DESCRIPTION
Add Sphinx extension which converts references to
headings within the documentation to clickable links.