### PR TITLE
fix(generic): use blocktranslate with with statement

### DIFF
--- a/apis_core/generic/templates/generic/generic_enrich.html
+++ b/apis_core/generic/templates/generic/generic_enrich.html
@@ -7,7 +7,7 @@
   <div class="container">
     {% if form.fields %}
       <h4 class="mb-4">
-        {% blocktranslate %}Updating <a href="{{ object.get_absolute_url }}">{{ object }}</a> using the data from <a href="{{ uri }}">{{ uri }}</a>{% endblocktranslate %}
+        {% blocktranslate with url=object.get_absolute_url %}Updating <a href="{{ url }}">{{ object }}</a> using the data from <a href="{{ uri }}">{{ uri }}</a>{% endblocktranslate %}
       </h4>
       {% crispy form form.helper %}
     {% endif %}

--- a/apis_core/generic/templates/generic/generic_list.html
+++ b/apis_core/generic/templates/generic/generic_list.html
@@ -43,7 +43,7 @@
     <div class="col-8">
       <div class="card">
         <div class="card-header">
-          {% blocktranslate %}{{ table.paginator.count }} results.{% endblocktranslate %}
+          {% blocktranslate with count=table.paginator.count %}{{ count }} results.{% endblocktranslate %}
           {% if view.export_formats %}
             {% translate "Download" %}
             {% for format in view.export_formats %}

--- a/apis_core/generic/templates/generic/generic_merge.html
+++ b/apis_core/generic/templates/generic/generic_merge.html
@@ -13,10 +13,10 @@
 {% block content %}
   <div class="container">
     <h4 class="mb-4">
-      {% blocktranslate %}Merging values of <a href="{{ other.get_absolute_url }}">{{ other }}</a> into <a href="{{ object.get_absolute_url }}">{{ object }}</a>{% endblocktranslate %}
+      {% blocktranslate with url=object.get_absolute_url %}Merging values of <a href="{{ url }}">{{ other }}</a> into <a href="{{ url }}">{{ object }}</a>{% endblocktranslate %}
     </h4>
     <div class="alert alert-warning" role="alert">
-      {% blocktranslate %}After the merge <a href="{{ other.get_absolute_url }}">{{ other }}</a> will be deleted!{% endblocktranslate %}
+      {% blocktranslate with url=object.get_absolute_url %}After the merge <a href="{{ url }}">{{ other }}</a> will be deleted!{% endblocktranslate %}
     </div>
     <table class="table table-sm table-hover table-bordered difftable">
       <thead>

--- a/apis_core/generic/templates/generic/generic_selectmergeorenrich.html
+++ b/apis_core/generic/templates/generic/generic_selectmergeorenrich.html
@@ -6,7 +6,7 @@
   <div class="container">
     <div class="card">
       <div class="card-header">
-        {% blocktranslate %}Select to merge into <a href="{{ object.get_absolute_url }}">{{ object }}</a>{% endblocktranslate %}
+        {% blocktranslate with url=object.get_absolute_url %}Select to merge into <a href="{{ url }}">{{ object }}</a>{% endblocktranslate %}
       </div>
       <div class="card-body">{% crispy form form.helper %}</div>
     </div>


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#std-templatetag-blocktranslate:
"To translate a template expression – say, accessing object attributes
or using template filters – you need to bind the expression to a local
variable for use within the translation block."
