### PR TITLE
chore(translations): remove exact location from po files

### DIFF
--- a/.github/workflows/django-messages.yml
+++ b/.github/workflows/django-messages.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get -f install gettext
       - name: Make messages
-        run: uv run ./manage.py makemessages -l de
+        run: uv run ./manage.py makemessages -l de --add-location file
       - name: Check changes using git-diff
         run: git diff --exit-code

--- a/apis_core/apis_entities/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/apis_entities/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 02:19-0500\n"
+"POT-Creation-Date: 2025-04-03 04:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,115 +18,114 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apis_core/apis_entities/abc.py:18
+#: apis_core/apis_entities/abc.py
 msgid "forname"
 msgstr "Vorname"
 
-#: apis_core/apis_entities/abc.py:21
+#: apis_core/apis_entities/abc.py
 msgid "surname"
 msgstr "Nachname"
 
-#: apis_core/apis_entities/abc.py:24
+#: apis_core/apis_entities/abc.py
 msgid "gender"
 msgstr "Gender"
 
-#: apis_core/apis_entities/abc.py:27
+#: apis_core/apis_entities/abc.py
 msgid "date of birth"
 msgstr "Geburtsdatum"
 
-#: apis_core/apis_entities/abc.py:30
+#: apis_core/apis_entities/abc.py
 msgid "date of death"
 msgstr "Todesdatum"
 
-#: apis_core/apis_entities/abc.py:35
+#: apis_core/apis_entities/abc.py
 msgid "person"
 msgstr "Person"
 
-#: apis_core/apis_entities/abc.py:36
+#: apis_core/apis_entities/abc.py
 msgid "persons"
 msgstr "Personen"
 
-#: apis_core/apis_entities/abc.py:57 apis_core/apis_entities/abc.py:89
-#: apis_core/apis_entities/abc.py:111
+#: apis_core/apis_entities/abc.py
 msgid "label"
 msgstr "Label"
 
-#: apis_core/apis_entities/abc.py:59
+#: apis_core/apis_entities/abc.py
 msgid "latitude"
 msgstr "Latitude"
 
-#: apis_core/apis_entities/abc.py:60
+#: apis_core/apis_entities/abc.py
 msgid "longitude"
 msgstr "Longitude"
 
-#: apis_core/apis_entities/abc.py:65
+#: apis_core/apis_entities/abc.py
 msgid "feature code"
 msgstr "Feature Code"
 
-#: apis_core/apis_entities/abc.py:71
+#: apis_core/apis_entities/abc.py
 msgid "place"
 msgstr "Ort"
 
-#: apis_core/apis_entities/abc.py:72
+#: apis_core/apis_entities/abc.py
 msgid "places"
 msgstr "Orte"
 
-#: apis_core/apis_entities/abc.py:94
+#: apis_core/apis_entities/abc.py
 msgid "group"
 msgstr "Gruppe"
 
-#: apis_core/apis_entities/abc.py:95
+#: apis_core/apis_entities/abc.py
 msgid "groups"
 msgstr "Gruppen"
 
-#: apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_autocomplete_result.html:11
+#: apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_autocomplete_result.html
 msgid "local result"
 msgstr "Lokaler Eintrag"
 
-#: apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_list.html:6
+#: apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_list.html
 msgid "Map"
 msgstr "Karte"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html:7
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
 msgid "Actions"
 msgstr "Aktionen"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html:11
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
 msgid "Delete"
 msgstr "Löschen"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html:17
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html:21
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
 msgid "Merge"
 msgstr "Zusammenführen"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html:25
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
 msgid "Tag Version"
 msgstr "Version taggen"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html:8
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
 msgid "View"
 msgstr "Ansehen"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html:12
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html:17
+#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
 msgid "History"
 msgstr "Geschichte"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html:18
+#: apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html
 msgid "... merge data"
 msgstr "... Daten zusammenführen"
 
-#: apis_core/apis_entities/templates/base.html:15
+#: apis_core/apis_entities/templates/base.html
 msgid "Entities"
 msgstr "Entitäten"
 
-#: apis_core/apis_entities/templates/columns/duplicate.html:2
+#: apis_core/apis_entities/templates/columns/duplicate.html
 msgid "duplicate"
 msgstr "duplizieren"

--- a/apis_core/collections/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/collections/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 02:19-0500\n"
+"POT-Creation-Date: 2025-04-03 04:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,26 +18,26 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apis_core/collections/templates/base.html:9
+#: apis_core/collections/templates/base.html
 msgid "Collections"
 msgstr ""
 
-#: apis_core/collections/templates/collections/collection_object_collection.html:10
+#: apis_core/collections/templates/collections/collection_object_collection.html
 #, python-format
 msgid "Click to change to %(parent_name)s"
 msgstr ""
 
-#: apis_core/collections/templates/collections/collection_object_collection.html:11
+#: apis_core/collections/templates/collections/collection_object_collection.html
 #, python-format
 msgid "Change %(object)s from %(name)s to %(parent_name)s?"
 msgstr ""
 
-#: apis_core/collections/templates/collections/collection_object_parent.html:7
+#: apis_core/collections/templates/collections/collection_object_parent.html
 #, python-format
 msgid "Click to change to %(collectionobject.collection.parent)s"
 msgstr ""
 
-#: apis_core/collections/templates/collections/collection_object_parent.html:8
+#: apis_core/collections/templates/collections/collection_object_parent.html
 #, python-format
 msgid ""
 "Change %(object)s from %(collectionobject.collection)s to "

--- a/apis_core/core/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/core/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 02:19-0500\n"
+"POT-Creation-Date: 2025-04-03 04:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apis_core/core/templates/base.html:133
+#: apis_core/core/templates/base.html
 msgid "log out"
 msgstr "abmelden"
 
-#: apis_core/core/templates/maintenance.html:8
+#: apis_core/core/templates/maintenance.html
 msgid "Site Maintenance"
 msgstr "Seiten Wartung"
 
-#: apis_core/core/templates/maintenance.html:12
+#: apis_core/core/templates/maintenance.html
 msgid "We&rsquo;ll be back soon!"
 msgstr "Wir weden bald zurück sein!"
 
-#: apis_core/core/templates/maintenance.html:15
+#: apis_core/core/templates/maintenance.html
 msgid ""
 "Sorry for the inconvenience but we&rsquo;re performing some maintenance at "
 "the moment. We&rsquo;ll be back online shortly!"
 msgstr ""
 
-#: apis_core/core/templates/maintenance.html:17
+#: apis_core/core/templates/maintenance.html
 msgid "The Team"
 msgstr "Das Team"
 
-#: apis_core/core/templates/registration/login.html:11
+#: apis_core/core/templates/registration/login.html
 msgid "login"
 msgstr "anmelden"

--- a/apis_core/documentation/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/documentation/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 02:19-0500\n"
+"POT-Creation-Date: 2025-04-03 04:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,58 +18,58 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apis_core/documentation/templates/documentation.html:15
+#: apis_core/documentation/templates/documentation.html
 msgid "Entities"
 msgstr "Entitäten"
 
-#: apis_core/documentation/templates/documentation.html:21
+#: apis_core/documentation/templates/documentation.html
 msgid "related via"
 msgstr "in Verbindung über"
 
-#: apis_core/documentation/templates/documentation.html:33
+#: apis_core/documentation/templates/documentation.html
 msgid "attributes"
 msgstr "Attribute"
 
-#: apis_core/documentation/templates/documentation.html:37
+#: apis_core/documentation/templates/documentation.html
 msgid "Verbose name"
 msgstr "Voller Name"
 
-#: apis_core/documentation/templates/documentation.html:38
+#: apis_core/documentation/templates/documentation.html
 msgid "Help text"
 msgstr "Hilfstext"
 
-#: apis_core/documentation/templates/documentation.html:39
+#: apis_core/documentation/templates/documentation.html
 msgid "Primary key"
 msgstr "Primärschlüssel"
 
-#: apis_core/documentation/templates/documentation.html:40
+#: apis_core/documentation/templates/documentation.html
 msgid "Can be blank"
 msgstr "Kann leer sein"
 
-#: apis_core/documentation/templates/documentation.html:41
+#: apis_core/documentation/templates/documentation.html
 msgid "Can be null"
 msgstr "Kann null sein"
 
-#: apis_core/documentation/templates/documentation.html:42
+#: apis_core/documentation/templates/documentation.html
 msgid "Choices"
 msgstr "Auswahlmöglichkeiten"
 
-#: apis_core/documentation/templates/documentation.html:43
+#: apis_core/documentation/templates/documentation.html
 msgid "Type"
 msgstr "Typ"
 
-#: apis_core/documentation/templates/documentation.html:76
+#: apis_core/documentation/templates/documentation.html
 msgid "Relations"
 msgstr "Relationen"
 
-#: apis_core/documentation/templates/documentation.html:80
+#: apis_core/documentation/templates/documentation.html
 msgid "with"
 msgstr "mit"
 
-#: apis_core/documentation/templates/documentation.html:85
+#: apis_core/documentation/templates/documentation.html
 msgid "Subjects"
 msgstr "Subjecs"
 
-#: apis_core/documentation/templates/documentation.html:86
+#: apis_core/documentation/templates/documentation.html
 msgid "Objects"
 msgstr "Ojbects"

--- a/apis_core/generic/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/generic/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 02:19-0500\n"
+"POT-Creation-Date: 2025-04-03 04:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,105 +18,100 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apis_core/generic/forms/fields.py:15
+#: apis_core/generic/forms/fields.py
 #, python-format
 msgid "Could not import %(value)s: %(exception)s"
 msgstr "Konnte %(value)s nicht importieren: %(exception)s"
 
-#: apis_core/generic/templates/base.html:18
+#: apis_core/generic/templates/base.html
 msgid "Other models"
 msgstr "Andere Modelle"
 
-#: apis_core/generic/templates/columns/delete.html:2
+#: apis_core/generic/templates/columns/delete.html
 msgid "delete"
 msgstr "löschen"
 
-#: apis_core/generic/templates/columns/delete.html:4
+#: apis_core/generic/templates/columns/delete.html
 #, python-format
 msgid "Are your sure you want to delete %(record)s?"
 msgstr "Wollen sie %(record)s sicher löschen?"
 
-#: apis_core/generic/templates/columns/edit.html:2
+#: apis_core/generic/templates/columns/edit.html
 msgid "edit"
 msgstr "bearbeiten"
 
-#: apis_core/generic/templates/columns/view.html:2
+#: apis_core/generic/templates/columns/view.html
 msgid "view"
 msgstr "ansehen"
 
-#: apis_core/generic/templates/generic/generic_confirm_delete.html:9
+#: apis_core/generic/templates/generic/generic_confirm_delete.html
 msgid "Confirm deletion of"
 msgstr "Bestätige Löschen von"
 
-#: apis_core/generic/templates/generic/generic_confirm_delete.html:15
+#: apis_core/generic/templates/generic/generic_confirm_delete.html
 msgid "Yes, delete"
 msgstr "Ja, löschen"
 
-#: apis_core/generic/templates/generic/generic_enrich.html:10
+#: apis_core/generic/templates/generic/generic_enrich.html
 #, python-format
 msgid ""
 "Updating <a href=\"%(url)s\">%(object)s</a> using the data from <a "
 "href=\"%(uri)s\">%(uri)s</a>"
 msgstr ""
-"Aktualisiere <a href=\"%(url)s\">%(object)s</a> mit den "
-"Daten von <a href=\"%(uri)s\">%(uri)s</a>"
+"Aktualisiere <a href=\"%(url)s\">%(object)s</a> mit den Daten von <a "
+"href=\"%(uri)s\">%(uri)s</a>"
 
-#: apis_core/generic/templates/generic/generic_form.html:7
-#: apis_core/generic/templates/generic/generic_form.html:17
+#: apis_core/generic/templates/generic/generic_form.html
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: apis_core/generic/templates/generic/generic_form.html:9
-#: apis_core/generic/templates/generic/generic_form.html:19
-#: apis_core/generic/templates/generic/generic_list.html:18
+#: apis_core/generic/templates/generic/generic_form.html
+#: apis_core/generic/templates/generic/generic_list.html
 msgid "Create"
 msgstr "Erstellen"
 
-#: apis_core/generic/templates/generic/generic_import.html:7
-#: apis_core/generic/templates/generic/generic_list.html:20
+#: apis_core/generic/templates/generic/generic_import.html
+#: apis_core/generic/templates/generic/generic_list.html
 msgid "Import"
 msgstr "Importieren"
 
-#: apis_core/generic/templates/generic/generic_list.html:34
+#: apis_core/generic/templates/generic/generic_list.html
 msgid "Reset filter"
 msgstr "Filter zurücksetzen"
 
-#: apis_core/generic/templates/generic/generic_list.html:46
+#: apis_core/generic/templates/generic/generic_list.html
 #, python-format
 msgid "%(count)s results."
 msgstr "%(count)s Ergebnisse."
 
-#: apis_core/generic/templates/generic/generic_list.html:48
+#: apis_core/generic/templates/generic/generic_list.html
 msgid "Download"
 msgstr "Herunterladen"
 
-#: apis_core/generic/templates/generic/generic_merge.html:16
+#: apis_core/generic/templates/generic/generic_merge.html
 #, python-format
 msgid ""
 "Merging values of <a href=\"%(url)s\">%(other)s</a> into <a "
 "href=\"%(url)s\">%(object)s</a>"
 msgstr ""
-"Übernehme Daten von <a href=\"%(url)s\">%(other)s</a> in "
-"<a href=\"%(url)s\">%(object)s</a>"
+"Übernehme Daten von <a href=\"%(url)s\">%(other)s</a> in <a "
+"href=\"%(url)s\">%(object)s</a>"
 
-#: apis_core/generic/templates/generic/generic_merge.html:19
+#: apis_core/generic/templates/generic/generic_merge.html
 #, python-format
 msgid "After the merge <a href=\"%(url)s\">%(other)s</a> will be deleted!"
 msgstr ""
-"Nach dem Zusammenführen wird <a "
-"href=\"%(url)s\">%(other)s</a> gelöscht!"
+"Nach dem Zusammenführen wird <a href=\"%(url)s\">%(other)s</a> gelöscht!"
 
-#: apis_core/generic/templates/generic/generic_merge.html:25
+#: apis_core/generic/templates/generic/generic_merge.html
 msgid "Old value"
 msgstr "Alter Wert"
 
-#: apis_core/generic/templates/generic/generic_merge.html:26
+#: apis_core/generic/templates/generic/generic_merge.html
 msgid "New value"
 msgstr "Neuer Wert"
 
-#: apis_core/generic/templates/generic/generic_selectmergeorenrich.html:9
+#: apis_core/generic/templates/generic/generic_selectmergeorenrich.html
 #, python-format
 msgid "Select to merge into <a href=\"%(url)s\">%(object)s</a>"
-msgstr ""
-"Auswahl um nach <a href=\"%(url)s\">%(object)s</a> zu "
-"überführen"
+msgstr "Auswahl um nach <a href=\"%(url)s\">%(object)s</a> zu überführen"

--- a/apis_core/relations/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/relations/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 02:19-0500\n"
+"POT-Creation-Date: 2025-04-03 04:49-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,54 +18,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: apis_core/relations/abc.py:13
+#: apis_core/relations/abc.py
 msgid "is member of"
 msgstr "ist Mitglied von"
 
-#: apis_core/relations/abc.py:17
+#: apis_core/relations/abc.py
 msgid "has as member"
 msgstr "hat als Mitglied"
 
-#: apis_core/relations/abc.py:26
+#: apis_core/relations/abc.py
 msgid "lives in"
 msgstr "lebt in"
 
-#: apis_core/relations/abc.py:30
+#: apis_core/relations/abc.py
 msgid "has habitant"
 msgstr "hat als Bewohner"
 
-#: apis_core/relations/abc.py:39
+#: apis_core/relations/abc.py
 msgid "is located in"
 msgstr "befindet sich in"
 
-#: apis_core/relations/abc.py:43
+#: apis_core/relations/abc.py
 msgid "is location of"
 msgstr "ist Ort von"
 
-#: apis_core/relations/abc.py:52
+#: apis_core/relations/abc.py
 msgid "born in"
 msgstr "geboren in"
 
-#: apis_core/relations/abc.py:56
+#: apis_core/relations/abc.py
 msgid "is birth place of"
 msgstr "ist Geburtsort von"
 
-#: apis_core/relations/abc.py:65
+#: apis_core/relations/abc.py
 msgid "died in"
 msgstr "gestorben in"
 
-#: apis_core/relations/abc.py:69
+#: apis_core/relations/abc.py
 msgid "is place of death of"
 msgstr "ist Todesort von"
 
-#: apis_core/relations/templates/base.html:14
+#: apis_core/relations/templates/base.html
 msgid "Relations"
 msgstr "Relationen"
 
-#: apis_core/relations/templates/base.html:19
+#: apis_core/relations/templates/base.html
 msgid "All relations"
 msgstr "Alle Relationen"
 
-#: apis_core/relations/templates/base.html:25
+#: apis_core/relations/templates/base.html
 msgid "Filter relations..."
 msgstr "Relationen filtern..."


### PR DESCRIPTION
This leads to too much noise, because we would have to update the
translations basically every time the linenumber of a text changes.
