### PR TITLE
fix(collections): use `.parent_collection` instead of `.parent`

### DIFF
--- a/apis_core/collections/templatetags/collections.py
+++ b/apis_core/collections/templatetags/collections.py
@@ -96,7 +96,7 @@ def collection_object_collection(context, obj, skoscollectioncollectionobjects):
         )
     if len(skoscollectioncollectionobjects) == 1:
         collectionobject = skoscollectioncollectionobjects.first()
-        context["parent"] = collectionobject.collection.parent
+        context["parent"] = collectionobject.collection.parent_collection
         context["collectionobject"] = collectionobject
         context["content_type"] = ContentType.objects.get_for_model(obj)
         context["object"] = obj


### PR DESCRIPTION
The whole idea of the `collection_object_collection` templatetag is that
it does **not** rely on the `.parent` attribute but instead uses the
`.parent_collection` that lists the collections this collection is part
of.
