### PR TITLE
refactor(generic): use custom CSS classes for object actions

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_actions_nav.html
@@ -7,7 +7,8 @@
         <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#">{% translate "Actions" %}</a>
         <div class="dropdown-menu">
           {% if object.get_delete_permission in perms %}
-            <a class="dropdown-item text-danger" href="{{ object.get_delete_url }}">
+            <a class="dropdown-item object-delete"
+               href="{{ object.get_delete_url }}">
               <span class="material-symbols-outlined material-symbols-align">delete</span>{% translate "Delete" %}
             </a>
           {% endif %}

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
@@ -4,11 +4,11 @@
   {% if object.get_change_permission in perms %}
     <ul class="nav nav-tabs card-header-tabs float-start">
       <li class="nav-item">
-        <a class="nav-link text-success {% if request.path == object.get_absolute_url %}active{% endif %} "
+        <a class="nav-link object-view {% if request.path == object.get_absolute_url %}active{% endif %} "
            href="{{ object.get_absolute_url }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>{% translate "View" %}</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link text-warning {% if request.path == object.get_edit_url %}active{% endif %} "
+        <a class="nav-link object-edit {% if request.path == object.get_edit_url %}active{% endif %} "
            href="{{ object.get_edit_url }}"><span class="material-symbols-outlined material-symbols-align">edit</span>{% translate "Edit" %}</a>
       </li>
       {% if object.history %}

--- a/apis_core/generic/static/css/generic.css
+++ b/apis_core/generic/static/css/generic.css
@@ -1,4 +1,16 @@
-/* additional object actions */
+/* object actions */
+.object-view {
+    color: rgb(25, 135, 84);
+}
+
+.object-edit {
+    color: rgb(255, 193, 7);
+}
+
+.object-delete {
+    color: rgb(220, 53, 69);
+}
+
 .object-duplicate {
     color: blueviolet;
 }

--- a/apis_core/generic/templates/columns/delete.html
+++ b/apis_core/generic/templates/columns/delete.html
@@ -5,4 +5,4 @@
    hx-target="closest tr"
    hx-swap="outerHTML swap:0.3s"
    href="{{ record.get_delete_url }}"
-   class="text-danger"><span class="material-symbols-outlined">delete</span></a>
+   class="object-delete"><span class="material-symbols-outlined">delete</span></a>

--- a/apis_core/generic/templates/columns/edit.html
+++ b/apis_core/generic/templates/columns/edit.html
@@ -1,4 +1,4 @@
 {% load i18n %}
 <a title="{% translate "edit" %}"
    href="{{ record.get_edit_url }}"
-   class="text-warning"><span class="material-symbols-outlined">edit</span></a>
+   class="object-edit"><span class="material-symbols-outlined">edit</span></a>

--- a/apis_core/generic/templates/columns/view.html
+++ b/apis_core/generic/templates/columns/view.html
@@ -1,4 +1,4 @@
 {% load i18n %}
 <a title="{% translate "view" %}"
    href="{{ record.get_absolute_url }}"
-   class="text-success"><span class="material-symbols-outlined">visibility</span></a>
+   class="object-view"><span class="material-symbols-outlined">visibility</span></a>


### PR DESCRIPTION
Switch styling for object actions view, edit, delete from Boostrap's built-in colour classes which convey meaning to custom CSS classes. This gathers all object action classes in one place (duplicate, merge, history actions already use custom CSS classes) and allows independent use of the built-ins.

Resolves: #1765