### PR TITLE
feat(apis_entities): open URIs in a new window/tab

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html
@@ -3,7 +3,9 @@
 {% if object.uri_set %}
   {% for uri in object.uri_set.all %}
     <div class="btn-group">
-      <a class="btn btn-sm btn-outline-secondary" href="{{ uri.uri }}">{{ uri.short_label }}</a>
+      <a class="btn btn-sm btn-outline-secondary"
+         target="_blank"
+         href="{{ uri.uri }}">{{ uri.short_label }}</a>
       {% if object.get_change_permission in perms %}
         {% if not uri.internal %}
           <button type="button"


### PR DESCRIPTION
closes #1726
both internal and external links will open in a new window/tab as these links take the user away from the APIS web app.

