### PR TITLE
fix: move history nav entry template to history

### DIFF
--- a/apis_core/apis_entities/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/apis_entities/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 04:49-0500\n"
+"POT-Creation-Date: 2025-04-14 03:47-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,10 +114,6 @@ msgstr "Ansehen"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
-msgid "History"
-msgstr "Historie"
-
 #: apis_core/apis_entities/templates/apis_entities/partials/linked_open_data.html
 msgid "... merge data"
 msgstr "... Daten zusammenführen"
@@ -129,3 +125,6 @@ msgstr "Entitäten"
 #: apis_core/apis_entities/templates/columns/duplicate.html
 msgid "duplicate"
 msgstr "duplizieren"
+
+#~ msgid "History"
+#~ msgstr "Geschichte"

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
@@ -13,12 +13,6 @@
           <a class="nav-link object-edit {% if request.path == object.get_edit_url %}active{% endif %} "
              href="{{ object.get_edit_url }}"><span class="material-symbols-outlined material-symbols-align">edit</span>{% translate "Edit" %}</a>
         </li>
-        {% if object.history %}
-          <li class="object-history nav-item">
-            <a class="nav-link {% if request.path == object.get_history_url %}active{% endif %}"
-               href="{{ object.get_history_url }}"><span class="material-symbols-outlined material-symbols-align">history</span>{% translate "History" %}</a>
-          </li>
-        {% endif %}
       {% endblock base-nav-inner %}
 
     </ul>

--- a/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/entity_base_nav.html
@@ -3,20 +3,24 @@
 {% block base-nav %}
   {% if object.get_change_permission in perms %}
     <ul class="nav nav-tabs card-header-tabs float-start">
-      <li class="nav-item">
-        <a class="nav-link object-view {% if request.path == object.get_absolute_url %}active{% endif %} "
-           href="{{ object.get_absolute_url }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>{% translate "View" %}</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link object-edit {% if request.path == object.get_edit_url %}active{% endif %} "
-           href="{{ object.get_edit_url }}"><span class="material-symbols-outlined material-symbols-align">edit</span>{% translate "Edit" %}</a>
-      </li>
-      {% if object.history %}
-        <li class="object-history nav-item">
-          <a class="nav-link {% if request.path == object.get_history_url %}active{% endif %}"
-             href="{{ object.get_history_url }}"><span class="material-symbols-outlined material-symbols-align">history</span>{% translate "History" %}</a>
+
+      {% block base-nav-inner %}
+        <li class="nav-item">
+          <a class="nav-link object-view {% if request.path == object.get_absolute_url %}active{% endif %} "
+             href="{{ object.get_absolute_url }}"><span class="material-symbols-outlined material-symbols-align">visibility</span>{% translate "View" %}</a>
         </li>
-      {% endif %}
+        <li class="nav-item">
+          <a class="nav-link object-edit {% if request.path == object.get_edit_url %}active{% endif %} "
+             href="{{ object.get_edit_url }}"><span class="material-symbols-outlined material-symbols-align">edit</span>{% translate "Edit" %}</a>
+        </li>
+        {% if object.history %}
+          <li class="object-history nav-item">
+            <a class="nav-link {% if request.path == object.get_history_url %}active{% endif %}"
+               href="{{ object.get_history_url }}"><span class="material-symbols-outlined material-symbols-align">history</span>{% translate "History" %}</a>
+          </li>
+        {% endif %}
+      {% endblock base-nav-inner %}
+
     </ul>
   {% endif %}
 {% endblock base-nav %}

--- a/apis_core/history/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/history/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-14 03:47-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: apis_core/history/templates/apis_entities/partials/entity_base_nav.html
+msgid "History"
+msgstr "Historie"

--- a/apis_core/history/templates/apis_entities/partials/entity_base_nav.html
+++ b/apis_core/history/templates/apis_entities/partials/entity_base_nav.html
@@ -1,0 +1,12 @@
+{% extends "apis_entities/partials/entity_base_nav.html" %}
+{% load i18n %}
+
+{% block base-nav-inner %}
+  {{ block.super }}
+  {% if object.history %}
+    <li class="object-history nav-item">
+      <a class="nav-link {% if request.path == object.get_history_url %}active{% endif %}"
+         href="{{ object.get_history_url }}"><span class="material-symbols-outlined material-symbols-align">history</span>{% translate "History" %}</a>
+    </li>
+  {% endif %}
+{% endblock base-nav-inner %}

--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -44,10 +44,10 @@ INSTALLED_APPS = [
     "apis_core.collections",
     "apis_core.apis_metainfo",
     "apis_core.relations",
+    "apis_core.history",
     "apis_core.apis_entities",
     # APIS history modules tracks changes of instances over
     # time and lets you revert changes
-    "apis_core.history",
     # The core APIS apps come last, so other apps can override
     # and extend their templates
     "apis_core.core",


### PR DESCRIPTION
update the templates to separate `history` better from `core`.
resolves #1780