### PR TITLE
fix(generic): templates: show only existing values

### DIFF
--- a/apis_core/generic/templates/generic/partials/default_model_field_value.html
+++ b/apis_core/generic/templates/generic/partials/default_model_field_value.html
@@ -1,1 +1,1 @@
-{{ value }}
+{% if value %}{{ value }}{% endif %}


### PR DESCRIPTION
The default should be to *not* show empty lists.

Closes: #1797
