### PR TITLE
feat(generic): move css include into the base template

### DIFF
--- a/apis_core/generic/templates/base.html
+++ b/apis_core/generic/templates/base.html
@@ -2,6 +2,12 @@
 {% load generic %}
 {% load core %}
 {% load i18n %}
+{% load static %}
+
+{% block styles %}
+  {{ block.super }}
+  <link href="{% static 'css/generic.css' %}" rel="stylesheet" />
+{% endblock styles %}
 
 {% block main-menu %}
   {{ block.super }}

--- a/apis_core/generic/templates/generic/generic_content.html
+++ b/apis_core/generic/templates/generic/generic_content.html
@@ -1,10 +1,4 @@
 {% extends basetemplate|default:"base.html" %}
-{% load static %}
-
-{% block styles %}
-  {{ block.super }}
-  <link href="{% static 'css/generic.css' %}" rel="stylesheet" />
-{% endblock styles %}
 
 {% block content %}
   <div class="container-fluid">


### PR DESCRIPTION
To make it easier for users to inject css files *after* the inclusion of
the `generic.css` file we move this inclusion to the `base.html` block.
This way it is included on the same level as the css files of the other
apps.
