### PR TITLE
Update CSS, JS indentation (config)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 K Kollmann
+# SPDX-License-Identifier: MIT
+
+# formatting rules for CSS and JS files applied by css-beautify and
+# js-beautify workflows, respectively
+[*.{css,js}]
+end_of_line=lf
+indent_style=space
+indent_size=2
+insert_final_newline=true
+trim_trailing_whitespace=true

--- a/.github/workflows/css-beautify.yml
+++ b/.github/workflows/css-beautify.yml
@@ -16,7 +16,7 @@ jobs:
         run: uv sync --only-dev
       - name: Run css-beautify
         run: |
-          if find apis_core -name "*.css" -exec uv run css-beautify -rn {} \; | grep -v unchanged; then
+          if find apis_core -name "*.css" -exec uv run css-beautify --editorconfig -r {} \; | grep -v unchanged; then
             exit 1;
           else
             exit 0;

--- a/.github/workflows/js-beautify.yml
+++ b/.github/workflows/js-beautify.yml
@@ -16,7 +16,7 @@ jobs:
         run: uv sync --only-dev
       - name: Run js-beautify
         run: |
-          if find apis_core -name "*.js" -exec uv run js-beautify -rn {} \; | grep -v unchanged; then
+          if find apis_core -name "*.js" -exec uv run js-beautify --editorconfig -r {} \; | grep -v unchanged; then
             exit 1;
           else
             exit 0;

--- a/apis_core/apis_entities/static/css/E53_Place_popover.css
+++ b/apis_core/apis_entities/static/css/E53_Place_popover.css
@@ -1,12 +1,12 @@
 #map {
-    height: 300px;
+  height: 300px;
 }
 
 .h80vh {
-    height: 80vh !important;
+  height: 80vh !important;
 }
 
 #popovermap {
-    width: 500px;
-    height: 500px;
+  width: 500px;
+  height: 500px;
 }

--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -1,13 +1,13 @@
 /* single object view header */
 #single-object-header h2 {
-    text-align: center;
+  text-align: center;
 }
 
 /* navigation between objects (in list) from single object view header */
 .prev-in-list {
-    float: right;
+  float: right;
 }
 
 .next-in-list {
-    float: left;
+  float: left;
 }

--- a/apis_core/apis_entities/static/js/E53_Place_map.js
+++ b/apis_core/apis_entities/static/js/E53_Place_map.js
@@ -1,23 +1,23 @@
 document.addEventListener('DOMContentLoaded', function() {
-    mapel = document.getElementById("map");
-    if (mapel) {
-        var map = L.map('map').setView([51.505, -0.09], 13);
-        var markers = L.markerClusterGroup();
+  mapel = document.getElementById("map");
+  if (mapel) {
+    var map = L.map('map').setView([51.505, -0.09], 13);
+    var markers = L.markerClusterGroup();
 
-        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
 
-        listitems = mapel.querySelectorAll("li");
-        var latlngs = [];
-        var markers = L.markerClusterGroup();
-        for (const element of listitems) {
-            var markercontent = element.innerHTML;
-            markers.addLayer(L.marker([element.dataset.latitude, element.dataset.longitude]).bindPopup(markercontent).openPopup());
-            latlngs.push([element.dataset.latitude, element.dataset.longitude]);
-        }
-        map.addLayer(markers);
-        var bounds = new L.LatLngBounds(latlngs);
-        map.fitBounds(bounds);
+    listitems = mapel.querySelectorAll("li");
+    var latlngs = [];
+    var markers = L.markerClusterGroup();
+    for (const element of listitems) {
+      var markercontent = element.innerHTML;
+      markers.addLayer(L.marker([element.dataset.latitude, element.dataset.longitude]).bindPopup(markercontent).openPopup());
+      latlngs.push([element.dataset.latitude, element.dataset.longitude]);
     }
+    map.addLayer(markers);
+    var bounds = new L.LatLngBounds(latlngs);
+    map.fitBounds(bounds);
+  }
 });

--- a/apis_core/apis_entities/static/js/E53_Place_popover.js
+++ b/apis_core/apis_entities/static/js/E53_Place_popover.js
@@ -2,39 +2,39 @@
  * show a map in a popover
  */
 function showMap(element) {
-    document.querySelectorAll(".popovermap").forEach(el => el.remove());
+  document.querySelectorAll(".popovermap").forEach(el => el.remove());
 
-    let map;
+  let map;
 
-    let rect = element.getBoundingClientRect();
-    let pTop = rect.top + window.scrollY - 250;
-    let pLeft = rect.left + window.scrollX - 550;
+  let rect = element.getBoundingClientRect();
+  let pTop = rect.top + window.scrollY - 250;
+  let pLeft = rect.left + window.scrollX - 550;
 
-    let mapDiv = document.createElement("div");
-    mapDiv.classList.add("popovermap");
-    mapDiv.setAttribute("id", "popovermap");
+  let mapDiv = document.createElement("div");
+  mapDiv.classList.add("popovermap");
+  mapDiv.setAttribute("id", "popovermap");
 
-    mapDiv.style.position = "absolute";
-    mapDiv.style.top = pTop + "px";
-    mapDiv.style.left = pLeft + "px";
+  mapDiv.style.position = "absolute";
+  mapDiv.style.top = pTop + "px";
+  mapDiv.style.left = pLeft + "px";
 
-    document.body.appendChild(mapDiv);
+  document.body.appendChild(mapDiv);
 
-    if (typeof map !== "undefined") {
-        map.off();
-        map.remove();
-    }
+  if (typeof map !== "undefined") {
+    map.off();
+    map.remove();
+  }
 
-    map = L.map('popovermap', {
-        center: [parseInt(element.dataset.latitude), parseInt(element.dataset.longitude)],
-        zoom: 5
-    });
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(map);
-    L.marker([parseInt(element.dataset.latitude), parseInt(element.dataset.longitude)]).addTo(map);
+  map = L.map('popovermap', {
+    center: [parseInt(element.dataset.latitude), parseInt(element.dataset.longitude)],
+    zoom: 5
+  });
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+  }).addTo(map);
+  L.marker([parseInt(element.dataset.latitude), parseInt(element.dataset.longitude)]).addTo(map);
 }
 
 function delMap(element) {
-    document.querySelectorAll(".popovermap").forEach(el => el.remove());
+  document.querySelectorAll(".popovermap").forEach(el => el.remove());
 }

--- a/apis_core/apis_entities/static/js/apis_entities.js
+++ b/apis_core/apis_entities/static/js/apis_entities.js
@@ -1,40 +1,40 @@
 $(document).ready(function() {
-    $(document).on('submit', 'form.form.ajax_form', unbind_ajax_forms);
+  $(document).on('submit', 'form.form.ajax_form', unbind_ajax_forms);
 });
 
 function unbind_ajax_forms(event) {
-    $(this).find('button').attr('disabled', true);
-    event.preventDefault();
-    event.stopPropagation();
-    var formData = $(this).serialize();
-    //var button_text = $(this).find(':button').text();
-    $.ajax({
-            type: 'POST',
-            url: $(this).attr('action'),
-            data: formData,
-            beforeSend: function(request) {
-                var csrftoken = getCookie('csrftoken');
-                request.setRequestHeader("X-CSRFToken", csrftoken);
-            },
-            //data:formData,
-        })
-        .done(function(response) {
-            window[response.call_function](response)
-        })
+  $(this).find('button').attr('disabled', true);
+  event.preventDefault();
+  event.stopPropagation();
+  var formData = $(this).serialize();
+  //var button_text = $(this).find(':button').text();
+  $.ajax({
+      type: 'POST',
+      url: $(this).attr('action'),
+      data: formData,
+      beforeSend: function(request) {
+        var csrftoken = getCookie('csrftoken');
+        request.setRequestHeader("X-CSRFToken", csrftoken);
+      },
+      //data:formData,
+    })
+    .done(function(response) {
+      window[response.call_function](response)
+    })
 }
 
 function getCookie(name) {
-    var cookieValue = null;
-    if (document.cookie && document.cookie != '') {
-        var cookies = document.cookie.split(';');
-        for (var i = 0; i < cookies.length; i++) {
-            var cookie = jQuery.trim(cookies[i]);
-            // Does this cookie string begin with the name we want?
-            if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
+  var cookieValue = null;
+  if (document.cookie && document.cookie != '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = jQuery.trim(cookies[i]);
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) == (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
     }
-    return cookieValue;
+  }
+  return cookieValue;
 }

--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -1,32 +1,32 @@
 a #logo:hover {
-    opacity: 0.5;
+  opacity: 0.5;
 }
 
 footer a:has(> img),
 footer a:has(> span[class*="material-symbols"]) {
-    display: inline-block;
+  display: inline-block;
 }
 
 footer a:has(> img):hover,
 footer a:has(> span[class*="material-symbols"]):hover {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 /* main modal in modal block */
 #modal .modal-dialog {
-    max-width: 800px;
+  max-width: 800px;
 }
 
 /* scroll-to-top button */
 #btn-back-to-top {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    display: none;
-    opacity: 0.5;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: none;
+  opacity: 0.5;
 }
 
 footer .icon {
-    height: 1em;
-    font-size: 1.5em;
+  height: 1em;
+  font-size: 1.5em;
 }

--- a/apis_core/core/static/css/maintenance.css
+++ b/apis_core/core/static/css/maintenance.css
@@ -1,20 +1,20 @@
 body {
-    text-align: center;
-    padding: 150px;
+  text-align: center;
+  padding: 150px;
 }
 
 h1 {
-    font-size: 50px;
+  font-size: 50px;
 }
 
 body {
-    font: 20px Helvetica, sans-serif;
-    color: #333;
+  font: 20px Helvetica, sans-serif;
+  color: #333;
 }
 
 article {
-    display: block;
-    text-align: left;
-    width: 650px;
-    margin: 0 auto;
+  display: block;
+  text-align: left;
+  width: 650px;
+  margin: 0 auto;
 }

--- a/apis_core/core/static/css/material-symbols.css
+++ b/apis_core/core/static/css/material-symbols.css
@@ -1,25 +1,25 @@
 @font-face {
-    font-family: 'Material Symbols Outlined';
-    font-style: normal;
-    src: url(/static/fonts/material-symbols.woff) format('woff');
+  font-family: 'Material Symbols Outlined';
+  font-style: normal;
+  src: url(/static/fonts/material-symbols.woff) format('woff');
 }
 
 .material-symbols-outlined {
-    font-family: 'Material Symbols Outlined';
-    font-weight: normal;
-    font-style: normal;
-    /* preferred icon size */
-    font-size: 24px;
-    display: inline-block;
-    line-height: 1;
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    direction: ltr;
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  /* preferred icon size */
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
 }
 
 /* fix misaligned Material Icons/Symbols */
 .material-symbols-align {
-    vertical-align: bottom;
+  vertical-align: bottom;
 }

--- a/apis_core/core/static/css/override_bootstrap.min.css
+++ b/apis_core/core/static/css/override_bootstrap.min.css
@@ -2,5 +2,5 @@
 fix an issue with select2
 TODO remove after move to Boostrap 5 */
 .select2-container--default .select2-selection span.select2-selection__rendered {
-    line-height: initial;
+  line-height: initial;
 }

--- a/apis_core/core/static/js/apis_select2.js
+++ b/apis_core/core/static/js/apis_select2.js
@@ -10,152 +10,152 @@
 
 document.addEventListener('dal-init-function', function() {
 
-    yl.registerFunction('apis_select2', function($, element) {
+  yl.registerFunction('apis_select2', function($, element) {
 
-        var $element = $(element);
+    var $element = $(element);
 
-        // Templating helper
-        function template(text, is_html) {
-            if (is_html) {
-                var $result = $('<span>');
-                $result.html(text);
-                return $result;
-            } else {
-                return text;
-            }
+    // Templating helper
+    function template(text, is_html) {
+      if (is_html) {
+        var $result = $('<span>');
+        $result.html(text);
+        return $result;
+      } else {
+        return text;
+      }
+    }
+
+    function result_template(item) {
+      var is_data_html = ($element.attr('data-html') !== undefined || $element.attr('data-result-html') !== undefined)
+
+      if (item.create_id) {
+        var $result = $('<span>').addClass('dal-create');
+        if (is_data_html) {
+          return $result.html(item.text);
+        } else {
+          return $result.text(item.text);
         }
+      } else {
+        return template(item.text, is_data_html);
+      }
+    }
 
-        function result_template(item) {
-            var is_data_html = ($element.attr('data-html') !== undefined || $element.attr('data-result-html') !== undefined)
+    function selected_template(item) {
+      if (item.selected_text !== undefined) {
+        return template(item.selected_text,
+          $element.attr('data-html') !== undefined || $element.attr('data-selected-html') !== undefined
+        );
+      } else {
+        return result_template(item);
+      }
+      return
+    }
 
-            if (item.create_id) {
-                var $result = $('<span>').addClass('dal-create');
-                if (is_data_html) {
-                    return $result.html(item.text);
-                } else {
-                    return $result.text(item.text);
-                }
-            } else {
-                return template(item.text, is_data_html);
-            }
-        }
+    var ajax = null;
+    if ($element.attr('data-autocomplete-light-url')) {
+      ajax = {
+        url: $element.attr('data-autocomplete-light-url'),
+        dataType: 'json',
+        delay: 250,
 
-        function selected_template(item) {
-            if (item.selected_text !== undefined) {
-                return template(item.selected_text,
-                    $element.attr('data-html') !== undefined || $element.attr('data-selected-html') !== undefined
-                );
-            } else {
-                return result_template(item);
-            }
-            return
-        }
+        data: function(params) {
+          var data = {
+            q: params.term, // search term
+            page: params.page,
+            create: $element.attr('data-autocomplete-light-create') && !$element.attr('data-tags'),
+            forward: yl.getForwards($element)
+          };
 
-        var ajax = null;
-        if ($element.attr('data-autocomplete-light-url')) {
-            ajax = {
-                url: $element.attr('data-autocomplete-light-url'),
-                dataType: 'json',
-                delay: 250,
-
-                data: function(params) {
-                    var data = {
-                        q: params.term, // search term
-                        page: params.page,
-                        create: $element.attr('data-autocomplete-light-create') && !$element.attr('data-tags'),
-                        forward: yl.getForwards($element)
-                    };
-
-                    return data;
-                },
-                processResults: function(data, page) {
-                    if ($element.attr('data-tags')) {
-                        $.each(data.results, function(index, value) {
-                            value.id = value.id;
-                        });
-                    }
-
-                    return data;
-                },
-                cache: true
-            };
-        }
-        use_tags = false;
-        tokenSeparators = null;
-        // Option 1: 'data-tags'
-        if ($element.attr('data-tags')) {
-            tokenSeparators = [','];
-            use_tags = true;
-        }
-        // Option 2: 'data-token-separators'
-        if ($element.attr('data-token-separators')) {
-            use_tags = true
-            tokenSeparators = $element.attr('data-token-separators')
-            if (tokenSeparators == 'null') {
-                tokenSeparators = null;
-            }
-        }
-        $element.select2({
-            tokenSeparators: tokenSeparators,
-            debug: true,
-            containerCssClass: ':all:',
-            placeholder: $element.attr('data-placeholder') || '',
-            language: $element.attr('data-autocomplete-light-language'),
-            minimumInputLength: $element.attr('data-minimum-input-length') || 0,
-            allowClear: !$element.is('[required]'),
-            templateResult: result_template,
-            templateSelection: selected_template,
-            ajax: ajax,
-            with: null,
-            tags: use_tags,
-            dropdownParent: $(element.form),
-        });
-
-        $element.on('select2:selecting', function(e) {
-            var data = e.params.args.data;
-
-            if (data.create_id !== true)
-                return;
-
-            e.preventDefault();
-            e.stopImmediatePropagation();
-
-            var select = $element;
-
-            $.ajax({
-                url: $element.attr('data-autocomplete-light-url'),
-                type: 'POST',
-                dataType: 'json',
-                data: {
-                    text: data.id,
-                    forward: yl.getForwards($element)
-                },
-                beforeSend: function(xhr, settings) {
-                    xhr.setRequestHeader("X-CSRFToken", document.csrftoken);
-                },
-                success: function(data, textStatus, jqXHR) {
-                    if ('error' in data) {
-                        error = data['error']
-                        document.querySelectorAll(".invalid-feedback").forEach(el => el.remove());
-                        now = new Date();
-                        date = now.getHours() + ":" + now.getMinutes() + ":" + now.getSeconds()
-                        $('.dal-create').append(
-                            `<p class="invalid-feedback d-block">${date}: <strong>${error}</strong>`
-                        );
-
-                    } else {
-                        select.append(
-                            $('<option>', {
-                                value: data.id,
-                                text: data.text,
-                                selected: true
-                            })
-                        );
-                        select.trigger('change');
-                        select.select2('close');
-                    }
-                }
+          return data;
+        },
+        processResults: function(data, page) {
+          if ($element.attr('data-tags')) {
+            $.each(data.results, function(index, value) {
+              value.id = value.id;
             });
-        });
+          }
+
+          return data;
+        },
+        cache: true
+      };
+    }
+    use_tags = false;
+    tokenSeparators = null;
+    // Option 1: 'data-tags'
+    if ($element.attr('data-tags')) {
+      tokenSeparators = [','];
+      use_tags = true;
+    }
+    // Option 2: 'data-token-separators'
+    if ($element.attr('data-token-separators')) {
+      use_tags = true
+      tokenSeparators = $element.attr('data-token-separators')
+      if (tokenSeparators == 'null') {
+        tokenSeparators = null;
+      }
+    }
+    $element.select2({
+      tokenSeparators: tokenSeparators,
+      debug: true,
+      containerCssClass: ':all:',
+      placeholder: $element.attr('data-placeholder') || '',
+      language: $element.attr('data-autocomplete-light-language'),
+      minimumInputLength: $element.attr('data-minimum-input-length') || 0,
+      allowClear: !$element.is('[required]'),
+      templateResult: result_template,
+      templateSelection: selected_template,
+      ajax: ajax,
+      with: null,
+      tags: use_tags,
+      dropdownParent: $(element.form),
     });
+
+    $element.on('select2:selecting', function(e) {
+      var data = e.params.args.data;
+
+      if (data.create_id !== true)
+        return;
+
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      var select = $element;
+
+      $.ajax({
+        url: $element.attr('data-autocomplete-light-url'),
+        type: 'POST',
+        dataType: 'json',
+        data: {
+          text: data.id,
+          forward: yl.getForwards($element)
+        },
+        beforeSend: function(xhr, settings) {
+          xhr.setRequestHeader("X-CSRFToken", document.csrftoken);
+        },
+        success: function(data, textStatus, jqXHR) {
+          if ('error' in data) {
+            error = data['error']
+            document.querySelectorAll(".invalid-feedback").forEach(el => el.remove());
+            now = new Date();
+            date = now.getHours() + ":" + now.getMinutes() + ":" + now.getSeconds()
+            $('.dal-create').append(
+              `<p class="invalid-feedback d-block">${date}: <strong>${error}</strong>`
+            );
+
+          } else {
+            select.append(
+              $('<option>', {
+                value: data.id,
+                text: data.text,
+                selected: true
+              })
+            );
+            select.trigger('change');
+            select.select2('close');
+          }
+        }
+      });
+    });
+  });
 })

--- a/apis_core/core/static/js/core.js
+++ b/apis_core/core/static/js/core.js
@@ -1,43 +1,43 @@
 //script that converts the multi select element
 $(document).ready(function() {
-    $('select.selectmultiple').multiselect({
-        includeSelectAllOption: true,
-        enableFiltering: true,
-        enableCaseInsensitiveFiltering: true,
-        templates: {
-            filter: '<div class="multiselect-filter"><div class="input-group input-group-sm p-1"><input class="form-control multiselect-search" type="text" /></div></div>',
-            button: '<button type="button" class="multiselect dropdown-toggle form-control" data-bs-toggle="dropdown" aria-expanded="false"><span class="multiselect-selected-text"></span></button>'
-        }
-    });
+  $('select.selectmultiple').multiselect({
+    includeSelectAllOption: true,
+    enableFiltering: true,
+    enableCaseInsensitiveFiltering: true,
+    templates: {
+      filter: '<div class="multiselect-filter"><div class="input-group input-group-sm p-1"><input class="form-control multiselect-search" type="text" /></div></div>',
+      button: '<button type="button" class="multiselect dropdown-toggle form-control" data-bs-toggle="dropdown" aria-expanded="false"><span class="multiselect-selected-text"></span></button>'
+    }
+  });
 })
 
 window.addEventListener('load', () => {
-    // scroll-to-top button
+  // scroll-to-top button
 
-    //Get the button
-    let mybutton = document.getElementById("btn-back-to-top");
+  //Get the button
+  let mybutton = document.getElementById("btn-back-to-top");
 
-    // When the user scrolls down 20px from the top of the document, show the button
-    window.onscroll = function() {
-        scrollFunction();
-    };
+  // When the user scrolls down 20px from the top of the document, show the button
+  window.onscroll = function() {
+    scrollFunction();
+  };
 
-    function scrollFunction() {
-        if (
-            document.body.scrollTop > 20 ||
-            document.documentElement.scrollTop > 20
-        ) {
-            mybutton.style.display = "block";
-        } else {
-            mybutton.style.display = "none";
-        }
+  function scrollFunction() {
+    if (
+      document.body.scrollTop > 20 ||
+      document.documentElement.scrollTop > 20
+    ) {
+      mybutton.style.display = "block";
+    } else {
+      mybutton.style.display = "none";
     }
+  }
 
-    // When the user clicks on the button, scroll to the top of the document
-    mybutton.addEventListener("click", backToTop);
+  // When the user clicks on the button, scroll to the top of the document
+  mybutton.addEventListener("click", backToTop);
 
-    function backToTop() {
-        document.body.scrollTop = 0;
-        document.documentElement.scrollTop = 0;
-    }
+  function backToTop() {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  }
 })

--- a/apis_core/generic/static/css/generic.css
+++ b/apis_core/generic/static/css/generic.css
@@ -1,24 +1,24 @@
 /* object actions */
 .object-view {
-    color: rgb(25, 135, 84) !important;
+  color: rgb(25, 135, 84) !important;
 }
 
 .object-edit {
-    color: rgb(255, 193, 7) !important;
+  color: rgb(255, 193, 7) !important;
 }
 
 .object-delete {
-    color: rgb(220, 53, 69) !important;
+  color: rgb(220, 53, 69) !important;
 }
 
 .object-duplicate {
-    color: blueviolet;
+  color: blueviolet;
 }
 
 .object-merge {
-    color: dodgerblue;
+  color: dodgerblue;
 }
 
 .object-history {
-    color: #007bff;
+  color: #007bff;
 }

--- a/apis_core/generic/static/css/more-less-column.css
+++ b/apis_core/generic/static/css/more-less-column.css
@@ -1,43 +1,43 @@
 summary.more-less-column {
-    list-style: none;
-    appearance: none;
-    /* for WebKit browsers */
-    -webkit-appearance: none;
+  list-style: none;
+  appearance: none;
+  /* for WebKit browsers */
+  -webkit-appearance: none;
 }
 
 /* optional: remove ::marker for older browsers */
 summary.more-less-column ::marker {
-    content: none;
+  content: none;
 }
 
 summary.more-less-column {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 /* add "Show more" text when collapsed */
 summary.more-less-column::after {
-    content: " Show more";
-    font-weight: normal;
-    font-size: smaller;
-    color: grey;
+  content: " Show more";
+  font-weight: normal;
+  font-size: smaller;
+  color: grey;
 }
 
 /* hide the summary text when expanded, show only "Show less" */
 details[open] summary.more-less-column::before {
-    content: "Show less";
-    color: grey;
+  content: "Show less";
+  color: grey;
 }
 
 /* hide the original summary text when expanded */
 details[open] summary.more-less-column::after {
-    content: "";
+  content: "";
 }
 
 details[open] summary.more-less-column {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 /* make sure the generated "Show less" text is visible */
 details[open] summary.more-less-column::before {
-    visibility: visible;
+  visibility: visible;
 }

--- a/apis_core/generic/static/js/multiline.js
+++ b/apis_core/generic/static/js/multiline.js
@@ -1,5 +1,5 @@
 function more(element) {
-    input = element.previousElementSibling.cloneNode(true);
-    input.value = "";
-    element.before(input);
+  input = element.previousElementSibling.cloneNode(true);
+  input.value = "";
+  element.before(input);
 }

--- a/apis_core/history/static/css/history.css
+++ b/apis_core/history/static/css/history.css
@@ -1,11 +1,11 @@
 .diff-remove {
-    background: #ffebe9;
+  background: #ffebe9;
 }
 
 .diff-insert {
-    background: #dafbe1;
+  background: #dafbe1;
 }
 
 .difftable td {
-    width: 40%;
+  width: 40%;
 }

--- a/apis_core/relations/static/css/relations.css
+++ b/apis_core/relations/static/css/relations.css
@@ -1,25 +1,25 @@
 #relationList {
-    overflow-y: auto;
-    max-height: 40vh;
+  overflow-y: auto;
+  max-height: 40vh;
 }
 
 #relationdialog {
-    border: 1px solid black;
-    border-radius: .3rem;
-    overflow: visible;
-    padding: 0;
-    opacity: 1;
-    transform: scale(1);
-    transition: all 0.5s ease-in-out;
+  border: 1px solid black;
+  border-radius: .3rem;
+  overflow: visible;
+  padding: 0;
+  opacity: 1;
+  transform: scale(1);
+  transition: all 0.5s ease-in-out;
 
-    @starting-style {
-        opacity: 0;
-        transform: scale(0.8);
-    }
+  @starting-style {
+    opacity: 0;
+    transform: scale(0.8);
+  }
 }
 
 #relation-dialog-content {
-    padding: 1rem;
-    overflow-y: auto;
-    max-height: 80vh;
+  padding: 1rem;
+  overflow-y: auto;
+  max-height: 80vh;
 }

--- a/apis_core/relations/static/js/filter_relations_menu.js
+++ b/apis_core/relations/static/js/filter_relations_menu.js
@@ -1,21 +1,21 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const relationList = document.getElementById('relationList');
-    const filterInput = document.getElementById('relationFilter');
-    const items = relationList.getElementsByClassName('relation-item');
+  const relationList = document.getElementById('relationList');
+  const filterInput = document.getElementById('relationFilter');
+  const items = relationList.getElementsByClassName('relation-item');
 
-    filterInput.style.display = items.length > 10 ? 'block' : 'none';
+  filterInput.style.display = items.length > 10 ? 'block' : 'none';
 
-    function filterItems() {
-        const filter = filterInput.value.toLowerCase();
-        for (let item of items) {
-            const text = item.textContent.toLowerCase();
-            if (text.includes(filter)) {
-                item.style.display = 'block';
-            } else {
-                item.style.display = 'none';
-            }
-        }
+  function filterItems() {
+    const filter = filterInput.value.toLowerCase();
+    for (let item of items) {
+      const text = item.textContent.toLowerCase();
+      if (text.includes(filter)) {
+        item.style.display = 'block';
+      } else {
+        item.style.display = 'none';
+      }
     }
+  }
 
-    filterInput.addEventListener('input', filterItems);
+  filterInput.addEventListener('input', filterItems);
 });

--- a/apis_core/relations/static/js/relation_dialog.js
+++ b/apis_core/relations/static/js/relation_dialog.js
@@ -1,20 +1,20 @@
 function rel_reinit_select2() {
-    document.querySelectorAll("[data-autocomplete-light-function]").forEach(element => {
-        var dalFunction = $(element).attr('data-autocomplete-light-function');
-        if (yl.functions.hasOwnProperty(dalFunction) && typeof yl.functions[dalFunction] == 'function') {
-            yl.functions[dalFunction]($, element);
-        }
-    });
-    $('.select2-selection').addClass("form-control");
+  document.querySelectorAll("[data-autocomplete-light-function]").forEach(element => {
+    var dalFunction = $(element).attr('data-autocomplete-light-function');
+    if (yl.functions.hasOwnProperty(dalFunction) && typeof yl.functions[dalFunction] == 'function') {
+      yl.functions[dalFunction]($, element);
+    }
+  });
+  $('.select2-selection').addClass("form-control");
 }
 
 rel_reinit_select2();
 
 document.body.addEventListener("dismissModal", function(evt) {
-    document.getElementById("relationdialog").close();
+  document.getElementById("relationdialog").close();
 });
 document.addEventListener('DOMContentLoaded', function() {
-    document.getElementById("relationdialog").addEventListener("mousedown", function(evt) {
-        evt.target == this && this.close();
-    });
+  document.getElementById("relationdialog").addEventListener("mousedown", function(evt) {
+    evt.target == this && this.close();
+  });
 });


### PR DESCRIPTION
This PR updates:

1) the indentation applied to CSS and JS files by our `css-beautify` and `js-beautify` workflows, respectively, from the built-in default of 4 spaces to 2 spaces by setting `indent_size=2` in `.editorconfig` and making the workflows pick up the formatting rules from there and
2) the indent of existing .css and .js file from 4 to 2 spaces to conform to the updated config.

Resolves: #1326

Note: `.editorconfig` is added as replacement for setting rules individually via command line arguments in workflows because it makes the rules applied/the formatting required more transparent, centralises the management of these rules and should make it easy to integrate them into local development workflows since it's [supported by many popular IDEs](https://editorconfig.org/#pre-installed).

Unlike djLint, which we use on Django templates, [js-beautify](https://github.com/beautifier/js-beautify) does not support configuration via `pyproject.toml`, otherwise it would obviously have made sense to put the rules there.