### PR TITLE
docs(apis_core): add basic docstring to urls module

### DIFF
--- a/apis_core/urls.py
+++ b/apis_core/urls.py
@@ -1,3 +1,7 @@
+"""
+Main entry point for APIS routes
+"""
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path


### PR DESCRIPTION
This is mostly so that mkdocs finds the module
