### PR TITLE
fix(generic): use `.model` instead of `.name.lower()`

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -51,7 +51,7 @@ class GenericModel:
     @classmethod
     def get_namespace_prefix(cls):
         ct = ContentType.objects.get_for_model(cls)
-        return f"{rdf_namespace_prefix()}-{ct.name.lower()}"
+        return f"{rdf_namespace_prefix()}-{ct.model}"
 
     def get_edit_url(self):
         ct = ContentType.objects.get_for_model(self)

--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -14,7 +14,7 @@ from apis_core.generic.signals import (
     pre_duplicate,
     pre_merge_with,
 )
-from apis_core.utils.settings import rdf_namespace_prefix
+from apis_core.utils.settings import apis_base_uri, rdf_namespace_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,10 @@ class GenericModel:
     def get_namespace_prefix(cls):
         ct = ContentType.objects.get_for_model(cls)
         return f"{rdf_namespace_prefix()}-{ct.model}"
+
+    @classmethod
+    def get_namespace_uri(cls):
+        return apis_base_uri() + cls.get_listview_url()
 
     def get_edit_url(self):
         ct = ContentType.objects.get_for_model(self)

--- a/apis_core/generic/serializers.py
+++ b/apis_core/generic/serializers.py
@@ -145,7 +145,6 @@ class GenericModelCidocSerializer(BaseSerializer):
 
     def to_representation(self, instance):
         g = Graph()
-        content_type = ContentType.objects.get_for_model(instance)
 
         g.namespace_manager.bind("crm", CRM, replace=True)
         g.namespace_manager.bind("owl", OWL, replace=True)
@@ -153,9 +152,10 @@ class GenericModelCidocSerializer(BaseSerializer):
         g.namespace_manager.bind(self.appellation_nsp_prefix, APPELLATION, replace=True)
         g.namespace_manager.bind(self.attr_nsp_prefix, ATTRIBUTES, replace=True)
 
-        self.instance_nsp_prefix = f"{self.rdf_nsp_base}-{content_type.name.lower()}"
         self.instance_namespace = Namespace(self.base_uri + instance.get_listview_url())
-        g.namespace_manager.bind(self.instance_nsp_prefix, self.instance_namespace)
+        g.namespace_manager.bind(
+            instance.get_namespace_prefix(), self.instance_namespace
+        )
 
         self.instance_uri = URIRef(self.instance_namespace[str(instance.id)])
 

--- a/apis_core/generic/serializers.py
+++ b/apis_core/generic/serializers.py
@@ -17,7 +17,7 @@ from rest_framework.serializers import (
 )
 
 from apis_core.generic.utils.rdf_namespace import APPELLATION, ATTRIBUTES, CRM
-from apis_core.utils.settings import apis_base_uri, rdf_namespace_prefix
+from apis_core.utils.settings import rdf_namespace_prefix
 
 
 class GenericHyperlinkedRelatedField(HyperlinkedRelatedField):
@@ -100,7 +100,6 @@ class SimpleObjectSerializer(Serializer):
 
 class GenericModelCidocSerializer(BaseSerializer):
     def __init__(self, *args, **kwargs):
-        self.base_uri = f"{apis_base_uri()}"
         self.rdf_nsp_base = rdf_namespace_prefix()
         self.appellation_nsp_prefix = f"{self.rdf_nsp_base}-appellation"
         self.attr_nsp_prefix = f"{self.rdf_nsp_base}-attr"
@@ -152,7 +151,7 @@ class GenericModelCidocSerializer(BaseSerializer):
         g.namespace_manager.bind(self.appellation_nsp_prefix, APPELLATION, replace=True)
         g.namespace_manager.bind(self.attr_nsp_prefix, ATTRIBUTES, replace=True)
 
-        self.instance_namespace = Namespace(self.base_uri + instance.get_listview_url())
+        self.instance_namespace = Namespace(instance.get_namespace_uri())
         g.namespace_manager.bind(
             instance.get_namespace_prefix(), self.instance_namespace
         )


### PR DESCRIPTION
The name is the human readable representation of the model and this can
contain spaces, which is not allowed as part of a rdf namespace.
