### PR TITLE
fix(apis_metainfo): move method from utils to apis_metainfo.utils

### DIFF
--- a/apis_core/apis_metainfo/utils.py
+++ b/apis_core/apis_metainfo/utils.py
@@ -1,0 +1,29 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured
+
+from apis_core.apis_metainfo.models import Uri
+from apis_core.utils.helpers import get_importer_for_model
+
+
+def create_object_from_uri(uri: str, model: object, raise_on_fail=False) -> object:
+    if uri.startswith("http"):
+        try:
+            uri = Uri.objects.get(uri=uri)
+            return uri.content_object
+        except Uri.DoesNotExist:
+            Importer = get_importer_for_model(model)
+            importer = Importer(uri, model)
+            instance = importer.create_instance()
+            content_type = ContentType.objects.get_for_model(instance)
+            uri = Uri.objects.create(
+                uri=importer.get_uri,
+                content_type=content_type,
+                object_id=instance.id,
+            )
+            return instance
+    if raise_on_fail:
+        content_type = ContentType.objects.get_for_model(model)
+        raise ImproperlyConfigured(
+            f'Could not create {content_type.name} from string "{uri}"'
+        )
+    return False

--- a/apis_core/generic/forms/fields.py
+++ b/apis_core/generic/forms/fields.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.forms import ModelChoiceField, MultiValueField, MultiWidget
 from django.utils.translation import gettext as _
 
-from apis_core.utils.helpers import create_object_from_uri
+from apis_core.apis_metainfo.utils import create_object_from_uri
 
 
 class ModelImportChoiceField(ModelChoiceField):

--- a/apis_core/generic/importers.py
+++ b/apis_core/generic/importers.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import IntegrityError
 
 from apis_core.apis_metainfo.models import Uri
-from apis_core.utils.helpers import create_object_from_uri
+from apis_core.apis_metainfo.utils import create_object_from_uri
 from apis_core.utils.rdf import get_something_from_uri
 
 logger = logging.getLogger(__name__)

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -29,7 +29,8 @@ from django_tables2.export.views import ExportMixin
 from django_tables2.tables import table_factory
 
 from apis_core.apis_metainfo.models import Uri
-from apis_core.utils.helpers import create_object_from_uri, get_importer_for_model
+from apis_core.apis_metainfo.utils import create_object_from_uri
+from apis_core.utils.helpers import get_importer_for_model
 
 from .filtersets import GenericFilterSet
 from .forms import (


### PR DESCRIPTION
The `create_object_from_uri` uses the Uri model, so it makes more sense
if it is located in the app that also contains this model. Besides,
having the method in the `utils.helpers` module led to circular import
errors.

Closes: #1816
