### PR TITLE
fix(generic): make endpoint enumeration exclude more generic

### DIFF
--- a/apis_core/generic/generators.py
+++ b/apis_core/generic/generators.py
@@ -59,7 +59,7 @@ class CustomEndpointEnumerator(EndpointEnumerator):
         api_endpoints = [
             endpoint
             for endpoint in api_endpoints
-            if not endpoint[0].startswith("/apis/api/{contenttype}/")
+            if "/api/{contenttype}/" not in endpoint[0]
         ]
         for content_type in ContentType.objects.all():
             if content_type.model_class() is not None and issubclass(


### PR DESCRIPTION
APIS does not have to run under `/apis`, so we exclude everything that
contains `/api/{contenttype}/` instead of everything that starts with
`/apis/api/{contenttype}`. Still a hack, but yeah...
