### PR TITLE
docs: fix grammar, spelling, punctuation

### DIFF
--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -4,7 +4,7 @@ title: Configuration
 
 # `APIS_BASE_URI`
 
-When you create an instance of an Entity a signal
+When you create an instance of an entity, a signal
 [apis_core.apis_entities.models.create_default_uri][] is triggered that tries to generate a canonical URI for
 the entity. The signal can be disabled by setting the
 `CREATE_DEFAULT_URI` setting to `False`. If the signal runs, it creates
@@ -13,13 +13,13 @@ the canonical URI from two parts. The first part comes from the
 `GetEntityGenericRoot` if that exists. If not, it uses the reverse
 route of `apis_core:GetEntityGeneric`, which is defined in
 [apis_core.urls][] and defaults to
-`/entity/{pk}`. If the value of `APIS_BASE_URI` changes and urls
+`/entity/{pk}`. If the value of `APIS_BASE_URI` changes and URLs
 containing the former `APIS_BASE_URI` remain in the database, then the
-old `APIS_BASE_URI` value must added to the setting
+old `APIS_BASE_URI` value must be added to the setting
 `APIS_FORMER_BASE_URIS`. `APIS_FORMER_BASE_URIS` is a list that contains
-base urls that were once used.
+base URLs that were once used.
 
-# Django Settings
+# Django settings
 
 This section deals with the internal configuration of APIS. For
 instructions on how to set it up please refer to
@@ -29,9 +29,9 @@ file of your Django project.
 
 ## REST_FRAMEWORK
 
-APIS uses the [Django
-Rest Framework](https://www.django-rest-framework.org/) for API
-provisioning. Rest Framework specific settings like the default page size
+APIS uses [Django
+REST framework](https://www.django-rest-framework.org/) for API
+provisioning. REST framework-specific settings like the default page size
 can be set here.
 
 ``` python
@@ -42,14 +42,14 @@ REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] = (
 
 Use the above default for allowing every user with permissions on a
 model to change all model instances. Set
-`"rest_framework.permissions.IsAuthenticated"` if every logged in user
+`"rest_framework.permissions.IsAuthenticated"` if every logged-in user
 should have all permissions.
 
 ``` python
 REST_FRAMEWORK["PAGE_SIZE"] = 50
 ```
 
-Sets the default page size the APIS RestAPI should deliver.
+Sets the default page size the APIS REST API should deliver.
 
 ## SPECTACULAR_SETTINGS
 
@@ -63,23 +63,23 @@ SPECTACULAR_SETTINGS["DEFAULT_GENERATOR_CLASS"] = 'apis_core.generic.generators.
 
 Background:
 
-The first reason is, that we are using a custom converter
+The first reason is that we are using a custom converter
 ([apis_core.generic.urls.ContenttypeConverter][]) to provide access to views and API views of different
-content types. The default endpoint generator of the drf-spectacular does
+content types. The default endpoint generator of drf-spectacular does
 not know about this converter and therefore sees the endpoints using
 this converter as *one* endpoint with one parameter called
 `contenttype`. That is not what we want, so we have to do our own
-enumeration -we iterate through all content types that inherit from
+enumeration: we iterate through all content types that inherit from
 `GenericModel` and create schema endpoints for those programmatically.
 
-The second reason is, that the `autoapi` schema generator of DRF
+The second reason is that the `autoapi` schema generator of DRF
 Spectacular and our
 [apis_core.generic.api_views.ModelViewSet][] don't work well together. Our ModelViewSet needs the
 dispatch method to set the model of the `ModelViewSet`, but this method
 is not being called by the generator while doing the inspection, which
 means the `ModelViewSet` does not know about the model it should work
 with and can not provide the correct serializer and filter classes.
-Therefore we create the callback for the endpoints by hand and set the
+Therefore, we create the callback for the endpoints by hand and set the
 model from there.
 
 ## APIS_BASE_URI
@@ -107,15 +107,15 @@ APIS_ANON_VIEWS_ALLOWED = False
 ```
 
 Sets whether list and detail views are accessible for anonymous (not
-logged in) users. If only a subset of the data should be exposed to the
+logged-in) users. If only a subset of the data should be exposed to the
 anonymous user, use [custom
 managers](https://docs.djangoproject.com/en/stable/topics/db/managers/#custom-managers).
 
-## Maintenance Middleware
+## Maintenance middleware
 
 APIS ships a maintenance middleware that you can use and activate to
 enable a maintenance mode in your project. Maintenance mode means that
-only superuser accounts can access the web interfaces, all other requests
+only superuser accounts can access the web interfaces; all other requests
 are being answered with a simple maintenance mode page (the
 `maintenance.html` template). To use the middleware, add
 
@@ -126,5 +126,5 @@ are being answered with a simple maintenance mode page (the
 to your `settings.MIDDLEWARE` list. To activate the maintenance mode
 once the middleware is enabled, simply create a file `apis_maintenance`
 in the directory the main Django process runs in. The path of the
-maintenance file can be changed in the settings:
+maintenance file can be changed in settings:
 `APIS_MAINTENANCE_FILE = "path of the file"`

--- a/docs/source/customization.md
+++ b/docs/source/customization.md
@@ -6,12 +6,12 @@ APIS is designed to be easily customizable. This section describes how
 you can customize the views and the templates of the views that are
 shipped with APIS by injecting classes and methods that are then
 automatically used by the generic views. The core of the logic described
-here is based on the [apis_core.generic][].
+here is based on [apis_core.generic][].
 It provides generic CRUD views and API views for all models that are
 configured to use it. To make a model use the generic functionality, it
 has to inherit from
 [apis_core.generic.abc.GenericModel][]. In
-standard APIS those models are
+standard APIS those models are:
 
 -   [apis_core.apis_metainfo.models.RootObject][]
 -   [apis_core.apis_metainfo.models.Uri][]
@@ -27,7 +27,7 @@ the generic views for it. `/apis/your_app.historicalperson/` will be the
 URL for the list view of the historical model.
 `/apis/api/your_app.historicalperson/` for the API view.
 
-If you want to use the generic app for your own model, simple make your
+If you want to use the generic app for your own model, simply make your
 model inherit from
 [apis_core.generic.abc.GenericModel][].
 
@@ -61,7 +61,7 @@ columns](https://django-tables2.readthedocs.io/en/latest/pages/api-reference.htm
 that you might want to use.
 
 Your table can also contain a `paginate_by` attribute, which is then
-used by the list view to determines the number of items per page. When
+used by the list view to determine the number of items per page. When
 this is not set, the page size defaults to `25`. To disable pagination
 altogether, use `table_pagination = False`.
 
@@ -81,10 +81,10 @@ custom template using your model name, so if your model is
 `myproject.Person` then you can use the `myproject/person_list.html`
 template to override the generic template.
 
-# Create and Update views
+# Create and update views
 
-The create and update view use the form
-[apis_core.generic.forms.GenericModelForm][] by default. You can override the form it uses by creating
+The create and update views use the form
+[apis_core.generic.forms.GenericModelForm][] by default. You can override the form they use by creating
 a custom form in `your_app.forms`. The form class has to be named
 `<Modelname>Form`, so if you have a model `Person` in your app
 `myproject`, the view looks for the form class
@@ -92,10 +92,10 @@ a custom form in `your_app.forms`. The form class has to be named
 
 ## Create and update view templates
 
-The create and update views looks for templates using the `_form.html`
-suffix. It uses the `generic/generic_form.html` template as fallback,
+The create and update views look for templates using the `_form.html`
+suffix. They use the `generic/generic_form.html` template as fallback,
 but you can use a custom template using your model name, so if your
-model is `myproject.Person` then you can use the
+model is `myproject.Person`, you can use the
 `myproject/person_form.html` template to override the generic template.
 
 # Autocomplete views
@@ -110,7 +110,7 @@ for the queryset `myproject.querysets.PersonAutocompleteQueryset`.
 
 The results of the autocomplete view can be themed using templates. The
 autocomplete view looks for templates using the
-`autocomplete_result.html` suffix, if no such template is found, the
+`autocomplete_result.html` suffix; if no such template is found, the
 string representation of the result is used. The autocomplete view uses
 the same template search function as for other templates, so if you have
 a model `myproject.Person` then you can use the
@@ -119,11 +119,11 @@ a model `myproject.Person` then you can use the
 The results of the autocomplete view can be extended with additional
 results coming from another source (an external API or another
 queryset). The view looks for this function in `your_app.querysets` and
-it has to be named `<Modelname>ExternalAutocomplete`, so if you have a
+has to be named `<Modelname>ExternalAutocomplete`, so if you have a
 model `Person` in your app `myproject`, the view looks for the function
 in `myproject.querysets.PersonExternalAutocomplete`.
 
-Lets say you have an app called `myapp` with a `models.py`
+Let's say you have an app called `myapp` with the following `models.py`:
 
 ``` python
 class Person(models.Model):
@@ -147,9 +147,9 @@ class PersonExternalAutocomplete:
 ```
 
 The class has to have a `get_results` method that receives a query as
-the first parameter and returns a result in the format, the
+the first parameter and returns a result in the format the
 [django-autocomplete-light](https://django-autocomplete-light.readthedocs.io/)
-module uses- this is a dict with the keys `id`, `text` and `selected_text`.
+module uses - a dict with the keys `id`, `text` and `selected_text`.
 
 # Import view
 
@@ -165,13 +165,13 @@ a custom form in `your_app.forms`. The form class has to be named
 The import view looks for templates using the `_import.html` suffix. It
 uses the `generic/generic_import.html` template as fallback, but you can
 use a custom template using your model name, so if your model is
-`myproject.Person` then you can use the `myproject/person_import.html`
+`myproject.Person`, you can use the `myproject/person_import.html`
 template to override the generic template.
 
 # Class, method and template lookup
 
 As mentioned above, APIS tries to find the correct class or method to
-override the ones the `generic` one ships. This is done using
+override the ones `generic` ships. This is done using
 [apis_core.generic.helpers.first_match_via_mro][]. The method does not only look for possible overrides using
 the name of the model itself, but also using all the parent models
 following the full inheritance chain. So if all your models inherit from
@@ -184,7 +184,7 @@ APIS provides the structure for easily importing data from external
 resources. One main component for this are `Importer` classes. They
 always belong to a Django model, reside in the same app as the Django
 model in the `importers` module and are named after the Django model. So
-if you have an app called `myapp` with a `models.py`
+if you have an app called `myapp` with the following `models.py`:
 
 ``` python
 class Person(models.Model):
@@ -199,8 +199,8 @@ The importers task is then to create a model instance from this URI,
 usually by fetching data from the URI, parsing it and extracting the
 needed fields. The instance should then be returned by the
 `create_instance` method of the importer. There is
-[apis_core.generic.importers.GenericModelImporter][] which you can inherit from. It is used by default of no
-other importer is defined for the model and it tries to do the right
+[apis_core.generic.importers.GenericModelImporter][] which you can inherit from. It is used by default if no
+other importer is defined for the model and tries to do the right
 thing out of the box: it first looks if there is an RDF configuration
 for the URI and if that fails tries to parse the URI response as JSON.
 
@@ -221,17 +221,17 @@ RDF-Import config files. Those RDF-Import config files are
 [TOML](https://toml.io/) configuration files. They have three main
 attributes, which are `filters`, `attributes` and `relations`.
 
-The `filters` attributes are key, value pairs that define filters that
+The `filters` attributes are key-value pairs that define filters that
 have to match on the input data. Multiple `filters` entries can be
-defined, only one of them has to match. Every `filters` entry can
-contain multiple key, value pairs, which ALL have to match:
+defined; only one of them has to match. Every `filters` entry can
+contain multiple key-value pairs, which ALL have to match:
 
 ``` toml
 [[filters]]
 "rdf:type" = "gndo:DifferentiatedPerson"
 ```
 
-The `attributes` config option lists key value pairs, which map keys
+The `attributes` config option lists key-value pairs which map keys
 (usually model attributes) to a single SPARQL query or a list of SPARQL
 queries. Instead of SPARQL it is also possible to simply write a compact
 URI which is then looked up in the graph that results from the data

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -28,7 +28,7 @@ title: Development
 
 -   `crispy-bootstrap5`
 
-    The default theme used for the crispy forms
+    The default theme used for crispy forms.
 
 -   `django-simple-history`
 
@@ -37,4 +37,4 @@ title: Development
 -   `pydot`
 
     Used in `apis_core.documentation` to create a dot representation of
-    the datamodel.
+    the data model.

--- a/docs/source/features.md
+++ b/docs/source/features.md
@@ -36,7 +36,7 @@ MIDDLEWARE = [
 
 The [apis_core.history.models.VersionMixin][] class is a mixin that can be added to any model to enable
 versioning. It adds a `history` property to the model that
-returns a `HistoricalRecords` instance. Additionally it
+returns a `HistoricalRecords` instance. Additionally, it
 allows to override the date of the revision by setting the
 `_history_date` property of the model instance. To activate
 versioning for a model, simply inherit from `VersionMixin`:
@@ -64,13 +64,13 @@ revisions of the model instance. It is also included in the
 accessed under
 `/apis/swagger/schema/swagger-ui/#/apis/apis_api_history_entity_edit_log_list`.
 
-## Management Commands
+## Management commands
 
 The APIS history plugin, based on `django-simple-history`,
 provides several management commands to help curate history objects.
 Here are some of the most useful commands:
 
-# 1. Populate History Tables
+# 1. Populate history tables
 
 ``` bash
 python manage.py populate_history --auto
@@ -82,7 +82,7 @@ models. It's particularly useful when you've added
 `--auto` flag applies the command to all tracked models, or
 you can specify a list of models instead.
 
-# 2. Clean Duplicate History Entries
+# 2. Clean duplicate history entries
 
 ``` bash
 python manage.py clean_duplicate_history --auto
@@ -94,7 +94,7 @@ This command removes duplicate history entries.
 changes were made. This command deletes history objects that are
 identical to the previous entry.
 
-# 3. Remove Old History Entries
+# 3. Remove old history entries
 
 ``` bash
 python manage.py clean_old_history --days 60 --auto
@@ -132,7 +132,7 @@ customize the model form to use the collection as choices for this
 field. Both approaches have pros and cons.
 
 There are a couple of templatetags that make working with collection
-easier, they all reside in the
+easier. They all reside in the
 [apis_core.collections.templatetags.apis_collections][] templatetag library. If you use them, you have to include
 [apis_core.collections.urls][] into your
 urls.py, for example like this:
@@ -151,7 +151,7 @@ The templatetags are:
 -   [apis_core.collections.templatetags.apis_collections.collection_toggle_by_id][]
 
 This templatetag takes the instance of an object and a collection (or,
-in the case of `_by_id` the id of a collection) and lets
+in the case of `_by_id`, the id of a collection) and lets
 the user create and remove the connection between this instance and the
 collection.
 
@@ -162,4 +162,4 @@ This templatetag provides a checkbox that enables a collection as
 instances will be added to this collection. This is implemented in
 [apis_core.collections.signals.add_to_session_collection][].
 To use this feature, [apis_core.history][] has to be enabled
-and the [crum.CurrentRequestUserMiddleware][] has to be added to the `MIDDLEWARE`
+and [crum.CurrentRequestUserMiddleware][] has to be added to `MIDDLEWARE`

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -23,7 +23,7 @@ TEI
 RDF
 
 :   [Resource Description Framework](https://www.w3.org/RDF/) is a
-    standard model for data interchange on the Web. In the context of
+    standard model for data interchange on the web. In the context of
     APIS, RDF is used to provide data in a machine-readable format via
     the API.
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -2,11 +2,11 @@
 title: Installation
 ---
 
-APIS-core is a library that allows you to easily build tools to manage
-prosopographical data. It is not a ready-made software solution that you
+APIS Core is a library that allows you to easily build tools to manage
+prosopographical data. It is not a ready-made software solution that you can
 just deploy and start working. The typical workflow for starting an APIS
 project is as follows: set up the project, create an
-`ontology` customize the functionalities
+`ontology`, customize functionalities
 and views, and finally add your data. This section will guide you
 through the first step.
 
@@ -24,31 +24,30 @@ This is the recommended way to install APIS on local machines as well as
 on server infrastructure. For experimenting with APIS you can use the
 [Docker file](https://github.com/acdh-oeaw/apis-core-rdf/blob/main/Dockerfile)
 provided in the APIS core library. It allows you to spin up an APIS
-instance using the sample-project shipped with the APIS core library. To
-start it start a terminal and run
+instance using the sample project shipped with the APIS core library. To
+start it, start a terminal and run:
 
 -   `cd path/to/apis-core-rdf` to change to the directory where the
-    Docker file is located.
--   `docker build -t apis .` to build the APIS image.
+    Docker file is located,
+-   `docker build -t apis .` to build the APIS image,
 -   `docker run -p 5000:5000 apis` to start the container.
 
 The APIS instance should now be accessible under
 <http://localhost:5000>.
 
-Alternatively you can also use the docker image built for our
-demo-project. To do so run:
+Alternatively you can also use the Docker image built for our
+demo project. To do so run:
 
 -   `docker run -p 5000:5000 ghcr.io/acdh-oeaw/apis-core-rdf/discworld/main:latest`
     to start the container.
 
 To use the image for local development you can mount your local APIS
-instance directory into the container, using the following command: To
-do so you can use the following command:
+instance directory into the container using the following command:
 
 `docker run -p 5000:5000 -v /path/to/your/apis_instance:/app apis`
 
 Please note that you might need to install custom dependencies for the
-APIS instance in your local docker container.
+APIS instance in your local Docker container.
 
 This container uses the Django development server and is not suitable
 for production use. Please see the next section for deploying APIS in
@@ -56,7 +55,7 @@ production.
 
 ## Docker Compose
 
-In production APIS should be used together with an SQL database. The
+In production, APIS should be used together with an SQL database. The
 simplest way to set that up is by using [Docker
 Compose](https://docs.docker.com/compose/). Below is an example of a
 `docker-compose.yml` file that sets up an APIS instance with a

--- a/docs/source/ontology.md
+++ b/docs/source/ontology.md
@@ -2,7 +2,7 @@
 title: Create your ontology
 ---
 
-The heart and soul of your APIS application is the
+The heart and soul of your APIS application is its
 `ontology`. It describes `entities` and `relations`.
 
 Given that APIS is based on [Django](https://www.djangoproject.com/),
@@ -32,14 +32,14 @@ class Person(AbstractEntity):
 ```
 
 [apis_core.apis_entities.models.AbstractEntity][]
-brings some useful functionality for Entities, but it also
-itself inherits from
+brings some useful functionality to entities but also
+inherits from
 [apis_core.generic.abc.GenericModel][],
 which means that as soon as you define your models and [run
-migrations](https://docs.djangoproject.com/en/stable/topics/migrations/)
-your models will show up in the APIS Web interface in `Entities` menu in
-the top left corner. For every `entity` you defined there will be an overview
-page that lists all instances for that `entity`, as well as a form for
+migrations](https://docs.djangoproject.com/en/stable/topics/migrations/),
+your models will show up in the APIS web interface in the `Entities` menu in
+the top left corner. For every `entity` you define, there will be an overview
+page that lists all instances for that `entity` as well as a form for
 creating, updating, merging and deleting entities.
 
 ![Image showing the APIS Entity menu with one item labeled Persons](img/ontology_entity_menu.png)
@@ -49,7 +49,7 @@ creating, updating, merging and deleting entities.
 To use the relations module, you have to add it to your
 `INSTALLED_APPS`. The module includes templates that add the relation
 listing to templates from other `apis_core` modules, so we recommend to
-put the Relations module at the top of the apps list:
+put the relations module at the top of the apps list:
 
 ``` python
 INSTALLED_APPS = ["apis_core.relations"] + INSTALLED_APPS
@@ -57,13 +57,13 @@ INSTALLED_APPS = ["apis_core.relations"] + INSTALLED_APPS
 
 Relations have to inherit from
 [apis_core.relations.models.Relation][].
-You will have to set the attribute `subj_model` and
-`obj_model` which point to some Django model (can also be a
+You will have to set the attributes `subj_model` and
+`obj_model`, which each point to some Django model (can also be a
 list of Django models). The Django models can be specified by their
 class name or using the natural key of the model
 (`APP_NAME.MODEL_CLASS`).
 
-A simple Relation between a person and a place could look like this:
+A simple relation between a person and a place could look like this:
 
 ``` python
 from apis_core.relations.models import Relation
@@ -74,7 +74,7 @@ class PersonLivedInPlace(Relation):
 ```
 
 You can define the class methods `name` and
-`reverse_name` to provide human readable strings for your
+`reverse_name` to provide human-readable strings for your
 relation model. They default to the `verbose_name`
 (`name`) and the `verbose_name` with the string
 ` reverse` appended (`reverse_name`).


### PR DESCRIPTION
Correct grammar, spelling errors (including
proper names, acronyms, inconsistent spellings
of headlines and regular words), missing
or misleading punctuation.

Closes: #1752