### PR TITLE
fix(core): fix text alignment in site footer

### DIFF
--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -190,7 +190,7 @@
     {% block footer %}
       <footer class="border-top p-2 bg-light">
         <div class="row m-0">
-          <div class="col text-left">
+          <div class="col text-start">
 
             {% block footer-left %}
               {% include "partials/footer-left.html" %}
@@ -210,7 +210,7 @@
             {% endblock footer-center %}
 
           </div>
-          <div class="col text-right">
+          <div class="col text-end">
 
             {% block footer-right %}
               {% block imprint %}


### PR DESCRIPTION
Use Bootstrap 5 CSS classes for text alignment
in site footer in base template.
This fixes the alignment of the "Imprint" link
(where available) on the right-hand side of the
site footer to mirror the icons on the left.
The alignment of the icons does not noticeably
change, presumably because left-(i.e. start-)
aligned text is the default. (The CSS classes
used until now had no effect on alignment
anymore; they are leftovers from Bootstrap 4.)

Closes: #1856