### PR TITLE
feat(core): replace hardcoded bootstrap class with custom values

### DIFF
--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -24,6 +24,8 @@ footer a:has(> span[class*="material-symbols"]):hover {
     right: 20px;
     display: none;
     opacity: 0.5;
+    background-color: var(--btn-back-to-top-bg-color, #dc3545);
+    color: var(--btn-back-to-top-color, #ffffff);
 }
 
 footer .icon {

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -242,9 +242,7 @@
       </div>
     {% endblock modal %}
 
-    <button type="button"
-            class="btn btn-danger btn-floating btn-lg"
-            id="btn-back-to-top">
+    <button type="button" class="btn btn-floating btn-lg" id="btn-back-to-top">
       <span>↑</span>
     </button>
   </body>


### PR DESCRIPTION
We drop the bootstrap `btn-danger` class from the back to top button
element and instead set the values manually.

Closes: #1855
