### PR TITLE
fix(apis_entities): reorder label & select place label using languages

### DIFF
--- a/apis_core/apis_entities/triple_configs/E53_PlaceFromWikidata.toml
+++ b/apis_core/apis_entities/triple_configs/E53_PlaceFromWikidata.toml
@@ -4,7 +4,7 @@
 
 
 [attributes]
-label = ["rdfs:label", "wdt:P1448/rdfs:label"]
+label = ["rdfs:label,de", "rdfs:label,en", "wdt:P1448/rdfs:label", "rdfs:label", ]
 longitude = '''
 SELECT ?longitude
 WHERE {


### PR DESCRIPTION
For the place labels we want first and foremost the german label, then
fall back to the english label, then the official one and only as last
fallback use the default label.

Closes: #1863
