### PR TITLE
ci(release-please): add `extra-files` to config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,7 +5,8 @@
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "package-name": "apis-core-rdf"
+      "package-name": "apis-core-rdf",
+      "extra-files": ["apis_core/__init__.py"]
     }
   }
 }


### PR DESCRIPTION
release please looks for the __init__ in the folder `apis_core_rdf`, but
we ship our modules still in `apis_core`.
