### PR TITLE
Allow to revert objects to a earlier state

### DIFF
--- a/apis_core/history/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/history/locale/de/LC_MESSAGES/django.po
@@ -3,12 +3,11 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-14 03:47-0500\n"
+"POT-Creation-Date: 2025-05-20 05:23-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +16,21 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 #: apis_core/history/templates/apis_entities/partials/entity_base_nav.html
 msgid "History"
 msgstr "Historie"
+
+#: apis_core/history/templates/history/reset.html
+#, python-format
+msgid "Confirm reset of %(object)s"
+msgstr "Zurücksetzen von %(object)s bestätigen"
+
+#: apis_core/history/templates/history/reset.html
+#, python-format
+msgid "Confirm reset of %(object)s to the version from %(date)s"
+msgstr "Bestätige sie das Zurücksetzen von %(object)s auf die Version von %(date)s"
+
+#: apis_core/history/templates/history/reset.html
+msgid "Yes, reset"
+msgstr "Ja, zurücksetzen"

--- a/apis_core/history/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/history/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-20 05:23-0500\n"
+"POT-Creation-Date: 2025-05-20 05:26-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,6 +21,10 @@ msgstr ""
 msgid "History"
 msgstr "Historie"
 
+#: apis_core/history/templates/history/columns/reset.html
+msgid "reset"
+msgstr "zurücksetzen"
+
 #: apis_core/history/templates/history/reset.html
 #, python-format
 msgid "Confirm reset of %(object)s"
@@ -29,7 +33,8 @@ msgstr "Zurücksetzen von %(object)s bestätigen"
 #: apis_core/history/templates/history/reset.html
 #, python-format
 msgid "Confirm reset of %(object)s to the version from %(date)s"
-msgstr "Bestätige sie das Zurücksetzen von %(object)s auf die Version von %(date)s"
+msgstr ""
+"Bestätige sie das Zurücksetzen von %(object)s auf die Version von %(date)s"
 
 #: apis_core/history/templates/history/reset.html
 msgid "Yes, reset"

--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -50,6 +50,10 @@ class APISHistoryTableBase(models.Model, GenericModel):
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:generic:detail", args=[ct, self.history_id])
 
+    def get_reset_url(self):
+        ct = ContentType.objects.get_for_model(self)
+        return reverse("apis_core:history:reset", args=[ct, self.history_id])
+
     def get_diff(self, other_version=None):
         if self.history_type == "-":
             return None

--- a/apis_core/history/tables.py
+++ b/apis_core/history/tables.py
@@ -1,6 +1,6 @@
 import django_tables2 as tables
 
-from apis_core.generic.tables import CustomTemplateColumn, ViewColumn
+from apis_core.generic.tables import ActionColumn, CustomTemplateColumn, ViewColumn
 
 
 class DescriptionColumnHistory(CustomTemplateColumn):
@@ -22,6 +22,15 @@ class OriginalIDColumn(CustomTemplateColumn):
     verbose_name = "Original ID"
 
 
+class ResetColumn(ActionColumn):
+    """
+    A column showing a reset button
+    """
+
+    template_name = "history/columns/reset.html"
+    permission = "change"
+
+
 class APISHistoryTableBaseTable(tables.Table):
     history_id = tables.Column(verbose_name="ID")
     original_id = OriginalIDColumn()
@@ -39,6 +48,7 @@ class HistoryGenericTable(tables.Table):
     fields_changed = tables.TemplateColumn(
         template_name="history/columns/fields_changed.html"
     )
+    reset = ResetColumn()
 
     class Meta:
         fields = [

--- a/apis_core/history/templates/history/columns/reset.html
+++ b/apis_core/history/templates/history/columns/reset.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% if record.instance.history.first != record %}
+  <a title="{% translate "reset" %}"
+     href="{{ record.get_reset_url }}"
+     class="object-delete"><span class="material-symbols-outlined">undo</span></a>
+{% endif %}

--- a/apis_core/history/templates/history/reset.html
+++ b/apis_core/history/templates/history/reset.html
@@ -1,0 +1,22 @@
+{% extends basetemplate|default:"base.html" %}
+{% load i18n %}
+
+{% block title %}
+  {% blocktranslate with object=object.instance.history.most_recent %}Confirm reset of {{ object }}{% endblocktranslate %}
+{% endblock title %}
+
+{% block content %}
+  <div class="container">
+    <div class="text-center mt-4">
+      <form action="" method="post">
+        {% csrf_token %}
+        <h4>
+          {% blocktranslate with object=object.instance.history.most_recent date=object.history_date %}Confirm reset of {{ object }} to the version from {{ date }}{% endblocktranslate %}:
+        </h4>
+        <input class="btn btn-danger"
+               type="submit"
+               value="{% translate "Yes, reset" %}" />
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/apis_core/history/urls.py
+++ b/apis_core/history/urls.py
@@ -25,4 +25,9 @@ urlpatterns = [
         GenericHistoryLog.as_view(),
         name="generichistorylog",
     ),
+    path(
+        "<contenttype:contenttype>/<int:pk>/reset",
+        views.HistoryReset.as_view(),
+        name="reset",
+    ),
 ]

--- a/apis_core/history/views.py
+++ b/apis_core/history/views.py
@@ -1,9 +1,12 @@
-from django.views.generic.detail import DetailView
+from django.forms import Form
+from django.views.generic.detail import BaseDetailView, DetailView
+from django.views.generic.edit import FormView
 from django_tables2 import SingleTableMixin
 from django_tables2.tables import table_factory
 from simple_history.utils import get_history_model_for_model
 
 from apis_core.generic.helpers import first_member_match, module_paths
+from apis_core.generic.views import GenericModelMixin
 
 from .tables import HistoryGenericTable
 
@@ -21,3 +24,15 @@ class HistoryView(SingleTableMixin, DetailView):
         table_modules = module_paths(self.model, path="tables", suffix="HistoryTable")
         table_class = first_member_match(table_modules, HistoryGenericTable)
         return table_factory(self.model, table_class)
+
+
+class HistoryReset(GenericModelMixin, BaseDetailView, FormView):
+    form_class = Form
+    template_name = "history/reset.html"
+
+    def form_valid(self, form):
+        self.get_object().instance.save()
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return self.get_object().instance.get_history_url()


### PR DESCRIPTION
Allow to revert objects to a earlier state using the history view

- feat(history): introduce view to reset object to a history version
- feat(history): add `get_reset_url` helper method to history models
- feat(history): add a link to the reset view to the history table

Closes: #283 