### PR TITLE
fix(utils): when resolving, also handle boolean `True` value

### DIFF
--- a/apis_core/utils/rdf.py
+++ b/apis_core/utils/rdf.py
@@ -26,6 +26,8 @@ def resolve(obj, graph):
         if obj.startswith("<") and obj.endswith(">"):
             return URIRef(obj[1:-1])
         return graph.namespace_manager.expand_curie(obj)
+    if isinstance(obj, bool) and obj is True:
+        return None
     return obj
 
 


### PR DESCRIPTION
When we receive a boolean `True` value as part of a triple, we actually
want to know if the triple exists in the graph. We therefore have to
replace the `True` with `None` (otherwise we would check if there is a
triple containing `True`, but `None` is a catchall value).

Closes: #1905
