### PR TITLE
fix(core): drop `modal` block

### DIFF
--- a/apis_core/core/static/css/core.css
+++ b/apis_core/core/static/css/core.css
@@ -12,11 +12,6 @@ footer a:has(> span[class*="material-symbols"]):hover {
     text-decoration: none;
 }
 
-/* main modal in modal block */
-#modal .modal-dialog {
-    max-width: 800px;
-}
-
 /* scroll-to-top button */
 #btn-back-to-top {
     position: fixed;

--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -224,19 +224,6 @@
       <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     {% endblock scripts %}
 
-    {% block modal %}
-      <!-- Modal -->
-      <div class="modal fade"
-           id="modal"
-           tabindex="-1"
-           aria-labelledby="modalLabel"
-           aria-hidden="true">
-        <div class="modal-dialog">
-          <div id="modal-here" class="modal-content"></div>
-        </div>
-      </div>
-    {% endblock modal %}
-
     <button type="button" class="btn btn-floating btn-lg" id="btn-back-to-top">
       <span>↑</span>
     </button>


### PR DESCRIPTION
Its not used anymore anywhere, we now use standard html dialog
everywhere

Closes: #1917
