### PR TITLE
Revert "feat(history): use history queryset for views"

### DIFF
--- a/apis_core/history/views.py
+++ b/apis_core/history/views.py
@@ -3,7 +3,6 @@ from django.views.generic.detail import BaseDetailView, DetailView
 from django.views.generic.edit import FormView
 from django_tables2 import SingleTableMixin
 from django_tables2.tables import table_factory
-from simple_history.utils import get_history_model_for_model
 
 from apis_core.generic.helpers import first_member_match, module_paths
 from apis_core.generic.views import GenericModelMixin
@@ -11,19 +10,16 @@ from apis_core.generic.views import GenericModelMixin
 from .tables import HistoryGenericTable
 
 
-class HistoryView(SingleTableMixin, DetailView):
+class HistoryView(GenericModelMixin, SingleTableMixin, DetailView):
     template_name = "history/history.html"
-
-    def setup(self, *args, **kwargs):
-        super().setup(*args, **kwargs)
-        if contenttype := kwargs.get("contenttype"):
-            self.model = get_history_model_for_model(contenttype.model_class())
-            self.queryset = self.model.objects.filter(id=kwargs.get("pk"))
 
     def get_table_class(self):
         table_modules = module_paths(self.model, path="tables", suffix="HistoryTable")
         table_class = first_member_match(table_modules, HistoryGenericTable)
         return table_factory(self.model, table_class)
+
+    def get_table_data(self):
+        return self.get_object().get_history_data()
 
 
 class HistoryReset(GenericModelMixin, BaseDetailView, FormView):


### PR DESCRIPTION
This reverts commit ae5fecd44b71d1971e62ce31ee46ea46ae6fa31f.

Using `GenericModelMixin` as a base for the HistoryView was actually the
correct approach, because we *are* primarily looking at *one* object and
we use the SingleTableMixin to list the related history data.

Closes: #1919
