### PR TITLE
fix(documentation): revert inadvertently translated material symbol

### DIFF
--- a/apis_core/documentation/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/documentation/locale/de/LC_MESSAGES/django.po
@@ -67,10 +67,6 @@ msgid "Relations"
 msgstr "Relationen"
 
 #: apis_core/documentation/templates/documentation.html
-msgid "with"
-msgstr "mit"
-
-#: apis_core/documentation/templates/documentation.html
 msgid "Subjects"
 msgstr "Subjecs"
 

--- a/apis_core/documentation/templates/documentation.html
+++ b/apis_core/documentation/templates/documentation.html
@@ -77,7 +77,7 @@
     {% for relation in datamodel.relations %}
       <a id="relation-{{ relation.model }}">
         <h2>
-          {{ relation.model_class.name }} <span class="material-symbols-outlined">{% translate "with" %}</span> {{ relation.model_class.reverse_name }}
+          {{ relation.model_class.name }} <span class="material-symbols-outlined">width</span> {{ relation.model_class.reverse_name }}
         </h2>
         <table class="table">
           <thead>


### PR DESCRIPTION
Closes: #1921
