### PR TITLE
fix(generic): use first element of list for enriching entities

### DIFF
--- a/apis_core/generic/importers.py
+++ b/apis_core/generic/importers.py
@@ -90,7 +90,7 @@ class GenericModelImporter:
             fields = data.keys()
         for field in fields:
             if hasattr(instance, field) and field in data.keys():
-                setattr(instance, field, data[field])
+                setattr(instance, field, data[field][0])
         instance.save()
 
     def create_instance(self):


### PR DESCRIPTION
The importer always provides a list of values that can be imported, but
usually the fields don't contain lists. So we default to the first
element in the list as the value to be imported.
