### PR TITLE
ci: use --frozen for uv in message check workflow

### DIFF
--- a/.github/workflows/django-messages.yml
+++ b/.github/workflows/django-messages.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install gettext
         run: sudo apt-get update && sudo apt-get -f install gettext
       - name: Make messages
-        run: uv run ./manage.py makemessages -l de --add-location file
+        run: uv run --frozen ./manage.py makemessages -l de --add-location file
       - name: Check changes using git-diff
         run: git diff --exit-code


### PR DESCRIPTION
the workflow checks changes using git diff. now that we have a `uv.lock`
file in the repository (57761c4523caca315c38cedb0462f01ff8f130b5) this
file gets updated if we run `uv` without the `--frozen` flag which would
then lead to a changed repository state
