### PR TITLE
docs(readme): correct link to creating your ontology

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ Now start using your Django project
 ./manage.py runserver
 ```
 
-Now you should be ready to roll. Start [creating your ontology](https://acdh-oeaw.github.io/apis-core-rdf/ontology.html).
+Now you should be ready to roll. Start [creating your ontology](https://acdh-oeaw.github.io/apis-core-rdf/ontology).


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change updates the link for creating an ontology by removing the `.html` extension.