### PR TITLE
fix(relations): use `.pk` instead of `.id`

### DIFF
--- a/apis_core/relations/signals.py
+++ b/apis_core/relations/signals.py
@@ -48,7 +48,7 @@ def merge_relations(sender, instance, entities, **kwargs):
 @receiver(post_delete)
 def set_relations_null(sender, instance, using, origin, **kwargs):
     content_type = ContentType.objects.get_for_model(instance)
-    object_id = instance.id
+    object_id = instance.pk
     if isinstance(object_id, int):
         Relation.objects.filter(
             subj_content_type=content_type, subj_object_id=object_id


### PR DESCRIPTION
The `id` is just an alias for `pk` in most cases, but sometimes it does
not exist. Its better to use `pk` directly.
