### PR TITLE
feat(generic): add options to mro_paths

### DIFF
--- a/apis_core/generic/helpers.py
+++ b/apis_core/generic/helpers.py
@@ -70,8 +70,9 @@ def mro_paths(model):
     paths = []
     if model is not None:
         for cls in filter(lambda x: x not in Model.mro(), model.mro()):
-            paths.append(cls.__module__.split(".")[:-1] + [cls.__name__])
-    return paths
+            paths.append(tuple([cls.__module__.split(".")[-2], cls.__name__]))
+            paths.append(tuple(cls.__module__.split(".")[:-1] + [cls.__name__]))
+    return [list(path) for path in list(dict.fromkeys(paths))]
 
 
 @functools.lru_cache


### PR DESCRIPTION
We enhance the list of mro_paths (which are used for class and template
lookups) to also include shorter versions of paths. Currently, for the
class `foo.bar.baz.MyClass` the list contained the whole path, which can
be cumbersome. For example, when working with templates it looks up the
template in `foo/bar/baz/myclass_{suffix}.html`. With this change we
also add a path to the lookup list containing only the class name and
the direct parent module, so for the example above this would be
`baz.Myclass` and the template lookup path list would then also contain
`baz/myclass_{suffix}.html`.
