### PR TITLE
improve generic object template lookup & improve relation detail view

### DIFF
--- a/apis_core/generic/templates/apis_core/generic/genericmodel_card.html
+++ b/apis_core/generic/templates/apis_core/generic/genericmodel_card.html
@@ -1,0 +1,18 @@
+{% load generic %}
+<div class="card">
+  <div class="card-header">
+
+    {% block card-header %}
+      {{ object }}
+    {% endblock card-header %}
+
+  </div>
+  <div class="card-body">
+
+    {% block card-body %}
+      {% template_list object "_card_table.html" as template_list %}
+      {% include template_list %}
+    {% endblock card-body %}
+
+  </div>
+</div>

--- a/apis_core/generic/templates/generic/generic_detail.html
+++ b/apis_core/generic/templates/generic/generic_detail.html
@@ -8,7 +8,8 @@
 {% if object %}
 
   {% block col %}
-    {% include "generic/partials/object_card.html" %}
+    {% template_list object "_card.html" as template_list %}
+    {% include template_list %}
   {% endblock col %}
 
 {% endif %}

--- a/apis_core/generic/templates/generic/partials/object_card.html
+++ b/apis_core/generic/templates/generic/partials/object_card.html
@@ -1,6 +1,0 @@
-{% load generic %}
-<div class="card">
-  <div class="card-header">{{ object }}</div>
-  {% template_list object "_card_table.html" as template_list %}
-  <div class="card-body">{% include template_list %}</div>
-</div>

--- a/apis_core/relations/templates/apis_core/relations/relation_card.html
+++ b/apis_core/relations/templates/apis_core/relations/relation_card.html
@@ -1,0 +1,9 @@
+{% extends "apis_core/generic/genericmodel_card.html" %}
+
+{% block card-header %}
+  <div class="text-center">
+    {% if object.subj %}<a href="{{ object.subj.get_absolute_url }}">{{ object.subj }}</a>{% endif %}
+    {{ object.name }}
+    {% if object.obj %}<a href="{{ object.obj.get_absolute_url }}">{{ object.obj }}</a>{% endif %}
+  </div>
+{% endblock card-header %}

--- a/apis_core/relations/templates/apis_core/relations/relation_card_table.html
+++ b/apis_core/relations/templates/apis_core/relations/relation_card_table.html
@@ -1,0 +1,24 @@
+{% load generic %}
+<table class="table table-hover">
+  <tr>
+    <th>Subject</th>
+    <td>
+      {% if object.subj %}<a href="{{ object.subj.get_absolute_url }}">{{ object.subj }}</a>{% endif %}
+    </td>
+  </tr>
+  <tr>
+    <th>Object</th>
+    <td>
+      {% if object.obj %}<a href="{{ object.obj.get_absolute_url }}">{{ object.obj }}</a>{% endif %}
+    </td>
+  </tr>
+  {% with "subj_content_type subj_object_id obj_content_type obj_object_id" as exclude_list %}
+    {% modeldict object as d %}
+    {% for key, value in d.items %}
+      {% if key.name not in exclude_list %}
+        {% model_field_template_lookup_list object key "table_row" as template_list %}
+        {% include template_list %}
+      {% endif %}
+    {% endfor %}
+  {% endwith %}
+</table>


### PR DESCRIPTION
- **feat(generic): use `template_list` templatetag in `generic_detail.html`**
- **feat(relations): introduce a `relation_card.html` template**
- **feat(relations): introduce a `relation_card_table.html` template**

Closes: #1728
