### PR TITLE
feat(generic): make ModelImportChoiceField more robust

### DIFF
--- a/apis_core/generic/forms/fields.py
+++ b/apis_core/generic/forms/fields.py
@@ -8,9 +8,11 @@ from apis_core.apis_metainfo.utils import create_object_from_uri
 class ModelImportChoiceField(ModelChoiceField):
     def to_python(self, value):
         result = None
-        if value:
+        if value.startswith(("http://", "https://")):
             try:
-                result = create_object_from_uri(value, self.queryset.model)
+                result = create_object_from_uri(
+                    value, self.queryset.model, raise_on_fail=True
+                )
             except Exception as e:
                 raise ValidationError(
                     _("Could not import %(value)s: %(exception)s"),


### PR DESCRIPTION
The field should only try to import when we are working with an URI and
it should raise an error if the import fails.
