### PR TITLE
fix(collections): check for filter existence before removing

### DIFF
--- a/apis_core/collections/filtersets.py
+++ b/apis_core/collections/filtersets.py
@@ -7,7 +7,8 @@ from apis_core.generic.filtersets import GenericFilterSet
 class SkosCollectionContentObjectFilterSet(GenericFilterSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        del self.filters["collections"]
+        if "collections" in self.filters:
+            del self.filters["collections"]
         content_types = SkosCollectionContentObject.objects.all().values("content_type")
         self.filters["content_type"].queryset = ContentType.objects.filter(
             pk__in=content_types


### PR DESCRIPTION
The collections filter only gets added if there are some collections. We
add a check if it has been added before we remove it in this inheriting
filterset, otherwise we get a KeyError.

Closes: #1978
