### PR TITLE
fix(generic): also add/remove collections if they are an empty list

### DIFF
--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -111,7 +111,8 @@ class GenericModelForm(forms.ModelForm):
         instance = super().save(*args, **kwargs)
         try:
             skoscollection = apps.get_model("collections.SkosCollection")
-            if collections := self.cleaned_data.get("collections"):
+            if "collections" in self.cleaned_data:
+                collections = self.cleaned_data.get("collections")
                 for collection in skoscollection.objects.exclude(pk__in=collections):
                     collection.remove(instance)
                 for collection in skoscollection.objects.filter(pk__in=collections):


### PR DESCRIPTION
The walrus operator interprets emtpy lists as False. This means we can
not use it to check the selected collections because maybe there is *no*
collection selected.
