### PR TITLE
feat(generic): use template lookup for create view

### DIFF
--- a/apis_core/generic/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/generic/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-08 04:32-0500\n"
+"POT-Creation-Date: 2025-08-05 02:12-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,6 +69,12 @@ msgstr "Bestätige Löschen von"
 msgid "Yes, delete"
 msgstr "Ja, löschen"
 
+#: apis_core/generic/templates/generic/generic_create.html
+#: apis_core/generic/templates/generic/generic_form.html
+#: apis_core/generic/templates/generic/generic_list.html
+msgid "Create"
+msgstr "Erstellen"
+
 #: apis_core/generic/templates/generic/generic_enrich.html
 #, python-format
 msgid "Updating %(object)s"
@@ -87,11 +93,6 @@ msgstr ""
 #, python-format
 msgid "Edit %(object)s"
 msgstr "%(object)s bearbeiten"
-
-#: apis_core/generic/templates/generic/generic_form.html
-#: apis_core/generic/templates/generic/generic_list.html
-msgid "Create"
-msgstr "Erstellen"
 
 #: apis_core/generic/templates/generic/generic_import.html
 #: apis_core/generic/templates/generic/generic_list.html

--- a/apis_core/generic/templates/generic/generic_create.html
+++ b/apis_core/generic/templates/generic/generic_create.html
@@ -1,0 +1,14 @@
+{% extends "generic/generic_content.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+{% block title %}
+  {% translate "Create" %}
+{% endblock title %}
+
+{% block col %}
+  <div class="card">
+    <div class="card-header">{% translate "Create" %}</div>
+    <div class="card-body">{% crispy form form.helper %}</div>
+  </div>
+{% endblock col %}

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -256,7 +256,7 @@ class Create(GenericModelMixin, PermissionRequiredMixin, CreateView):
     the `first_member_match` helper.
     """
 
-    template_name = "generic/generic_form.html"
+    template_name_suffix = "_create"
     permission_action_required = "add"
 
     def get_form_class(self):


### PR DESCRIPTION
The template name for the generic create view was set to
`generic/generic_form.html` which means that it only used this
template and did not allow to overload it for specific content types.
This commit replaces the hardcoded template name with a template name
suffix `_create` which means the view will look for a matching template
and fall back to `generic/generic_create.html` if none found.

Closes: #1982