### PR TITLE
fix(relations): remove leading slashes from links to static files

### DIFF
--- a/apis_core/relations/templates/base.html
+++ b/apis_core/relations/templates/base.html
@@ -37,10 +37,10 @@
 
 {% block scriptHeader %}
   {{ block.super }}
-  <script src="{% static '/js/filter_relations_menu.js' %}"></script>
+  <script src="{% static 'js/filter_relations_menu.js' %}"></script>
 {% endblock scriptHeader %}
 
 {% block styles %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static '/css/relations.css' %}">
+  <link rel="stylesheet" href="{% static 'css/relations.css' %}">
 {% endblock styles %}


### PR DESCRIPTION
This fixes `SuspiciousFileOperation` errors thrown by Django Debug Toolbar, which isn't a Core dependency but may be used by individual projects or developers for debugging purposes.
An equivalent fix was applied in the past in d657a9843.

Resolves: #2010