### PR TITLE
fix(relations): check for filter existence before removal

### DIFF
--- a/apis_core/relations/filtersets.py
+++ b/apis_core/relations/filtersets.py
@@ -92,7 +92,7 @@ class RelationFilterSet(GenericFilterSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if model := getattr(self.Meta, "model", False):
-            if model is Relation:
+            if model is Relation and "collections" in self.filters:
                 del self.filters["collections"]
             all_models = [ct.model_class() for ct in get_all_relation_subj_and_obj()]
             subj_models = getattr(model, "subj_model", all_models)


### PR DESCRIPTION
Confirm `collections` filter exists before attempting to remove it from `RelationFilterSet` to prevent a `KeyError`. Equivalent to fix applied to `collections` app in 0bc979ec6.

Resolves: #2014