### PR TITLE
feat(relations): surround relations menu in a block

### DIFF
--- a/apis_core/relations/templates/base.html
+++ b/apis_core/relations/templates/base.html
@@ -5,34 +5,37 @@
 
 {% block main-menu %}
   {{ block.super }}
-  <li class="nav-item dropdown">
-    <a href="#"
-       class="nav-link dropdown-toggle"
-       data-bs-toggle="dropdown"
-       role="button"
-       aria-haspopup="true"
-       aria-expanded="false">{% translate "Relations" %}
-      <span class="caret" />
-    </a>
-    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <a class="dropdown-item"
-         href="{% url "apis_core:generic:list" "relations.relation" %}">{% translate "All relations" %}</a>
-      <div class="dropdown-divider"></div>
-      <form class="mx-2">
-        <input type="text"
-               id="relationFilter"
-               class="form-control mb-2 form-control-sm"
-               placeholder="{% translate "Filter relations..." %}">
-      </form>
-      <div id="relationList">
-        {% get_relation_content_types as content_types %}
-        {% for content_type in content_types %}
-          <a class="dropdown-item relation-item"
-             href="{{ content_type.model_class.get_listview_url }}">{{ content_type.model_class.name }}</a>
-        {% endfor %}
+
+  {% block relations-menu %}
+    <li class="nav-item dropdown">
+      <a href="#"
+         class="nav-link dropdown-toggle"
+         data-bs-toggle="dropdown"
+         role="button"
+         aria-haspopup="true"
+         aria-expanded="false">{% translate "Relations" %}
+        <span class="caret" />
+      </a>
+      <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+        <a class="dropdown-item"
+           href="{% url "apis_core:generic:list" "relations.relation" %}">{% translate "All relations" %}</a>
+        <div class="dropdown-divider"></div>
+        <form class="mx-2">
+          <input type="text"
+                 id="relationFilter"
+                 class="form-control mb-2 form-control-sm"
+                 placeholder="{% translate "Filter relations..." %}">
+        </form>
+        <div id="relationList">
+          {% get_relation_content_types as content_types %}
+          {% for content_type in content_types %}
+            <a class="dropdown-item relation-item"
+               href="{{ content_type.model_class.get_listview_url }}">{{ content_type.model_class.name }}</a>
+          {% endfor %}
+        </div>
       </div>
-    </div>
-  </li>
+    </li>
+  {% endblock relations-menu %}
 {% endblock main-menu %}
 
 {% block scriptHeader %}


### PR DESCRIPTION
This way, apps that wish to override the relations menu can simply override the relations-menu block