### PR TITLE
birger/make genericmodel abstract

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 from django.db.models import BooleanField, CharField, TextField
 from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.db.models.query import QuerySet
@@ -19,7 +20,10 @@ from apis_core.utils.settings import apis_base_uri, rdf_namespace_prefix
 logger = logging.getLogger(__name__)
 
 
-class GenericModel:
+class GenericModel(models.Model):
+    class Meta:
+        abstract = True
+
     def __repr__(self):
         if id := getattr(self, "id", None):
             return super().__repr__() + f" (ID: {id})"

--- a/apis_core/generic/tests/models.py
+++ b/apis_core/generic/tests/models.py
@@ -3,7 +3,7 @@ from django.db import models
 from apis_core.generic.abc import GenericModel
 
 
-class Person(models.Model, GenericModel):
+class Person(GenericModel, models.Model):
     first_name = models.CharField()
     last_name = models.CharField()
 
@@ -11,5 +11,5 @@ class Person(models.Model, GenericModel):
         return f"{self.first_name} {self.last_name}"
 
 
-class Dummy(models.Model, GenericModel):
+class Dummy(GenericModel, models.Model):
     pass

--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -43,7 +43,7 @@ class APISHistoricalRecords(HistoricalRecords, GenericModel):
         )
 
 
-class APISHistoryTableBase(models.Model, GenericModel):
+class APISHistoryTableBase(GenericModel, models.Model):
     class Meta:
         abstract = True
 

--- a/apis_core/relations/migrations/0001_initial.py
+++ b/apis_core/relations/migrations/0001_initial.py
@@ -3,8 +3,6 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
-import apis_core.generic.abc
-
 
 class Migration(migrations.Migration):
     initial = True
@@ -45,6 +43,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(models.Model, apis_core.generic.abc.GenericModel),
+            bases=(models.Model,),
         ),
     ]

--- a/apis_core/relations/models.py
+++ b/apis_core/relations/models.py
@@ -56,7 +56,7 @@ def get_by_natural_key(natural_key: str):
     return ContentType.objects.get_by_natural_key(app_label, name).model_class()
 
 
-class Relation(models.Model, GenericModel, metaclass=RelationModelBase):
+class Relation(GenericModel, models.Model, metaclass=RelationModelBase):
     subj_content_type = models.ForeignKey(
         ContentType, on_delete=models.CASCADE, related_name="relation_subj_set"
     )

--- a/sample_project/migrations/0001_initial.py
+++ b/sample_project/migrations/0001_initial.py
@@ -5,8 +5,6 @@ import simple_history.models
 from django.conf import settings
 from django.db import migrations, models
 
-import apis_core.generic.abc
-
 
 class Migration(migrations.Migration):
     initial = True
@@ -76,7 +74,7 @@ class Migration(migrations.Migration):
                 ),
                 ("name", models.CharField(blank=True, default="", max_length=1024)),
             ],
-            bases=(apis_core.generic.abc.GenericModel, models.Model),
+            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name="Person",
@@ -175,7 +173,6 @@ class Migration(migrations.Migration):
             bases=(
                 simple_history.models.HistoricalChanges,
                 models.Model,
-                apis_core.generic.abc.GenericModel,
             ),
         ),
         migrations.CreateModel(
@@ -250,7 +247,6 @@ class Migration(migrations.Migration):
             bases=(
                 simple_history.models.HistoricalChanges,
                 models.Model,
-                apis_core.generic.abc.GenericModel,
             ),
         ),
         migrations.CreateModel(
@@ -371,7 +367,6 @@ class Migration(migrations.Migration):
             bases=(
                 simple_history.models.HistoricalChanges,
                 models.Model,
-                apis_core.generic.abc.GenericModel,
             ),
         ),
     ]

--- a/sample_project/migrations/0009_versionprofession.py
+++ b/sample_project/migrations/0009_versionprofession.py
@@ -5,8 +5,6 @@ import simple_history.models
 from django.conf import settings
 from django.db import migrations, models
 
-import apis_core.generic.abc
-
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -54,7 +52,6 @@ class Migration(migrations.Migration):
             bases=(
                 simple_history.models.HistoricalChanges,
                 models.Model,
-                apis_core.generic.abc.GenericModel,
             ),
         ),
     ]


### PR DESCRIPTION
- **feat(generic): make GenericModel a real abstract model**
- **fix(sample_project): remove occurrences of GenericModel from migrations**

BREAKING-CHANGE: GenericModel is no an abstract model, so projects have
to adapt their migrations (and remove GenericModel from the bases) and
maybe also their models.py (and reorder class inheritance)