### PR TITLE
fix(relations): let template inherit from correct template

### DIFF
--- a/apis_core/relations/templates/relations/relation_form.html
+++ b/apis_core/relations/templates/relations/relation_form.html
@@ -1,4 +1,4 @@
-{% extends "generic/generic_form.html" %}
+{% extends "generic/genericmodel_form.html" %}
 {% load i18n %}
 
 {% block card-header-content %}


### PR DESCRIPTION
The `generic_form` template was renamed to `genericmodel_form`
