### PR TITLE
fix(apis_entities): update base template for place templates

### DIFF
--- a/apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_list.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_list.html
@@ -1,4 +1,4 @@
-{% extends "generic/generic_list.html" %}
+{% extends "generic/genericmodel_list.html" %}
 {% load i18n %}
 
 {% block table %}

--- a/apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_map.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/e53_place_map.html
@@ -1,4 +1,4 @@
-{% extends "generic/generic_list.html" %}
+{% extends "generic/genericmodel_list.html" %}
 {% load static %}
 
 {% block scripts %}


### PR DESCRIPTION
The base template was renamed to `genericmodel_list.html`
