### PR TITLE
tests(utils): rdf importer tests for data from dnb

### DIFF
--- a/apis_core/utils/test_rdf.py
+++ b/apis_core/utils/test_rdf.py
@@ -119,3 +119,14 @@ class RdfTest(TestCase):
 
         self.assertIn(expected["surname"], attributes["surname"])
         self.assertEqual(len(attributes["forename"]), 0)
+
+    def test_dnb_place_without_coordinates(self):
+        expected = {"label": "Wutai Shan"}
+        # https://d-nb.info/gnd/4241848-3
+        uri = str(testdata / "wutaishan.rdf")
+
+        attributes = rdf.get_something_from_uri(uri)
+        self.assertEqual(len(attributes.get("latitude", [])), 0)
+        self.assertEqual(len(attributes.get("longitude", [])), 0)
+
+        self.assertIn(expected["label"], attributes["label"])

--- a/apis_core/utils/test_rdf.py
+++ b/apis_core/utils/test_rdf.py
@@ -100,3 +100,22 @@ class RdfTest(TestCase):
 
         attributes = rdf.get_something_from_uri(uri)
         self.assertEqual(oeaw["label"], attributes["label"])
+
+    def test_dnb_person_with_forename_and_surname(self):
+        expected = {"surname": "Einstein", "forename": "Albert"}
+        # https://d-nb.info/gnd/118529579
+        uri = str(testdata / "einstein.rdf")
+
+        attributes = rdf.get_something_from_uri(uri)
+        self.assertIn(expected["surname"], attributes["surname"])
+        self.assertIn(expected["forename"], attributes["forename"])
+
+    def test_dnb_person_with_only_personal_name(self):
+        expected = {"surname": "Sacher"}
+        # https://d-nb.info/gnd/1041944586
+        uri = str(testdata / "sacher.rdf")
+
+        attributes = rdf.get_something_from_uri(uri)
+
+        self.assertIn(expected["surname"], attributes["surname"])
+        self.assertEqual(len(attributes["forename"]), 0)

--- a/apis_core/utils/testdata/einstein.rdf
+++ b/apis_core/utils/testdata/einstein.rdf
@@ -1,0 +1,852 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:agrelon="https://d-nb.info/standards/elementset/agrelon#" xmlns:agrovoc="https://aims.fao.org/aos/agrovoc/" xmlns:bflc="http://id.loc.gov/ontologies/bflc/" xmlns:bibo="http://purl.org/ontology/bibo/" xmlns:cidoc="http://www.cidoc-crm.org/cidoc-crm/" xmlns:dbp="http://dbpedia.org/property/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcatde="http://dcat-ap.de/def/dcatde/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dnb_intern="http://dnb.de/" xmlns:dnbt="https://d-nb.info/standards/elementset/dnb#" xmlns:ebu="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:editeur="https://ns.editeur.org/thema/" xmlns:embne="https://datos.bne.es/resource/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gbv="http://purl.org/ontology/gbv/" xmlns:geo="http://www.opengis.net/ont/geosparql#" xmlns:gndo="https://d-nb.info/standards/elementset/gnd#" xmlns:isbd="http://iflastandards.info/ns/isbd/elements/" xmlns:lcsh="https://id.loc.gov/authorities/subjects/" xmlns:lib="http://purl.org/library/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:marcRole="http://id.loc.gov/vocabulary/relators/" xmlns:mesh="http://id.nlm.nih.gov/mesh/vocab#" xmlns:mo="http://purl.org/ontology/mo/" xmlns:naf="https://id.loc.gov/authorities/names/" xmlns:nsogg="https://purl.org/bncf/tid/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:ram="https://data.bnf.fr/ark:/12148/" xmlns:rdau="http://rdaregistry.info/Elements/u/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:schema="http://schema.org/" xmlns:sf="http://www.opengis.net/ont/sf#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:thesoz="http://lod.gesis.org/thesoz/" xmlns:umbel="http://umbel.org/umbel#" xmlns:v="http://www.w3.org/2006/vcard/ns#" xmlns:wdrs="http://www.w3.org/2007/05/powder-s#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#DifferentiatedPerson"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="https://isni.org/isni/000000012281955X"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/118529579/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579/about">
+    <dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579/about">
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-05T10:51:56.000</dcterms:modified>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579/about">
+    <gndo:descriptionLevel rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:gndIdentifier>118529579</gndo:gndIdentifier>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <foaf:page rdf:resource="https://de.wikipedia.org/wiki/Albert_Einstein"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="https://dbpedia.org/resource/Albert_Einstein"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="http://viaf.org/viaf/75121530"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="https://isni.org/isni/000000012281955X"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="http://www.wikidata.org/entity/Q937"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="http://id.loc.gov/rwo/agents/n79022889"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-588)185770878</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="https://d-nb.info/gnd/185770878"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <dnbt:deprecatedUri>https://d-nb.info/gnd/185770878</dnbt:deprecatedUri>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-588a)185770878</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-588a)118529579</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-588a)13745788X</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-588a)135386861</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-101c)311076866</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:oldAuthorityNumber>(DE-588c)4013939-6</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einstein, A.</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144827"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144827">
+    <gndo:forename>A.</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144827">
+    <gndo:surname>Einstein</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einstein</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144828"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144828">
+    <gndo:personalName>Einstein</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ai yin si tan</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144829"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144829">
+    <gndo:personalName>Ai yin si tan</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainshtain, Albert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144830"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144830">
+    <gndo:forename>Albert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144830">
+    <gndo:surname>Ainshtain</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainshutain, A.</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144831"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144831">
+    <gndo:forename>A.</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144831">
+    <gndo:surname>Ainshutain</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainshutain</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144832"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144832">
+    <gndo:personalName>Ainshutain</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainštain</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144833"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144833">
+    <gndo:personalName>Ainštain</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Aïnstaïn, Albertos</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144834"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144834">
+    <gndo:forename>Albertos</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144834">
+    <gndo:surname>Aïnstaïn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Aïnstaïn, Almpert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144835"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144835">
+    <gndo:forename>Almpert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144835">
+    <gndo:surname>Aïnstaïn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainstaina, Albarta</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144836"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144836">
+    <gndo:forename>Albarta</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144836">
+    <gndo:surname>Ainstaina</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainsten</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144837"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144837">
+    <gndo:personalName>Ainsten</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ainsyut'ain, Alberŭt'ŭ</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144838"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144838">
+    <gndo:forename>Alberŭt'ŭ</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144838">
+    <gndo:surname>Ainsyut'ain</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Aiyinsitan</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144839"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144839">
+    <gndo:personalName>Aiyinsitan</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ai-yin-ssu-t'an, A-po-t'e</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144840"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144840">
+    <gndo:forename>A-po-t'e</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144840">
+    <gndo:surname>Ai-yin-ssu-t'an</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ai-yin-ssu-t'an</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144841"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144841">
+    <gndo:personalName>Ai-yin-ssu-t'an</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ajnštajn, A.</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144842"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144842">
+    <gndo:forename>A.</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144842">
+    <gndo:surname>Ajnštajn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ayinsten</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144843"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144843">
+    <gndo:personalName>Ayinsten</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Aynishtayn</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144844"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144844">
+    <gndo:personalName>Aynishtayn</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Aynštayn, Ālbirt</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144845"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144845">
+    <gndo:forename>Ālbirt</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144845">
+    <gndo:surname>Aynštayn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Aynštāyn, Albirt</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144846"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144846">
+    <gndo:forename>Albirt</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144846">
+    <gndo:surname>Aynštāyn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einshtein, Al'bert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144847"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144847">
+    <gndo:forename>Al'bert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144847">
+    <gndo:surname>Einshtein</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einsteina, Alberta</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144848"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144848">
+    <gndo:forename>Alberta</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144848">
+    <gndo:surname>Einsteina</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einšteinas, A.</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144849"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144849">
+    <gndo:forename>A.</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144849">
+    <gndo:surname>Einšteinas</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ėjnštejn, Al'bert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144850"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144850">
+    <gndo:forename>Al'bert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144850">
+    <gndo:surname>Ėjnštejn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ėjnštejn, A.</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144851"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144851">
+    <gndo:forename>A.</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144851">
+    <gndo:surname>Ėjnštejn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Eynshṭeyn, Alberṭ</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144852"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144852">
+    <gndo:forename>Alberṭ</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144852">
+    <gndo:surname>Eynshṭeyn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Eynšteyn, A.</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144853"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144853">
+    <gndo:forename>A.</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144853">
+    <gndo:surname>Eynšteyn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Inshtin</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144854"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144854">
+    <gndo:personalName>Inshtin</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ajnštajn, Albert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144855"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144855">
+    <gndo:forename>Albert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144855">
+    <gndo:surname>Ajnštajn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ejnštejn, Albert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144856"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144856">
+    <gndo:forename>Albert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144856">
+    <gndo:surname>Ejnštejn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Ėjnštejn, Alʹbert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144857"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144857">
+    <gndo:forename>Alʹbert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144857">
+    <gndo:surname>Ėjnštejn</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Xal-bhar-kri-xa-yan-si-tcan</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144858"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144858">
+    <gndo:personalName>Xal-bhar-kri-xa-yan-si-tcan</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Xa-yan-si-tcan</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144859"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144859">
+    <gndo:personalName>Xa-yan-si-tcan</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Xen-si-than</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144860"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144860">
+    <gndo:personalName>Xen-si-than</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>愛因斯坦</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144861"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144861">
+    <gndo:personalName>愛因斯坦</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einstein, Albert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144862"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144862">
+    <gndo:forename>Albert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144862">
+    <gndo:surname>Einstein</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson>Einstein, Albert</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144863"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144863">
+    <gndo:forename>Albert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144863">
+    <gndo:surname>Einstein</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="zh-Hans">爱因斯坦, 阿尔伯特</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144864"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144864">
+    <gndo:forename>阿尔伯特</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144864">
+    <gndo:surname>爱因斯坦</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="sr-Cyrl">Ајнштајн, Алберт</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144865"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144865">
+    <gndo:forename>Алберт</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144865">
+    <gndo:surname>Ајнштајн</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="ru">Эйнштейн, Альберт</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144866"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144866">
+    <gndo:forename>Альберт</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144866">
+    <gndo:surname>Эйнштейн</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="uk">Ейнштейн, Альберт</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144867"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144867">
+    <gndo:forename>Альберт</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144867">
+    <gndo:surname>Ейнштейн</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="bg">Айнщайн, Алберт</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144868"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144868">
+    <gndo:forename>Алберт</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144868">
+    <gndo:surname>Айнщайн</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="el">Αι͏̈νστάιν, Άλμπερτ</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144869"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144869">
+    <gndo:forename>Άλμπερτ</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144869">
+    <gndo:surname>Αι͏̈νστάιν</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="fa">آینشتین, آلبرت</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144870"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144870">
+    <gndo:forename>آلبرت</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144870">
+    <gndo:surname>آینشتین</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameForThePerson xml:lang="zh-Hant">愛因斯坦</gndo:variantNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:variantNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144871"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144871">
+    <gndo:personalName>愛因斯坦</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:preferredNameForThePerson>Einstein, Albert</gndo:preferredNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:preferredNameEntityForThePerson rdf:nodeID="node1j44g7rq7x5144872"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144872">
+    <gndo:forename>Albert</gndo:forename>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144872">
+    <gndo:surname>Einstein</gndo:surname>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/118688405"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144873"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144873">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/118688405"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144873">
+    <gndo:functionOrRoleAsLiteral>Erste Ehefrau</gndo:functionOrRoleAsLiteral>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144873">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/116425741"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144874"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144874">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/116425741"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144874">
+    <gndo:functionOrRoleAsLiteral>Zweite Ehefrau</gndo:functionOrRoleAsLiteral>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144874">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/143075845"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <agrelon:hasChild rdf:resource="https://d-nb.info/gnd/143075845"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144875"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144875">
+    <agrelon:hasChild rdf:resource="https://d-nb.info/gnd/143075845"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144875">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/118810928"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <agrelon:hasChild rdf:resource="https://d-nb.info/gnd/118810928"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144876"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144876">
+    <agrelon:hasChild rdf:resource="https://d-nb.info/gnd/118810928"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144876">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/116425725"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144877"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144877">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/116425725"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144877">
+    <gndo:functionOrRoleAsLiteral>Cousin</gndo:functionOrRoleAsLiteral>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144877">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:professionalRelationship rdf:resource="https://d-nb.info/gnd/116243481"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144878"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144878">
+    <gndo:professionalRelationship rdf:resource="https://d-nb.info/gnd/116243481"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144878">
+    <gndo:functionOrRoleAsLiteral>Sekretärin</gndo:functionOrRoleAsLiteral>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144878">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/11609026X"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144879"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144879">
+    <gndo:familialRelationship rdf:resource="https://d-nb.info/gnd/11609026X"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144879">
+    <gndo:functionOrRoleAsLiteral>Schwiegersohn</gndo:functionOrRoleAsLiteral>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144879">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:acquaintanceshipOrFriendship rdf:resource="https://d-nb.info/gnd/138573131"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:hasRelation rdf:nodeID="node1j44g7rq7x5144880"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144880">
+    <gndo:acquaintanceshipOrFriendship rdf:resource="https://d-nb.info/gnd/138573131"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144880">
+    <gndo:functionOrRoleAsLiteral>Doktorvater</gndo:functionOrRoleAsLiteral>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144880">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#Relationship"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/15514-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/136256-2"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/36190-2"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/35495-8"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/30381-1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/118340-0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/43972-1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/2003658-9"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/2003822-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/1001101-8"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/35311-5"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/37531-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/35038-2"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/1000125-6"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/31924-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/35019-9"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/2015138-X"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:affiliation rdf:resource="https://d-nb.info/gnd/35671-2"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:gender rdf:resource="https://d-nb.info/standards/vocab/gnd/gender#male"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:academicDegree>Prof.</gndo:academicDegree>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:relatedSubjectHeading rdf:resource="https://d-nb.info/gnd/4042421-2"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:gndSubjectCategory rdf:resource="https://d-nb.info/standards/vocab/gnd/gnd-sc#21.5p"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:geographicAreaCode rdf:resource="https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:geographicAreaCode rdf:resource="https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-CH"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:geographicAreaCode rdf:resource="https://d-nb.info/standards/vocab/gnd/geographic-area-code#XD-US"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Äther und Relativitätstheorie</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Geometrie und Erfahrung</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Geleitw. zu: Reichinstein, David: Grenzflächenvorgänge in der unbelebten und belebten Natur</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Vorw. zu: Freundlich, Erwin F.: Die Grundlagen der Einsteinschen Gravitationstheorie</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Mitverf. von: Thomson, Joseph J.: James Clerk Maxwell</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>On the method of theoretical physics</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Mitverf. von: Lorentz, Hendrik A.: Das Relativitätsprinzip</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Über die spezielle und die allgemeine Relativitätstheorie</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:publication>Vier Vorlesungen über Relativitätstheorie gehalten im Mai 1921 an der Universität Princeton</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/118529579/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579/about">
+    <dcterms:creator rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-101"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579/about">
+    <dcatde:maintainer rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-101"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:biographicalOrHistoricalInformation xml:lang="de">Deutscher Physiker und Pazifist</gndo:biographicalOrHistoricalInformation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:placeOfBirth rdf:resource="https://d-nb.info/gnd/4061529-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:placeOfDeath rdf:resource="https://d-nb.info/gnd/4103300-0"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:placeOfActivity rdf:resource="https://d-nb.info/gnd/4005762-8"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:placeOfActivity rdf:resource="https://d-nb.info/gnd/4076310-9"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:placeOfActivity rdf:resource="https://d-nb.info/gnd/4068038-1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:placeOfActivity rdf:resource="https://d-nb.info/gnd/4005728-8"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <owl:sameAs rdf:resource="https://www.filmportal.de/4533E35F16964C939B82033BB6259E32"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:professionOrOccupation rdf:nodeID="node1j44g7rq7x5144881"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144881">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144881">
+    <rdf:_1 rdf:resource="https://d-nb.info/gnd/4045968-8"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144881">
+    <rdf:_2 rdf:resource="https://d-nb.info/gnd/4137384-4"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g7rq7x5144881">
+    <rdf:_3 rdf:resource="https://d-nb.info/gnd/4066567-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:dateOfBirth rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1879-03-14</gndo:dateOfBirth>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/118529579">
+    <gndo:dateOfDeath rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1955-04-18</gndo:dateOfDeath>
+  </rdf:Description>
+</rdf:RDF>

--- a/apis_core/utils/testdata/sacher.rdf
+++ b/apis_core/utils/testdata/sacher.rdf
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:agrelon="https://d-nb.info/standards/elementset/agrelon#" xmlns:agrovoc="https://aims.fao.org/aos/agrovoc/" xmlns:bflc="http://id.loc.gov/ontologies/bflc/" xmlns:bibo="http://purl.org/ontology/bibo/" xmlns:cidoc="http://www.cidoc-crm.org/cidoc-crm/" xmlns:dbp="http://dbpedia.org/property/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcatde="http://dcat-ap.de/def/dcatde/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dnb_intern="http://dnb.de/" xmlns:dnbt="https://d-nb.info/standards/elementset/dnb#" xmlns:ebu="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:editeur="https://ns.editeur.org/thema/" xmlns:embne="https://datos.bne.es/resource/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gbv="http://purl.org/ontology/gbv/" xmlns:geo="http://www.opengis.net/ont/geosparql#" xmlns:gndo="https://d-nb.info/standards/elementset/gnd#" xmlns:isbd="http://iflastandards.info/ns/isbd/elements/" xmlns:lcsh="https://id.loc.gov/authorities/subjects/" xmlns:lib="http://purl.org/library/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:marcRole="http://id.loc.gov/vocabulary/relators/" xmlns:mesh="http://id.nlm.nih.gov/mesh/vocab#" xmlns:mo="http://purl.org/ontology/mo/" xmlns:naf="https://id.loc.gov/authorities/names/" xmlns:nsogg="https://purl.org/bncf/tid/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:ram="https://data.bnf.fr/ark:/12148/" xmlns:rdau="http://rdaregistry.info/Elements/u/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:schema="http://schema.org/" xmlns:sf="http://www.opengis.net/ont/sf#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:thesoz="http://lod.gesis.org/thesoz/" xmlns:umbel="http://umbel.org/umbel#" xmlns:v="http://www.w3.org/2006/vcard/ns#" xmlns:wdrs="http://www.w3.org/2007/05/powder-s#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#DifferentiatedPerson"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/1041944586/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586/about">
+    <dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586/about">
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-04-27T13:19:59.000</dcterms:modified>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586/about">
+    <gndo:descriptionLevel rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#3"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:gndIdentifier>1041944586</gndo:gndIdentifier>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <owl:sameAs rdf:resource="http://viaf.org/viaf/305251337"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:preferredNameForThePerson>Sacher</gndo:preferredNameForThePerson>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:preferredNameEntityForThePerson rdf:nodeID="node1j44g3m9ox5129791"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g3m9ox5129791">
+    <gndo:personalName>Sacher</gndo:personalName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:gender rdf:resource="https://d-nb.info/standards/vocab/gnd/gender#male"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:geographicAreaCode rdf:resource="https://d-nb.info/standards/vocab/gnd/geographic-area-code#XA-DE"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:publication>Cigarren und Menschen. - 1847</gndo:publication>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/1041944586/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586/about">
+    <dcterms:creator rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-61"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586/about">
+    <dcatde:maintainer rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-605"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:periodOfActivity>1847</gndo:periodOfActivity>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/1041944586">
+    <gndo:professionOrOccupation rdf:nodeID="node1j44g3m9ox5129792"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g3m9ox5129792">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="node1j44g3m9ox5129792">
+    <rdf:_1 rdf:resource="https://d-nb.info/gnd/4053309-8"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/apis_core/utils/testdata/wutaishan.rdf
+++ b/apis_core/utils/testdata/wutaishan.rdf
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:agrelon="https://d-nb.info/standards/elementset/agrelon#" xmlns:agrovoc="https://aims.fao.org/aos/agrovoc/" xmlns:bflc="http://id.loc.gov/ontologies/bflc/" xmlns:bibo="http://purl.org/ontology/bibo/" xmlns:cidoc="http://www.cidoc-crm.org/cidoc-crm/" xmlns:dbp="http://dbpedia.org/property/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcatde="http://dcat-ap.de/def/dcatde/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dnb_intern="http://dnb.de/" xmlns:dnbt="https://d-nb.info/standards/elementset/dnb#" xmlns:ebu="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:editeur="https://ns.editeur.org/thema/" xmlns:embne="https://datos.bne.es/resource/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gbv="http://purl.org/ontology/gbv/" xmlns:geo="http://www.opengis.net/ont/geosparql#" xmlns:gndo="https://d-nb.info/standards/elementset/gnd#" xmlns:isbd="http://iflastandards.info/ns/isbd/elements/" xmlns:lcsh="https://id.loc.gov/authorities/subjects/" xmlns:lib="http://purl.org/library/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:marcRole="http://id.loc.gov/vocabulary/relators/" xmlns:mesh="http://id.nlm.nih.gov/mesh/vocab#" xmlns:mo="http://purl.org/ontology/mo/" xmlns:naf="https://id.loc.gov/authorities/names/" xmlns:nsogg="https://purl.org/bncf/tid/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:ram="https://data.bnf.fr/ark:/12148/" xmlns:rdau="http://rdaregistry.info/Elements/u/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:schema="http://schema.org/" xmlns:sf="http://www.opengis.net/ont/sf#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:thesoz="http://lod.gesis.org/thesoz/" xmlns:umbel="http://umbel.org/umbel#" xmlns:v="http://www.w3.org/2006/vcard/ns#" xmlns:wdrs="http://www.w3.org/2007/05/powder-s#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#NaturalGeographicUnit"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/4241848-3/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-06-02T16:19:51.000</dcterms:modified>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <gndo:descriptionLevel rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:gndIdentifier>4241848-3</gndo:gndIdentifier>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <owl:sameAs rdf:resource="http://viaf.org/viaf/315522453"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:oldAuthorityNumber>(DE-588c)4241848-3</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:broaderTermInstantial rdf:resource="https://d-nb.info/gnd/4144619-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:gndSubjectCategory rdf:resource="https://d-nb.info/standards/vocab/gnd/gnd-sc#19.1b"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:geographicAreaCode rdf:resource="https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/4241848-3/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcterms:creator rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-605"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcatde:maintainer rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-605"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:biographicalOrHistoricalInformation xml:lang="de">Höchste Erhebung in d. gleichnamigen Gebirgszug in d. chines. Provinz Shanxi; einer der Vier berühmten Berge</gndo:biographicalOrHistoricalInformation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:variantNameForThePlaceOrGeographicName>Wutaischan</gndo:variantNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:variantNameForThePlaceOrGeographicName>Wutaishan</gndo:variantNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:variantNameForThePlaceOrGeographicName>Wu-t'ai-shan</gndo:variantNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:preferredNameForThePlaceOrGeographicName>Wutai Shan</gndo:preferredNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:broaderTermPartitive rdf:resource="https://d-nb.info/gnd/4241847-1"/>
+  </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
This pull request adds new RDF test data files and introduces a new test to improve coverage for corporate body and territorial administrative unit parsing from DNB RDF files. The changes ensure that the RDF parsing logic is correctly handling various real-world examples, increasing the robustness of the codebase.

### Test coverage improvements

* Added a new test `test_dnb_corporate_body` in `apis_core/utils/test_rdf.py` to verify correct label extraction for corporate bodies and territorial administrative units from DNB RDF files.

### New test data

* Added `apis_core/utils/testdata/wiener_stadtbibliothek.rdf` containing RDF data for the Wiener Stadtbibliothek corporate body, used in the new test.
* Added `apis_core/utils/testdata/gebietsverband_lungau.rdf` containing RDF data for the Gebietsverband Lungau territorial corporate body, used in the new test.
* Added `apis_core/utils/testdata/british_residency_hyd.rdf` containing RDF data for the British Residency (Hyderabad), expanding the variety of test cases for RDF parsing.