### PR TITLE
ci(coverage): move coverage options to pyproject.toml

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
        run: uv run --group docs mkdocs build -f docs/mkdocs.yml -d _build
      - name: Build coverage
        run: |
-         uv run --group docs coverage run --source="." manage.py test
+         uv run --group docs coverage run
          uv run --group docs coverage html
      - uses: actions/checkout@v5
        with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,8 @@ acdh-arche-assets = "AcdhArcheAssets"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "sample_project.settings"
+
+[tool.coverage.run]
+command_line = "-m pytest"
+source = ["."]
+omit = ["**/tests/*"]


### PR DESCRIPTION
...and configure coverage to ignore `tests` folders
