### PR TITLE
import geographic place

### DIFF
--- a/apis_core/apis_entities/triple_configs/E53_PlaceFromDNB.toml
+++ b/apis_core/apis_entities/triple_configs/E53_PlaceFromDNB.toml
@@ -1,4 +1,7 @@
 [[filters]]
+"rdf:type" = "gndo:NaturalGeographicUnit"
+
+[[filters]]
 "rdf:type" = "gndo:TerritorialCorporateBodyOrAdministrativeUnit"
 
 

--- a/apis_core/utils/test_rdf.py
+++ b/apis_core/utils/test_rdf.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from django.test import TestCase
 
+from apis_core.apis_entities.abc import E53_Place
 from apis_core.utils import rdf
 
 # use `curl -H "Accept: application/rdf+xml" -L $URI` to fetch data
@@ -100,3 +101,14 @@ class RdfTest(TestCase):
 
         attributes = rdf.get_something_from_uri(uri)
         self.assertEqual(oeaw["label"], attributes["label"])
+
+    def test_dnb_geographic_unit(self):
+        expected = {"label": "Wutai Shan"}
+        # https://d-nb.info/gnd/4241848-3
+        uri = str(testdata / "wutaishan.rdf")
+
+        attributes = rdf.get_something_from_uri(uri, [E53_Place])
+        self.assertEqual(len(attributes.get("latitude", [])), 0)
+        self.assertEqual(len(attributes.get("longitude", [])), 0)
+
+        self.assertIn(expected["label"], attributes["label"])

--- a/apis_core/utils/testdata/wutaishan.rdf
+++ b/apis_core/utils/testdata/wutaishan.rdf
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:agrelon="https://d-nb.info/standards/elementset/agrelon#" xmlns:agrovoc="https://aims.fao.org/aos/agrovoc/" xmlns:bflc="http://id.loc.gov/ontologies/bflc/" xmlns:bibo="http://purl.org/ontology/bibo/" xmlns:cidoc="http://www.cidoc-crm.org/cidoc-crm/" xmlns:dbp="http://dbpedia.org/property/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcatde="http://dcat-ap.de/def/dcatde/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dnb_intern="http://dnb.de/" xmlns:dnbt="https://d-nb.info/standards/elementset/dnb#" xmlns:ebu="http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#" xmlns:editeur="https://ns.editeur.org/thema/" xmlns:embne="https://datos.bne.es/resource/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gbv="http://purl.org/ontology/gbv/" xmlns:geo="http://www.opengis.net/ont/geosparql#" xmlns:gndo="https://d-nb.info/standards/elementset/gnd#" xmlns:isbd="http://iflastandards.info/ns/isbd/elements/" xmlns:lcsh="https://id.loc.gov/authorities/subjects/" xmlns:lib="http://purl.org/library/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:marcRole="http://id.loc.gov/vocabulary/relators/" xmlns:mesh="http://id.nlm.nih.gov/mesh/vocab#" xmlns:mo="http://purl.org/ontology/mo/" xmlns:naf="https://id.loc.gov/authorities/names/" xmlns:nsogg="https://purl.org/bncf/tid/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:ram="https://data.bnf.fr/ark:/12148/" xmlns:rdau="http://rdaregistry.info/Elements/u/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:schema="http://schema.org/" xmlns:sf="http://www.opengis.net/ont/sf#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:thesoz="http://lod.gesis.org/thesoz/" xmlns:umbel="http://umbel.org/umbel#" xmlns:v="http://www.w3.org/2006/vcard/ns#" xmlns:wdrs="http://www.w3.org/2007/05/powder-s#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <rdf:type rdf:resource="https://d-nb.info/standards/elementset/gnd#NaturalGeographicUnit"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/4241848-3/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2022-06-02T16:19:51.000</dcterms:modified>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <gndo:descriptionLevel rdf:resource="https://d-nb.info/standards/vocab/gnd/description-level#1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:gndIdentifier>4241848-3</gndo:gndIdentifier>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <owl:sameAs rdf:resource="http://viaf.org/viaf/315522453"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:oldAuthorityNumber>(DE-588c)4241848-3</gndo:oldAuthorityNumber>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:broaderTermInstantial rdf:resource="https://d-nb.info/gnd/4144619-7"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:gndSubjectCategory rdf:resource="https://d-nb.info/standards/vocab/gnd/gnd-sc#19.1b"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:geographicAreaCode rdf:resource="https://d-nb.info/standards/vocab/gnd/geographic-area-code#XB-CN"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <wdrs:describedby rdf:resource="https://d-nb.info/gnd/4241848-3/about"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcterms:creator rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-605"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3/about">
+    <dcatde:maintainer rdf:resource="https://ld.zdb-services.de/resource/organisations/DE-605"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:biographicalOrHistoricalInformation xml:lang="de">Höchste Erhebung in d. gleichnamigen Gebirgszug in d. chines. Provinz Shanxi; einer der Vier berühmten Berge</gndo:biographicalOrHistoricalInformation>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:variantNameForThePlaceOrGeographicName>Wutaischan</gndo:variantNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:variantNameForThePlaceOrGeographicName>Wutaishan</gndo:variantNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:variantNameForThePlaceOrGeographicName>Wu-t'ai-shan</gndo:variantNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:preferredNameForThePlaceOrGeographicName>Wutai Shan</gndo:preferredNameForThePlaceOrGeographicName>
+  </rdf:Description>
+  <rdf:Description rdf:about="https://d-nb.info/gnd/4241848-3">
+    <gndo:broaderTermPartitive rdf:resource="https://d-nb.info/gnd/4241847-1"/>
+  </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
This pull request adds support for handling DNB "NaturalGeographicUnit" places in the RDF parsing logic and tests. The main changes include updating filter configuration to recognize this type, adding a corresponding test case, and providing a sample RDF file for test data.

* Updated `E53_PlaceFromDNB.toml` to include a filter for `"rdf:type" = "gndo:NaturalGeographicUnit"`, enabling the system to recognize and process this entity type.

**Tests:**

* Added a new test case `test_dnb_geographic_unit` in `test_rdf.py` to verify correct parsing of a DNB NaturalGeographicUnit RDF file, checking label extraction and absence of latitude/longitude data.
* Added new sample RDF file `wutaishan.rdf` containing a DNB NaturalGeographicUnit for use in tests.

closes #2074 