### PR TITLE
fix(apis_entities): filter for gndo:Company for Groups

### DIFF
--- a/apis_core/apis_entities/triple_configs/E74_GroupFromDNB.toml
+++ b/apis_core/apis_entities/triple_configs/E74_GroupFromDNB.toml
@@ -1,6 +1,9 @@
 [[filters]]
 "rdf:type" = "gndo:CorporateBody"
 
+[[filters]]
+"rdf:type" = "gndo:Company"
+
 [attributes]
 label = ["gndo:preferredNameForTheCorporateBody", "gndo:variantNameForTheCorporateBody"]
 start_date = "gndo:dateOfEstablishment"


### PR DESCRIPTION
Add filter for RDF type `gndo:Company` to triple configs for `Groups` to fix failing GND imports for certain organisations.

Closes: #2084