### PR TITLE
fix(apis_entities): use preferredNameEntityForThePerson in importer

### DIFF
--- a/apis_core/apis_entities/triple_configs/E21_PersonFromDNB.toml
+++ b/apis_core/apis_entities/triple_configs/E21_PersonFromDNB.toml
@@ -2,7 +2,7 @@
 "rdf:type" = "gndo:DifferentiatedPerson"
 
 [attributes]
-forename = ["gndo:preferredNameEntityForThePerson/gndo:forename", "gndo:variantNameForThePerson/gndo:forename", "gndo:forename"]
+forename = ["gndo:preferredNameEntityForThePerson/gndo:forename", "gndo:variantNameForThePerson/gndo:forename", "gndo:forename", "gndo:preferredNameForThePerson"]
 surname = ["gndo:preferredNameEntityForThePerson/gndo:surname", "gndo:variantNameForThePerson/gndo:surname", "gndo:surname"]
 alternative_names = "gndo:variantNameForThePerson"
 date_of_birth = "gndo:dateOfBirth"

--- a/apis_core/utils/test_rdf.py
+++ b/apis_core/utils/test_rdf.py
@@ -50,6 +50,7 @@ class RdfTest(TestCase):
                 "Rudolf",
                 "Rodolphe",
                 "...",
+                "Ramus, Pierre",
             ],
             "surname": ["Ramus", "Großmann", "Grossmann", "Grossman", "Libertarian"],
             "alternative_names": [


### PR DESCRIPTION
If no `forename` is set, fall back to `preferredNameEntityForThePerson`

Closes: #2086
