### PR TITLE
relations label

### DIFF
--- a/apis_core/generic/templates/generic/genericmodel_list.html
+++ b/apis_core/generic/templates/generic/genericmodel_list.html
@@ -15,7 +15,13 @@
     <div class="card">
       <div class="card-header">
         <div class="row">
-          <div class="col">{{ object_list.model.get_verbose_name_plural|title }}</div>
+          <div class="col">
+
+            {% block listviewheader %}
+              {{ object_list.model.get_verbose_name_plural|title }}
+            {% endblock listviewheader %}
+
+          </div>
           <div class="col">
             {% if object_list.model.get_add_permission in perms %}
               <a class="btn btn-outline-success float-end btn-sm"

--- a/apis_core/relations/models.py
+++ b/apis_core/relations/models.py
@@ -137,3 +137,14 @@ class Relation(GenericModel, models.Model, metaclass=RelationModelBase):
     @classmethod
     def reverse_name(cls) -> str:
         return cls._meta.verbose_name + " reverse"
+
+    @classmethod
+    def name_and_reverse_name(cls) -> str:
+        """
+        Return a string with both the name and the reverse name.
+
+        If they are identical, return only the name.
+        """
+        if cls.name() != cls.reverse_name():
+            return f"{cls.name()} - {cls.reverse_name()}"
+        return cls.name()

--- a/apis_core/relations/templates/base.html
+++ b/apis_core/relations/templates/base.html
@@ -30,7 +30,7 @@
           {% get_relation_content_types as content_types %}
           {% for content_type in content_types %}
             <a class="dropdown-item relation-item"
-               href="{{ content_type.model_class.get_listview_url }}">{{ content_type.model_class.name }}</a>
+               href="{{ content_type.model_class.get_listview_url }}">{{ content_type.model_class.name_and_reverse_name }}</a>
           {% endfor %}
         </div>
       </div>

--- a/apis_core/relations/templates/relations/relation_list.html
+++ b/apis_core/relations/templates/relations/relation_list.html
@@ -1,0 +1,5 @@
+{% extends "generic/genericmodel_list.html" %}
+
+{% block listviewheader %}
+  {{ object_list.model.name_and_reverse_name|title }}
+{% endblock listviewheader %}


### PR DESCRIPTION
This pull request improves how relation names are displayed throughout the UI by introducing a new method to show both the name and reverse name of relation models when appropriate. This enhances clarity for users when viewing lists of relations. The main changes are grouped below:

**Display improvements for relation names:**

* Added a new class method `name_and_reverse_name` to relation models, which returns a string combining the name and reverse name if they differ, or just the name if they are the same.
* Updated the dropdown list in `base.html` to use `name_and_reverse_name` instead of just `name`, making relation names more descriptive in the UI.
* Modified the generic list template to allow child templates to override the list view header, enabling the new relation name display.
* Overrode the `listviewheader` block in `relation_list.html` to display the combined name and reverse name for relation lists.

closes #2094 
closes #2095 