### PR TITLE
fix(generic): rebuild the form layout after modification

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -218,6 +218,10 @@ class List(
                 initial=self._get_columns_initial(columns_exclude),
             )
             filterset.form.fields = {**{"columns": columns}, **filterset.form.fields}
+        # rebuild the layout, now that the columns field was added
+        filterset.form.helper.layout = filterset.form.helper.build_default_layout(
+            filterset.form
+        )
         # If the filterset form contains form data
         # we add a CSS class to the element wrapping
         # that field in HTML. This CSS class can be


### PR DESCRIPTION
We pass the form to the formhelper since 93c2bc, which makes the
formhelper create a layout for the form right away. Adding a field
afterwards does not get reflected in the layout, so we have to rebuild
the form layout after adding the field.
