### PR TITLE
docs(apis_entities): correct DuplicateColumn docstring to clarify button type

### DIFF
--- a/apis_core/apis_entities/tables.py
+++ b/apis_core/apis_entities/tables.py
@@ -3,7 +3,7 @@ from apis_core.generic.tables import ActionColumn, GenericTable
 
 class DuplicateColumn(ActionColumn):
     """
-    A column showing a view button
+    A column showing a duplicate button
     """
 
     template_name = "columns/duplicate.html"


### PR DESCRIPTION
This pull request makes a minor documentation update to the `DuplicateColumn` class in `apis_core/apis_entities/tables.py`, clarifying that the column displays a duplicate button rather than a view button.