### PR TITLE
feat(apis_entities): move from CSS floats to flex

### DIFF
--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -2,12 +2,3 @@
 #single-object-header h2 {
     text-align: center;
 }
-
-/* navigation between objects (in list) from single object view header */
-.prev-in-list {
-    float: right;
-}
-
-.next-in-list {
-    float: left;
-}

--- a/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity.html
@@ -16,9 +16,10 @@
       <div class="card-header">
 
         {% block card-header-content %}
-          <div id="single-object-header" class="row">
-            <div class="col-md-2">{% include "apis_entities/partials/prev_url.html" %}</div>
-            <div class="col-md-8">
+          <div id="single-object-header"
+               class="d-flex flex-column flex-md-row justify-content-between justify-content-sm-around">
+            <div class="d-flex justify-content-end">{% include "apis_entities/partials/prev_url.html" %}</div>
+            <div>
               <h2>
                 {% include "apis_entities/partials/listview_url.html" %}
                 {{ object }}
@@ -31,7 +32,7 @@
 
               </h2>
             </div>
-            <div class="col-md-2">{% include "apis_entities/partials/next_url.html" %}</div>
+            <div class="d-flex justify-content-start">{% include "apis_entities/partials/next_url.html" %}</div>
           </div>
         {% endblock card-header-content %}
 


### PR DESCRIPTION
Convert header layout of single object view from
relying on CSS `float`s to being `flex`-based.
This change makes the header section responsive
and allows for greater flexibility in terms of how elements can be arranged or displayed in individual apps, including at different screen sizes.
The new layout has Bootstrap Flex classes at its core but also uses vanilla CSS for tweaks to text, margins or visibility of elements to make it easier to override these downstream (i.e. without having to always resort to `important` rules to trump Bootstrap's `important` defaults).
Some elements are now left off small screens by default for better use of screen real estate.
Elements are primarily referenced/manipulated via class selectors rather than ID selectors to keep the calculated weight of CSS rules (specificity) low; additional "empty"/ unused IDs could always be added to elements later on to allow devs to "skip" weight calculations (by basing overrides directly on IDs, which carry the most weight).

Solves: #1540