### PR TITLE
fix(apis_entities): use heading only where relevant

### DIFF
--- a/apis_core/apis_entities/templates/apis_entities/partials/next_url.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/next_url.html
@@ -1,8 +1,6 @@
 {% if object.get_next_id %}
-  <h2>
-    <a class="next-in-list"
-       href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_next_id %}">
-      <span class="material-symbols-outlined">chevron_right</span>
-    </a>
-  </h2>
+  <a class="next-in-list"
+     href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_next_id %}">
+    <span class="material-symbols-outlined">chevron_right</span>
+  </a>
 {% endif %}

--- a/apis_core/apis_entities/templates/apis_entities/partials/prev_url.html
+++ b/apis_core/apis_entities/templates/apis_entities/partials/prev_url.html
@@ -1,8 +1,6 @@
 {% if object.get_prev_id %}
-  <h2>
-    <a class="prev-in-list"
-       href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_prev_id %}">
-      <span class="material-symbols-outlined">chevron_left</span>
-    </a>
-  </h2>
+  <a class="prev-in-list"
+     href="{% url request.resolver_match.view_name request.resolver_match.kwargs.contenttype object.get_prev_id %}">
+    <span class="material-symbols-outlined">chevron_left</span>
+  </a>
 {% endif %}


### PR DESCRIPTION
Removes `<h2>` tags surrounding links for previous
and next items in single object view, which exist in
addition to the same heading level used for name of
the current object.
The latter can be considered the (only relevant)
section heading for the rest of the page, but the
links to sibling items do not serve the same purpose.

Resolves: #2120