### PR TITLE
fix(apis_entities): use correct heading size

### DIFF
--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -1,5 +1,5 @@
 /* single object view header */
-#single-object-header h2 {
+#single-object-header h1 {
     text-align: center;
 }
 

--- a/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity.html
+++ b/apis_core/apis_entities/templates/apis_core/apis_entities/abstractentity.html
@@ -19,7 +19,7 @@
           <div id="single-object-header" class="row">
             <div class="col-md-2">{% include "apis_entities/partials/prev_url.html" %}</div>
             <div class="col-md-8">
-              <h2>
+              <h1>
                 {% include "apis_entities/partials/listview_url.html" %}
                 {{ object }}
                 <a href="{{ object.get_absolute_url }}">
@@ -29,7 +29,7 @@
                 {% block object-actions %}
                 {% endblock object-actions %}
 
-              </h2>
+              </h1>
             </div>
             <div class="col-md-2">{% include "apis_entities/partials/next_url.html" %}</div>
           </div>


### PR DESCRIPTION
Switch heading used for object descriptor in single entity object view from second level `<h2>` heading to `<h1>` so as not to skip a heading level.

Fixes: #2116