### PR TITLE
fix(generic): fix Django Debug Toolbar error

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -27,7 +27,7 @@ class GenericModel(models.Model):
     def __repr__(self):
         if id := getattr(self, "id", None):
             return super().__repr__() + f" (ID: {id})"
-        return super().__repr__()
+        return repr(super())
 
     @property
     def content_type(self):


### PR DESCRIPTION
Fix `AttributeError` thrown by Django Debug Toolbar (middleware) since version `v0.53.0.` by replacing return statement of `super().__repr__()` with
`repr(super())`.

Closes: #2089