### PR TITLE
fix(history): don't let APISHistoricalRecords inherit from GenericModel

### DIFF
--- a/apis_core/history/models.py
+++ b/apis_core/history/models.py
@@ -16,7 +16,7 @@ from simple_history.models import HistoricalRecords
 from apis_core.generic.abc import GenericModel
 
 
-class APISHistoricalRecords(HistoricalRecords, GenericModel):
+class APISHistoricalRecords(HistoricalRecords):
     def get_m2m_fields_from_model(self, model):
         # Change the original simple history function to also return m2m fields
         m2m_fields = []


### PR DESCRIPTION
APISHistoricalRecords is not a model. It was configured to inherit from
GenericModel, though This was not a problem so far, because GenericModel
was a simple Python Mixin, but with 34a28fa the GenericModel class
became an abstract Django model.
That led to Django interpreting all the `history` attributes of
versioned models as DeferredAttributes fields, which they are not. Given
that fields have attributes that a GenericModel does not have, this led
to an exception.

Closes: #2089
