### PR TITLE
fix(generic): only add table columns with non-field names

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -196,10 +196,13 @@ class List(
         ]
         # we add any annotated fields to that
         choices += [(key, key) for key in self.get_queryset().query.annotations.keys()]
-        # lets also add the custom table fields
+        # add custom table columns whose names do not match model field names;
+        # this covers columns for extra (non-field) data but also applies to
+        # columns for fields which are set on the table using different names
         choices += [
             (key.name, capfirst(str(key) or key.name or "Nameless column"))
             for key in self.get_table().columns
+            if key.name not in [f[0] for f in choices]
         ]
         # now we drop all the choices that are listed in columns_exclude
         choices = list(filter(lambda x: x[0] not in columns_exclude, choices))


### PR DESCRIPTION
When adding custom table columns to the `choices`
columns selector, only add columns whose names do
not already appear in `choices`, i.e. columns whose names do not match model field names.
This applies to columns used for extra data but also field columns whose column names do not match the
original field names (meaning columns which point to specific model fields via "accessor", but which are not given the same names on the table).

Closes: #2143