### PR TITLE
fix(generic): readd missing ContentType import

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -7,6 +7,7 @@ from django import forms, http
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import URLValidator


### PR DESCRIPTION
The import was removed in 9c117ea but is then used again in 374bd7c
