### PR TITLE
fix(apis_entities): dropping float CSS rules

### DIFF
--- a/apis_core/apis_entities/static/css/apis_entities.css
+++ b/apis_core/apis_entities/static/css/apis_entities.css
@@ -2,12 +2,3 @@
 #single-object-header h2 {
     text-align: center;
 }
-
-/* navigation between objects (in list) from single object view header */
-.prev-in-list {
-    float: right;
-}
-
-.next-in-list {
-    float: left;
-}


### PR DESCRIPTION
float should not be used anymore and the rules don't improve that much
anyway

Closes: #1540
