### PR TITLE
fix(generic): raise ValidationError instead of ValueError

### DIFF
--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -150,7 +150,7 @@ class GenericSelectMergeOrEnrichForm(forms.Form):
         uri = self.cleaned_data["uri"]
         if uri.isdigit() or self.content_type.model_class().valid_import_url(uri):
             return uri
-        raise ValueError(f"{uri} is neither an ID nor something we can import")
+        raise ValidationError(f"{uri} is neither an ID nor something we can import")
 
 
 class GenericMergeWithForm(forms.Form):


### PR DESCRIPTION
The ValueError raises an exception. If we use a ValidationError instead,
the form shows the error and the user can act accordingly.

Closes: #2199
Closes: #2142
