### PR TITLE
fix(relations): don't list symmetric relations twice

### DIFF
--- a/apis_core/relations/templates/relations/partials/create_relation_link.html
+++ b/apis_core/relations/templates/relations/partials/create_relation_link.html
@@ -11,13 +11,15 @@
     {% if linkify %}</a>{% endif %}
 {% endif %}
 {% if object.content_type.model_class is relation_type.model_class.obj_model_type %}
-  {% if linkify %}
-    <a href="{{ relation_type.model_class.get_createview_url }}?obj_content_type={{ object.content_type.id }}&sobj_object_id={{ object.id }}"
-       class="text-decoration-none"
-       hx-get="{{ baseurlform }}?obj_content_type={{ object.content_type.id }}&obj_object_id={{ object.id }}&hx=true&relation_types={{ relation_types }}&replace_id={{ replace_id }}&reverse=True&table_suffix={{ table_suffix }}"
-       hx-target="#relation-dialog-content"
-       onclick="relationdialog.showModal();">
-    {% endif %}
-    <span class="reverse{% if badge %} badge bg-secondary{% else %} btn btn-sm btn-outline-secondary{% endif %}">{{ relation_type.model_class.reverse_name }}</span>
-    {% if linkify %}</a>{% endif %}
+  {% if relation_type.model_class.name != relation_type.model_class.reverse_name %}
+    {% if linkify %}
+      <a href="{{ relation_type.model_class.get_createview_url }}?obj_content_type={{ object.content_type.id }}&sobj_object_id={{ object.id }}"
+         class="text-decoration-none"
+         hx-get="{{ baseurlform }}?obj_content_type={{ object.content_type.id }}&obj_object_id={{ object.id }}&hx=true&relation_types={{ relation_types }}&replace_id={{ replace_id }}&reverse=True&table_suffix={{ table_suffix }}"
+         hx-target="#relation-dialog-content"
+         onclick="relationdialog.showModal();">
+      {% endif %}
+      <span class="reverse{% if badge %} badge bg-secondary{% else %} btn btn-sm btn-outline-secondary{% endif %}">{{ relation_type.model_class.reverse_name }}</span>
+      {% if linkify %}</a>{% endif %}
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
If the `.name` and the `.reverse_name` of a relation are identical, we
only list them once, because in this case it does not make a difference
if the relation is object->subject or subject->object.

Closes: #1448
