### PR TITLE
fix(generic): fix typo in enrich view

### DIFF
--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -597,7 +597,7 @@ class Enrich(GenericModelMixin, PermissionRequiredMixin, FormView):
             if key.startswith("update_"):
                 key = key.removeprefix("update_")
                 data[key] = self.data[key]
-        data["_uris"] = [self.uri]
+        data["same_as"] = [self.uri] + data.get("same_as", [])
         if data:
             errors = self.object.import_data(data)
             for field, error in errors.items():


### PR DESCRIPTION
The attribute in the data dict that triggers the creation of URIs is
`same_as`, not `_uri`. To recreate the former behaviour of adding the
URI we enrich from to the URIs of the instance, we simply add this to
the `same_as` list.

Closes: #2204
