### PR TITLE
fix(generic): override content instead of col in import template

### DIFF
--- a/apis_core/generic/templates/generic/genericmodel_create.html
+++ b/apis_core/generic/templates/generic/genericmodel_create.html
@@ -6,9 +6,11 @@
   {% translate "Create" %}
 {% endblock title %}
 
-{% block col %}
-  <div class="card">
-    <div class="card-header">{% translate "Create" %}</div>
-    <div class="card-body">{% crispy form form.helper %}</div>
+{% block content %}
+  <div class="container-fluid">
+    <div class="card">
+      <div class="card-header">{% translate "Create" %}</div>
+      <div class="card-body">{% crispy form form.helper %}</div>
+    </div>
   </div>
-{% endblock col %}
+{% endblock content %}

--- a/apis_core/generic/templates/generic/genericmodel_detail.html
+++ b/apis_core/generic/templates/generic/genericmodel_detail.html
@@ -7,9 +7,11 @@
 
 {% if object %}
 
-  {% block col %}
-    {% template_list object suffix="_card.html" as template_list %}
-    {% include template_list %}
-  {% endblock col %}
+  {% block content %}
+    <div class="container-fluid">
+      {% template_list object suffix="_card.html" as template_list %}
+      {% include template_list %}
+    </div>
+  {% endblock content %}
 
 {% endif %}

--- a/apis_core/generic/templates/generic/genericmodel_form.html
+++ b/apis_core/generic/templates/generic/genericmodel_form.html
@@ -10,19 +10,21 @@
   {% endif %}
 {% endblock title %}
 
-{% block col %}
-  <div class="card">
-    <div class="card-header">
+{% block content %}
+  <div class="container-fluid">
+    <div class="card">
+      <div class="card-header">
 
-      {% block card-header-content %}
-        {% if object %}
-          {% blocktrans with object as object %}Edit {{ object }}{% endblocktrans %}
-        {% else %}
-          {% translate "Create" %}
-        {% endif %}
-      {% endblock card-header-content %}
+        {% block card-header-content %}
+          {% if object %}
+            {% blocktrans with object as object %}Edit {{ object }}{% endblocktrans %}
+          {% else %}
+            {% translate "Create" %}
+          {% endif %}
+        {% endblock card-header-content %}
 
+      </div>
+      <div class="card-body">{% crispy form form.helper %}</div>
     </div>
-    <div class="card-body">{% crispy form form.helper %}</div>
   </div>
-{% endblock col %}
+{% endblock content %}

--- a/apis_core/generic/templates/generic/genericmodel_import.html
+++ b/apis_core/generic/templates/generic/genericmodel_import.html
@@ -6,9 +6,11 @@
   {% translate "Import" %}
 {% endblock title %}
 
-{% block col %}
-  <div class="card">
-    <div class="card-header">{% translate "Import" %}</div>
-    <div class="card-body">{% crispy form form.helper %}</div>
+{% block content %}
+  <div class="container-fluid">
+    <div class="card">
+      <div class="card-header">{% translate "Import" %}</div>
+      <div class="card-body">{% crispy form form.helper %}</div>
+    </div>
   </div>
-{% endblock col %}
+{% endblock content %}

--- a/apis_core/generic/templates/generic/overview.html
+++ b/apis_core/generic/templates/generic/overview.html
@@ -1,25 +1,27 @@
 {% extends "generic/generic_content.html" %}
 {% load generic %}
 
-{% block col %}
-  <div class="card">
-    <div class="card-header">Overview</div>
-    <div class="card-body text-center">
-      {% genericmodel_content_types as contenttypes %}
-      {% regroup contenttypes|dictsort:"app_label" by app_label as contenttypes_by_app %}
-      {% for app in contenttypes_by_app %}
-        <div class="mb-5">
-          <h3>{{ app.grouper }}</h3>
-          {% for contenttype in app.list %}
-            <a href="{% url 'apis_core:generic:list' contenttype %}">
-              <button type="button" class="btn btn-outline-dark m-2">
-                {{ contenttype.name|capfirst }}
-                {{ contenttype|content_type_count }}
-              </button>
-            </a>
-          {% endfor %}
-        </div>
-      {% endfor %}
+{% block content %}
+  <div class="container-fluid">
+    <div class="card">
+      <div class="card-header">Overview</div>
+      <div class="card-body text-center">
+        {% genericmodel_content_types as contenttypes %}
+        {% regroup contenttypes|dictsort:"app_label" by app_label as contenttypes_by_app %}
+        {% for app in contenttypes_by_app %}
+          <div class="mb-5">
+            <h3>{{ app.grouper }}</h3>
+            {% for contenttype in app.list %}
+              <a href="{% url 'apis_core:generic:list' contenttype %}">
+                <button type="button" class="btn btn-outline-dark m-2">
+                  {{ contenttype.name|capfirst }}
+                  {{ contenttype|content_type_count }}
+                </button>
+              </a>
+            {% endfor %}
+          </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
-{% endblock col %}
+{% endblock content %}


### PR DESCRIPTION
The `col` block is targeted at sidebars and uses only as much space as
the inner html needs. Given that the import form does is not part of a
sidebar, it makse sense to not use the `col` and instead overload the
whole `content` block

Closes: #2218
