### PR TITLE
fix(generic): place header outside of `if` & add error message

### DIFF
--- a/apis_core/generic/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/generic/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-02 01:56-0500\n"
+"POT-Creation-Date: 2025-11-24 00:49-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,12 +106,9 @@ msgstr "Aktualisiere %(object)s"
 
 #: apis_core/generic/templates/generic/genericmodel_enrich.html
 #, python-format
-msgid ""
-"Updating <a href=\"%(url)s\">%(object)s</a> using the data from <a "
-"href=\"%(uri)s\">%(uri)s</a>"
+msgid "Updating <a href=\"%(url)s\">%(object)s</a> using the data from %(uri)s"
 msgstr ""
-"Aktualisiere <a href=\"%(url)s\">%(object)s</a> mit den Daten von <a "
-"href=\"%(uri)s\">%(uri)s</a>"
+"Aktualisiere <a href=\"%(url)s\">%(object)s</a> mit den Daten von %(uri)s"
 
 #: apis_core/generic/templates/generic/genericmodel_enrich.html
 #, python-format

--- a/apis_core/generic/templates/generic/genericmodel_enrich.html
+++ b/apis_core/generic/templates/generic/genericmodel_enrich.html
@@ -10,7 +10,7 @@
 {% block content %}
   <div class="container">
     <h4 class="mb-4">
-      {% blocktranslate with url=object.get_absolute_url %}Updating <a href="{{ url }}">{{ object }}</a> using the data from <a href="{{ uri }}">{{ uri }}</a>{% endblocktranslate %}
+      {% blocktranslate with url=object.get_absolute_url uri=uri|urlize %}Updating <a href="{{ url }}">{{ object }}</a> using the data from {{ uri }}{% endblocktranslate %}
     </h4>
     {% if form.fields %}
       {% crispy form form.helper %}


### PR DESCRIPTION
The header of the enrich dialog was only shown if there were fields in
the form, which was sometimes not the case. The header is now always
shown and an informative message is displayed instead of the form if
there are no fields that can be imported.

Closes: #2220
