### PR TITLE
refactor(generic): move column selector out of filterset

### DIFF
--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -20,6 +20,19 @@ from apis_core.generic.forms.fields import ModelImportChoiceField
 logger = logging.getLogger(__name__)
 
 
+class ColumnsSelectorForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        choices = kwargs.pop("choices", [])
+        super().__init__(*args, **kwargs)
+        initial = kwargs.get("initial", {}).get("choices", [])
+        self.fields["columns"] = forms.MultipleChoiceField(
+            required=False, choices=choices, initial=initial
+        )
+        self.helper = FormHelper()
+        self.helper.form_method = "GET"
+        self.helper.form_tag = False
+
+
 class GenericImportForm(forms.Form):
     class Meta:
         fields = []
@@ -43,23 +56,15 @@ class GenericFilterSetForm(forms.Form):
     """
     FilterSet form for generic models
     Adds a submit button using the django crispy form helper
-    Adds a `columns` selector that lists all the fields from
-    the model
     """
 
     columns_exclude = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         self.helper = FormHelper(self)
         self.helper.form_method = "GET"
-        self.helper.add_input(Submit("submit", _("Submit")))
-
-    def clean(self):
-        self.cleaned_data = super().clean()
-        self.cleaned_data.pop("columns", None)
-        return self.cleaned_data
+        self.helper.form_tag = False
 
 
 class GenericModelForm(forms.ModelForm):

--- a/apis_core/generic/templates/generic/genericmodel_list.html
+++ b/apis_core/generic/templates/generic/genericmodel_list.html
@@ -33,12 +33,20 @@
         </div>
       </div>
       <div class="card-body">
-        {% if filter.form.errors %}<div class="alert alert-warning">{{ filter.form.errors }}</div>{% endif %}
+        <form method="get">
+          {% crispy columns_selector columns_selector.helper %}
+          {% if filter.form.errors %}<div class="alert alert-warning">{{ filter.form.errors }}</div>{% endif %}
 
-        {% block filter %}
-          {% crispy filter.form filter.form.helper %}
-        {% endblock filter %}
+          {% block filter %}
+            {% crispy filter.form filter.form.helper %}
+          {% endblock filter %}
 
+          <input type="submit"
+                 name="submit"
+                 value="Submit"
+                 class="btn btn-primary"
+                 id="submit-id-submit">
+        </form>
       </div>
       <div class="card-footer text-muted">
         <a class="btn btn-outline-secondary"  href=".">{% translate "Reset filter" %}</a>

--- a/apis_core/generic/tests/test_generic.py
+++ b/apis_core/generic/tests/test_generic.py
@@ -198,7 +198,7 @@ class TestGeneric(object):
         response = admin_client.get("/generic_tests.person/")
         assertContains(
             response,
-            '<select name="columns" class="selectmultiple form-select" id="id_columns" multiple>',
+            '<select name="choices-columns" class="selectmultiple form-select" id="id_choices-columns" multiple>',
         )
         assertContains(response, '<option value="id" selected>ID</option>')
         assertContains(response, '<option value="first_name">First name</option>')


### PR DESCRIPTION
Having the column selector in the filterset leads to too much problems &
technical debt. This change moves the colums selector into its own form.
Both forms (the filterset form and the column selector form) are now
included in the view with prefixes and put into one `<form>` element.

Closes: #2214
