### PR TITLE
fix(utils): implement workaround for gnd problem in rdf parsing

### DIFF
--- a/apis_core/utils/rdf.py
+++ b/apis_core/utils/rdf.py
@@ -124,8 +124,12 @@ def get_value_graph(graph: Graph, curies: str | list[str]) -> list:
 def load_uri_using_path(uri, configfile: Path) -> dict:
     uri = get_normalized_uri(uri)
     graph = Graph()
+    # workaround for a bug in d-nb: with the default list of accept
+    # headers of rdflib, d-nb sometimes returns json-ld and sometimes turtle
+    # with json-ld, rdflib has problems finding the namespaces
+    format = "turtle" if uri.startswith("https://d-nb.info/gnd/") else None
     try:
-        graph.parse(uri)
+        graph.parse(uri, format=format)
     except ParserError as e:
         logger.info(e)
 


### PR DESCRIPTION
When an rdflib graph parses an URI, it sends a bunch of default accept
headers. d-nb.info then sometimes returns turtle and sometimes returns
json-ld format. With json-ld, this leads to problems because the
namespace manager does not find the namespaces from our filters and the
filter therefore don't work. So for d-nb.info we force the format to be
"ttl".
