### PR TITLE
fix(generic): use nur instead of uri when setting the import uri

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -187,7 +187,7 @@ class GenericModel(models.Model):
         data = cls.fetch_from(uri) or {}
         if allow_empty or data:
             instance = cls()
-            instance._uris = [data.get("uri", uri)]
+            instance._uris = [data.get("uri", nuri)]
             instance.save()
             instance.import_data(data)
             return instance


### PR DESCRIPTION
This small change was lost in a rebase
