### PR TITLE
fix(apis_entities): fix typo in E74_GroupFromDNB config

### DIFF
--- a/apis_core/apis_entities/templates/triple_configs/E74_GroupFromDNB.toml
+++ b/apis_core/apis_entities/templates/triple_configs/E74_GroupFromDNB.toml
@@ -29,5 +29,5 @@
 label = ["gndo:preferredNameForTheCorporateBody", "gndo:variantNameForTheCorporateBody"]
 start_date = "gndo:dateOfEstablishment"
 end_date = "gndo:dateOfTermination"
-sameas = "owl:sameAs"
+same_as = "owl:sameAs"
 {% endblock attributes %}


### PR DESCRIPTION
The attribute we want is called `same_as` not `sameas`. Only from
the list in `same_as` new URIs are created.

Closes: #2245
