### PR TITLE
fix(utils)!: drop deprecated function `get_entity_settings_by_modelname`

### DIFF
--- a/apis_core/utils/settings.py
+++ b/apis_core/utils/settings.py
@@ -4,25 +4,11 @@
 import logging
 import tomllib
 from urllib.parse import urlparse
-from warnings import deprecated
 
 from django.conf import settings
 from django.template.utils import get_app_template_dirs
 
 logger = logging.getLogger(__name__)
-
-
-@deprecated("Not used anywhere, so it will be dropped.")
-def get_entity_settings_by_modelname(entity: str = None) -> dict:
-    """
-    return the settings for a specific entity or the dict for all entities
-    if no entity is given
-    """
-    apis_entities = getattr(settings, "APIS_ENTITIES", {})
-    if entity:
-        # lookup entity settings by name and by capitalized name
-        return apis_entities.get(entity, apis_entities.get(entity.capitalize(), {}))
-    return apis_entities
 
 
 def dict_from_toml_directory(directory: str) -> dict:


### PR DESCRIPTION
The `get_entity_settings_by_modelname` function was deprecated in
version 0.60, so we drop it now
