### PR TITLE
chore: move dev dependencies to dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,12 @@ dependencies = [
     "httpx>=0.28.1",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
     "coverage==7.5.3",
     "deptry==0.23",
     "djlint==1.36.4",
@@ -39,12 +43,6 @@ dev-dependencies = [
     "ruff==0.11.2",
     "pytest-django>=4.11.1",
 ]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[dependency-groups]
 docs = [
     "markdown-include>=0.8.1",
     "mkdocs>=1.6.1",


### PR DESCRIPTION
Move development dependencies from legacy field used by
`uv` to standardised way of grouping dependencies via
dependency groups – like we are already doing for `docs`
dependencies.
This gets rid of a deprecation warning issued by `uv`.

Resolves: #2301
