### PR TITLE
feat(generic): reorder action buttons

### DIFF
--- a/apis_core/generic/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/generic/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-24 00:49-0600\n"
+"POT-Creation-Date: 2026-03-24 05:15-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,11 @@ msgid "Other models"
 msgstr "Andere Modelle"
 
 #: apis_core/generic/templates/columns/actions.html
+#: apis_core/generic/templates/columns/view.html
+msgid "view"
+msgstr "ansehen"
+
+#: apis_core/generic/templates/columns/actions.html
 #: apis_core/generic/templates/columns/edit.html
 msgid "edit"
 msgstr "bearbeiten"
@@ -58,11 +63,6 @@ msgstr "löschen"
 #, python-format
 msgid "Are your sure you want to delete %(record)s?"
 msgstr "Wollen sie %(record)s sicher löschen?"
-
-#: apis_core/generic/templates/columns/actions.html
-#: apis_core/generic/templates/columns/view.html
-msgid "view"
-msgstr "ansehen"
 
 #: apis_core/generic/templates/columns/actions.html
 #: apis_core/generic/templates/columns/duplicate.html

--- a/apis_core/generic/templates/columns/actions.html
+++ b/apis_core/generic/templates/columns/actions.html
@@ -1,5 +1,10 @@
 {% load i18n %}
 <div class="actions-column">
+  {% if record.get_view_permission in perms %}
+    <a title="{% translate "view" %}"
+       href="{{ record.get_absolute_url }}"
+       class="object-view"><span class="material-symbols-outlined">visibility</span></a>
+  {% endif %}
   {% if record.get_change_permission in perms %}
     <a title="{% translate "edit" %}"
        href="{{ record.get_edit_url }}"
@@ -13,11 +18,6 @@
        hx-swap="outerHTML swap:0.3s"
        href="{{ record.get_delete_url }}"
        class="object-delete"><span class="material-symbols-outlined">delete</span></a>
-  {% endif %}
-  {% if record.get_view_permission in perms %}
-    <a title="{% translate "view" %}"
-       href="{{ record.get_absolute_url }}"
-       class="object-view"><span class="material-symbols-outlined">visibility</span></a>
   {% endif %}
   {% if record.get_add_permission in perms %}
     <a title="{% translate "duplicate" %}"


### PR DESCRIPTION
Change order of action buttons from existing to:
view, edit, delete, duplicate based on assumed
order of relevancy and to guard against users
worrying about placement of the delete action.
See #2318 for a more comprehensive explanation.
