### PR TITLE
fix: add meta tag to use strict-origin-when-cross-origin referrer policy

### DIFF
--- a/apis_core/core/templates/base.html
+++ b/apis_core/core/templates/base.html
@@ -21,6 +21,7 @@
             content="APIS Core{% if debug %} {% apis_version %}{% endif %}">
       <meta name="htmx-config"
             content='{"responseHandling":[ {"code":"204", "swap": true}, {"code":"[23]..", "swap": true}, {"code":"[45]..", "swap": false, "error":true}, {"code":"...", "swap": false}]}' />
+      <meta name="referrer" content="strict-origin-when-cross-origin">
     {% endblock meta %}
 
     {% block styles %}


### PR DESCRIPTION
fixes #2321

Added a `<meta name="referrer" content="strict-origin-when-cross-origin">` tag to the `base.html` template