### PR TITLE
fix(utils): handle unkown namespace exception

### DIFF
--- a/apis_core/utils/rdf.py
+++ b/apis_core/utils/rdf.py
@@ -142,7 +142,11 @@ def get_value_graph(graph: Graph, curies: str | list[str]) -> list:
     if isinstance(curies, str):
         curies = [curies]
     for curie in curies:
-        results = graph.query(build_sparql_query(curie))
+        try:
+            results = graph.query(build_sparql_query(curie))
+        except Exception as e:
+            logger.debug("Could not parse query: %s", e)
+            results = []
         objects = [result[0] for result in results]
         for obj in objects:
             if isinstance(obj, BNode):


### PR DESCRIPTION
rdflib only adds the namespaces to the graph that are actually used in
on of the triples. It throws an exception when it encounters a
namespace prefix it doesn't know (even if it was defined in the source
data file).
We handle this case by catching the exception and adding a debug log
statement.

Closes: #2340
