### PR TITLE
ci(check-static): look for leading slashes in static template tag

### DIFF
--- a/.github/workflows/check-static-template-tag.yml
+++ b/.github/workflows/check-static-template-tag.yml
@@ -1,0 +1,17 @@
+#SPDX-FileCopyrightText: 2026 Birger Schacht
+#SPDX-License-Identifier: MIT
+
+name: Check for leading slashes in static template tags
+on:
+  pull_request:
+    paths:
+      - "**.html"
+
+jobs:
+  check-slash-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Look for leading slashes
+        run: |
+          ! grep -r 'static "/' apis_core


### PR DESCRIPTION
The argument for the {% static 'foo/bar.ext' %} template tag should
not start with a leading slash because that leads to errors in some
setups.

Closes: #2013
