### PR TITLE
feat(collections): add missing translations for filter labels

### DIFF
--- a/apis_core/collections/filters.py
+++ b/apis_core/collections/filters.py
@@ -4,6 +4,7 @@ import django_filters
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
+from django.utils.translation import pgettext
 
 from apis_core.generic.forms.fields import RowColumnMultiValueField
 
@@ -21,7 +22,10 @@ class CollectionsIncludeExcludeFilter(django_filters.filters.ModelMultipleChoice
     def field(self):
         return RowColumnMultiValueField(
             fields=[super().field, super().field],
-            labels=["include", "exclude"],
+            labels=[
+                pgettext("filter list by collections", "include"),
+                pgettext("filter list by collections", "exclude"),
+            ],
             required=self.extra["required"],
         )
 

--- a/apis_core/collections/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/collections/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-04 04:43-0500\n"
+"POT-Creation-Date: 2026-05-13 12:32-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apis_core/collections/filters.py
+msgctxt "filter list by collections"
+msgid "include"
+msgstr "inkludiere"
+
+#: apis_core/collections/filters.py
+msgctxt "filter list by collections"
+msgid "exclude"
+msgstr "exkludiere"
 
 #: apis_core/collections/forms.py apis_core/collections/templates/base.html
 msgid "Collections"


### PR DESCRIPTION
Translate labels for form fields for filtering list view by `Collections`.
Uses `pgettext` rather than `gettext` to add contextual markers to force the included translations (overrides a built-in translation for one – and only one – of the words used, which is defaulted to otherwise).