### PR TITLE
feat(generic): add explicit label for columns selector

### DIFF
--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -21,7 +21,10 @@ logger = logging.getLogger(__name__)
 
 
 class ColumnsSelectorForm(forms.Form):
-    columns = forms.MultipleChoiceField(required=False)
+    columns = forms.MultipleChoiceField(
+        required=False,
+        label=_("Visible columns"),
+    )
     remember = forms.BooleanField(required=False, label="Remember selected columns")
 
     def __init__(self, *args, **kwargs):

--- a/apis_core/generic/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/generic/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-24 00:49-0600\n"
+"POT-Creation-Date: 2026-05-18 05:17-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apis_core/generic/forms/__init__.py
+msgid "Visible columns"
+msgstr "Sichtbare Spalten"
 
 #: apis_core/generic/forms/__init__.py
 msgid "Submit"


### PR DESCRIPTION
Add `label` for filter form select element for columns to allow for a German translation to be added.
Use wording in both English and German which makes clear(er) that the column selection applies to the list display. (Just "columns" is ambiguous since the select element is part of the filter form and could also be understood to affect how filters are applied or displayed.)