### PR TITLE
ci(dependabot): drop the `pip` package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
   - package-ecosystem: "uv"
     directory: "/"
     schedule:


### PR DESCRIPTION
The `uv` ecosystem now updates both `pyproject.toml` and `uv.lock`
