### PR TITLE
fix(entities): use `pk` for attribute to make `ty` happy

### DIFF
--- a/apis_core/entities/abc.py
+++ b/apis_core/entities/abc.py
@@ -8,4 +8,4 @@ class Entity(models.Model):
 
     @property
     def get_canonical_url(self):
-        return reverse("apis_core:canonical-entity", args=[self.id])
+        return reverse("apis_core:canonical-entity", args=[self.pk])


### PR DESCRIPTION
`.id` is a dynamic property which `ty` can not handle (yet?), so lets
use `.pk` instead which leads to the same result.
