### PR TITLE
fix(sample_project): add documentation before core in the app list

### DIFF
--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     # swagger ui generation
     "drf_spectacular",
     # The APIS apps
+    "apis_core.documentation",
     "apis_core.generic",
     # APIS collections provide a collection model similar to
     # SKOS collections and allow tagging of content
@@ -52,7 +53,6 @@ INSTALLED_APPS = [
     # The core APIS apps come last, so other apps can override
     # and extend their templates
     "apis_core.core",
-    "apis_core.documentation",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
This way the menu item is included in the main menu, otherwise its
simply dropped.
