### PR TITLE
birger/1727 redirect

### DIFF
--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -100,12 +100,18 @@ class GenericModel(models.Model):
         return reverse("apis_core:generic:selectmergeorenrich", args=[ct, self.id])
 
     def get_create_success_url(self, request: Optional[HttpRequest] = None):
+        if request and request.GET.get("redirect", False):
+            return request.GET.get("redirect")
         return self.get_absolute_url()
 
     def get_update_success_url(self, request: Optional[HttpRequest] = None):
+        if request and request.GET.get("redirect", False):
+            return request.GET.get("redirect")
         return self.get_edit_url()
 
     def get_delete_success_url(self, request: Optional[HttpRequest] = None):
+        if request and request.GET.get("redirect", False):
+            return request.GET.get("redirect")
         return self.get_listview_url()
 
     def get_api_detail_endpoint(self):

--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Tuple
+from typing import Optional, Tuple
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
@@ -9,6 +9,7 @@ from django.db.models import BooleanField, CharField, TextField
 from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.db.models.query import QuerySet
 from django.forms import model_to_dict
+from django.http.request import HttpRequest
 from django.urls import reverse
 
 from apis_core.generic.helpers import mro_paths, permission_fullname
@@ -98,10 +99,10 @@ class GenericModel(models.Model):
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:generic:selectmergeorenrich", args=[ct, self.id])
 
-    def get_create_success_url(self):
+    def get_create_success_url(self, request: Optional[HttpRequest] = None):
         return self.get_absolute_url()
 
-    def get_update_success_url(self):
+    def get_update_success_url(self, request: Optional[HttpRequest] = None):
         return self.get_edit_url()
 
     def get_api_detail_endpoint(self):

--- a/apis_core/generic/abc.py
+++ b/apis_core/generic/abc.py
@@ -105,6 +105,9 @@ class GenericModel(models.Model):
     def get_update_success_url(self, request: Optional[HttpRequest] = None):
         return self.get_edit_url()
 
+    def get_delete_success_url(self, request: Optional[HttpRequest] = None):
+        return self.get_listview_url()
+
     def get_api_detail_endpoint(self):
         ct = ContentType.objects.get_for_model(self)
         return reverse("apis_core:generic:genericmodelapi-detail", args=[ct, self.id])

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -21,7 +21,6 @@ from django.http import QueryDict
 from django.shortcuts import get_object_or_404, redirect
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import select_template
-from django.urls import reverse
 from django.utils.text import capfirst
 from django.views import View
 from django.views.generic import DetailView
@@ -383,12 +382,7 @@ class Delete(GenericModelMixin, GenericModelPermissionRequiredMixin, DeleteView)
     permission_action_required = "delete"
 
     def get_success_url(self):
-        if redirect := self.request.GET.get("redirect"):
-            return redirect
-        return reverse(
-            "apis_core:generic:list",
-            args=[self.request.resolver_match.kwargs["contenttype"]],
-        )
+        return self.object.get_delete_success_url(request=self.request)
 
 
 class Update(

--- a/apis_core/generic/views.py
+++ b/apis_core/generic/views.py
@@ -370,7 +370,7 @@ class Create(
         return template.render({"object": self.object})
 
     def get_success_url(self):
-        return self.object.get_create_success_url()
+        return self.object.get_create_success_url(request=self.request)
 
 
 class Delete(GenericModelMixin, GenericModelPermissionRequiredMixin, DeleteView):
@@ -413,7 +413,7 @@ class Update(
         return template.render({"object": self.object})
 
     def get_success_url(self):
-        return self.object.get_update_success_url()
+        return self.object.get_update_success_url(request=self.request)
 
 
 class Duplicate(GenericModelMixin, GenericModelPermissionRequiredMixin, View):

--- a/apis_core/relations/locale/de/LC_MESSAGES/django.po
+++ b/apis_core/relations/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-30 03:59-0500\n"
+"POT-Creation-Date: 2026-07-02 07:20-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,6 +77,27 @@ msgstr "Alle Relationen"
 #: apis_core/relations/templates/base.html
 msgid "Filter relations..."
 msgstr "Relationen filtern..."
+
+#: apis_core/relations/templates/columns/relation_actions.html
+msgid "view"
+msgstr "ansehen"
+
+#: apis_core/relations/templates/columns/relation_actions.html
+msgid "edit"
+msgstr "bearbeiten"
+
+#: apis_core/relations/templates/columns/relation_actions.html
+msgid "delete"
+msgstr "löschen"
+
+#: apis_core/relations/templates/columns/relation_actions.html
+#, python-format
+msgid "Are your sure you want to delete %(record)s?"
+msgstr "Wollen sie %(record)s sicher löschen?"
+
+#: apis_core/relations/templates/columns/relation_actions.html
+msgid "duplicate"
+msgstr ""
 
 #: apis_core/relations/templates/relations/relation_form.html
 msgid "Edit relation"

--- a/apis_core/relations/models.py
+++ b/apis_core/relations/models.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+from typing import Optional
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -7,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Case, When
 from django.db.models.base import ModelBase
+from django.http.request import HttpRequest
 from model_utils.managers import InheritanceManager
 
 from apis_core.generic.abc import GenericModel
@@ -175,3 +177,8 @@ class Relation(GenericModel, models.Model, metaclass=RelationModelBase):
         if cls.name() != cls.reverse_name():
             return f"{cls.name()} - {cls.reverse_name()}"
         return cls.name()
+
+    def get_update_success_url(self, request: Optional[HttpRequest] = None):
+        if request and request.GET.get("redirect", False):
+            return super().get_update_success_url(request)
+        return self.get_absolute_url()

--- a/apis_core/relations/tables.py
+++ b/apis_core/relations/tables.py
@@ -1,4 +1,8 @@
-from apis_core.generic.tables import CustomTemplateColumn, GenericTable
+from apis_core.generic.tables import ActionsColumn, CustomTemplateColumn, GenericTable
+
+
+class RelationActionsColumn(ActionsColumn):
+    template_name = "columns/relation_actions.html"
 
 
 class RelationColumn(CustomTemplateColumn):
@@ -8,6 +12,7 @@ class RelationColumn(CustomTemplateColumn):
 
 class RelationsListTable(GenericTable):
     relation = RelationColumn()
+    actions = RelationActionsColumn()
 
     class Meta:
         attrs = {"class": "table-sm"}

--- a/apis_core/relations/templates/columns/relation_actions.html
+++ b/apis_core/relations/templates/columns/relation_actions.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+<div class="actions-column">
+  {% if record.get_view_permission in perms %}
+    <a title="{% translate "view" %}"
+       href="{{ record.get_absolute_url }}"
+       class="object-view"><span class="material-symbols-outlined">visibility</span></a>
+  {% endif %}
+  {% if record.get_change_permission in perms %}
+    <a title="{% translate "edit" %}"
+       href="{{ record.get_edit_url }}?redirect={{ request.path }}"
+       class="object-edit"><span class="material-symbols-outlined">edit</span></a>
+  {% endif %}
+  {% if record.get_delete_permission in perms %}
+    <a title="{% translate "delete" %}"
+       hx-delete="{{ record.get_api_detail_endpoint }}"
+       hx-confirm="{% blocktranslate %}Are your sure you want to delete {{ record }}?{% endblocktranslate %}"
+       hx-target="closest tr"
+       hx-swap="outerHTML swap:0.3s"
+       href="{{ record.get_delete_url }}"
+       class="object-delete"><span class="material-symbols-outlined">delete</span></a>
+  {% endif %}
+  {% if record.get_add_permission in perms %}
+    <a title="{% translate "duplicate" %}"
+       class="object-duplicate"
+       href="{{ record.get_duplicate_url }}">
+      <span class="material-symbols-outlined">content_copy</span></a>
+  {% endif %}
+</div>


### PR DESCRIPTION
- **feat(generic): optinally pass the request object to _success_url methods**
- **feat(generic): add a `get_delete_success_url` method for the Delete view**
- **feat(generic): handle the `?redirect` parameter in success_url methods**
- **feat(generic): use `get_delete_success_url` instead of view logic**
- **feat(generic): pass `request` to `get_*_success_url` methods**
- **feat(relations): go to relation detail view after updating**
- **feat(relations): override actions column for relations**

Closes: #1727