### PR TITLE
feat(generic): use default container instead of fluid container

### DIFF
--- a/apis_core/generic/templates/generic/genericmodel_detail.html
+++ b/apis_core/generic/templates/generic/genericmodel_detail.html
@@ -8,7 +8,7 @@
 {% if object %}
 
   {% block content %}
-    <div class="container-fluid">
+    <div class="container">
       {% template_list object prefix="partials/" suffix="_card.html" as template_list %}
       {% include template_list %}
     </div>


### PR DESCRIPTION
The `.container-fluid` class is always width: 100% which is not really
nice to work with on big screens. It is better to use the default
`.container` class wich has a different `max-width` for different
breakpoints.
