### PR TITLE
refactor(generic)!: rename `template_list` to `model_mro_templates`

### DIFF
--- a/apis_core/entities/templates/entities/e53_place_detail.html
+++ b/apis_core/entities/templates/entities/e53_place_detail.html
@@ -9,7 +9,7 @@
 
 {% block col-zero %}
   <div class="card">
-    {% template_list object prefix="partials/" suffix="_card_table.html" as template_list %}
+    {% model_mro_templates object prefix="partials/" suffix="_card_table.html" as template_list %}
     <div class="card-body">{% include template_list %}</div>
     <div class="card-body pt-0">
       <table class="table table-hover table-bordered">

--- a/apis_core/entities/templates/entities/entity_detail.html
+++ b/apis_core/entities/templates/entities/entity_detail.html
@@ -3,7 +3,7 @@
 
 {% block col-zero %}
   <div class="card">
-    {% template_list object prefix="partials/" suffix="_card_table.html" as template_list %}
+    {% model_mro_templates object prefix="partials/" suffix="_card_table.html" as template_list %}
     <div class="card-body">{% include template_list %}</div>
     <div class="card-footer">{% include "entities/partials/linked_open_data.html" %}</div>
   </div>

--- a/apis_core/generic/templates/generic/genericmodel_detail.html
+++ b/apis_core/generic/templates/generic/genericmodel_detail.html
@@ -9,7 +9,7 @@
 
   {% block content %}
     <div class="container-fluid">
-      {% template_list object prefix="partials/" suffix="_card.html" as template_list %}
+      {% model_mro_templates object prefix="partials/" suffix="_card.html" as template_list %}
       {% include template_list %}
     </div>
   {% endblock content %}

--- a/apis_core/generic/templates/generic/partials/genericmodel_card.html
+++ b/apis_core/generic/templates/generic/partials/genericmodel_card.html
@@ -10,7 +10,7 @@
   <div class="card-body">
 
     {% block card-body %}
-      {% template_list object prefix="partials/" suffix="_card_table.html" as template_list %}
+      {% model_mro_templates object prefix="partials/" suffix="_card_table.html" as template_list %}
       {% include template_list %}
     {% endblock card-body %}
 

--- a/apis_core/generic/templatetags/generic.py
+++ b/apis_core/generic/templatetags/generic.py
@@ -112,7 +112,7 @@ def content_type_count(content_type):
 
 
 @register.simple_tag
-def template_list(obj, folder="", prefix="", suffix=""):
+def model_mro_templates(obj, folder="", prefix="", suffix=""):
     return template_names_via_mro(
         type(obj), folder=folder, prefix=prefix, suffix=suffix
     )

--- a/apis_core/history/templates/apis_core/history/apishistorytablebase_detail.html
+++ b/apis_core/history/templates/apis_core/history/apishistorytablebase_detail.html
@@ -10,7 +10,7 @@
 
 {% block col-zero %}
   <div class="card">
-    {% template_list object prefix="partials/" suffix="_card_table.html" as template_list %}
+    {% model_mro_templates object prefix="partials/" suffix="_card_table.html" as template_list %}
     <div class="card-body">{% include template_list %}</div>
   </div>
 {% endblock col-zero %}


### PR DESCRIPTION
BREAKING-CHANGE: The `generic.template_list` templatetag was renamed to
`model_mro_templates` to make make the name more specific to what the
templatetag actually does.

This commit also updates the use of the templatetag in other modules.
