### PR TITLE
fix(generic): use correct attribute name in MergeOrEnrichForm

### DIFF
--- a/apis_core/generic/forms/__init__.py
+++ b/apis_core/generic/forms/__init__.py
@@ -158,9 +158,7 @@ class GenericSelectMergeOrEnrichForm(forms.Form):
 
     def clean_uri(self):
         uri = self.cleaned_data["uri"]
-        if uri.isdigit() or self.get_self_content_type.model_class().valid_import_url(
-            uri
-        ):
+        if uri.isdigit() or self.content_type.model_class().valid_import_url(uri):
             return uri
         raise ValidationError(f"{uri} is neither an ID nor something we can import")
 


### PR DESCRIPTION
The attribute was updated to `.get_self_content_type` in
8bfb79705d25d43f2ac721686690d4f3746d6d38, beliving that this refers to
the property of GenericModel. But it does actually refer to the
attribute of the form, so we revert this change.
